### PR TITLE
Added multi-stage to Dockerfile.finish

### DIFF
--- a/build/package/Dockerfile.finish
+++ b/build/package/Dockerfile.finish
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8
+FROM registry.access.redhat.com/ubi8 AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -26,4 +26,6 @@ COPY internal /etc/go/internal
 COPY pkg /etc/go/pkg
 RUN cd /etc/go/cmd/finish && CGO_ENABLED=0 go build -o /usr/local/bin/ods-finish
 
+FROM registry.access.redhat.com/ubi8/ubi-micro
+COPY --from=builder /usr/local/bin/ods-finish /usr/local/bin/ods-finish
 WORKDIR /go


### PR DESCRIPTION
Refers to https://github.com/opendevstack/ods-pipeline/issues/18

## Dockerfile.finish

### Size comparison (before vs after)
```
localhost:5000/ods/finish    latest    1ff24c9cdf24    3 days ago    749MB 
localhost:5000/ods/finish    latest    3ab999a4060e    32 minutes ago    43.7MB 
```

### Build image time in GH action (before vs after)
```
1m36s https://github.com/opendevstack/ods-pipeline/runs/2846481414?check_suite_focus=true
48s https://github.com/opendevstack/ods-pipeline/runs/2848520040?check_suite_focus=true
```` 

### Push image time in GH action (before vs after)
```
38s https://github.com/opendevstack/ods-pipeline/runs/2846503756?check_suite_focus=true#step:10:1
4s https://github.com/opendevstack/ods-pipeline/runs/2848542559?check_suite_focus=true#step:10:1
```` 

### Total time (before vs after)
```
1m36s + 38s = 134s
48s + 4s = 52s
```