### PR TITLE
Added multi-stage to Dockerfile.sonar

### DIFF
--- a/build/package/Dockerfile.finish
+++ b/build/package/Dockerfile.finish
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8
+FROM registry.access.redhat.com/ubi8 AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -26,4 +26,6 @@ COPY internal /etc/go/internal
 COPY pkg /etc/go/pkg
 RUN cd /etc/go/cmd/finish && CGO_ENABLED=0 go build -o /usr/local/bin/ods-finish
 
+FROM registry.access.redhat.com/ubi8/ubi-micro
+COPY --from=builder /usr/local/bin/ods-finish /usr/local/bin/ods-finish
 WORKDIR /go

--- a/build/package/Dockerfile.sonar
+++ b/build/package/Dockerfile.sonar
@@ -51,8 +51,9 @@ COPY internal /etc/go/internal
 COPY pkg /etc/go/pkg
 RUN cd /etc/go/cmd/sonar && CGO_ENABLED=0 go build -o /usr/local/bin/sonar
 
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-FROM registry.access.redhat.com/ubi8/openjdk-11
+RUN microdnf install --nodocs java-11-openjdk-headless which && microdnf clean all
 
 COPY --from=builder /usr/local/bin/sonar /usr/local/bin/sonar
 COPY --from=builder /usr/local/sonar-scanner-cli /usr/local/sonar-scanner-cli

--- a/build/package/Dockerfile.sonar
+++ b/build/package/Dockerfile.sonar
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11
+FROM registry.access.redhat.com/ubi8/openjdk-11 AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -35,7 +35,6 @@ RUN cd /tmp \
     && mv sonar-scanner-${SONAR_SCANNER_VERSION} /usr/local/sonar-scanner-cli \
     && rm -rf sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
     && /usr/local/sonar-scanner-cli/bin/sonar-scanner --version
-ENV PATH=/usr/local/sonar-scanner-cli/bin:$PATH
 
 # Install CNES report.
 RUN cd /tmp \
@@ -51,5 +50,14 @@ COPY cmd /etc/go/cmd
 COPY internal /etc/go/internal
 COPY pkg /etc/go/pkg
 RUN cd /etc/go/cmd/sonar && CGO_ENABLED=0 go build -o /usr/local/bin/sonar
+
+
+FROM registry.access.redhat.com/ubi8/openjdk-11
+
+COPY --from=builder /usr/local/bin/sonar /usr/local/bin/sonar
+COPY --from=builder /usr/local/sonar-scanner-cli /usr/local/sonar-scanner-cli
+COPY --from=builder /usr/local/cnes/cnesreport.jar /usr/local/cnes/cnesreport.jar
+
+ENV PATH=/usr/local/sonar-scanner-cli/bin:$PATH
 
 WORKDIR /go


### PR DESCRIPTION
Refers to https://github.com/opendevstack/ods-pipeline/issues/18

## Dockerfile.sonar

### Size comparison (iterations before vs after)
```
(it. 0) localhost:5000/ods/sonar    latest    ec8b553f7493    6 minutes ago    1.32GB
(it. 1) localhost:5000/ods/sonar    latest    ebea09c05674    4 seconds ago    661MB
(it. 2) localhost:5000/ods/sonar    latest    4328c93293fb   33 seconds ago    401MB
```

### Build image time in GH action (before vs after)
```
(it. 0) 2m51s https://github.com/opendevstack/ods-pipeline/runs/2848897315?check_suite_focus=true
(it. 1) 1m38s https://github.com/opendevstack/ods-pipeline/runs/2849591004?check_suite_focus=true
(it. 2) 1m41s https://github.com/opendevstack/ods-pipeline/runs/2849858325?check_suite_focus=true
```` 

### Push image time in GH action (before vs after)
```
(it. 0) 1m8s https://github.com/opendevstack/ods-pipeline/runs/2848927909?check_suite_focus=true#step:8:1
(it. 1) 47s https://github.com/opendevstack/ods-pipeline/runs/2849618793?check_suite_focus=true#step:8:1
(it. 2) 24s https://github.com/opendevstack/ods-pipeline/runs/2849890947?check_suite_focus=true#step:8:1
```` 

### Total time (before vs after)
```
(it. 0) 2m51s + 1m8s = 3m59s
(it. 1) 1m38s + 47s = 2m25s
(it. 2) 1m41s + 24s = 2m5s 🚀
```