### PR TITLE
Added multi-stage to Dockerfile.interceptor

### DIFF
--- a/build/package/Dockerfile.interceptor
+++ b/build/package/Dockerfile.interceptor
@@ -1,5 +1,4 @@
-FROM golang:1.15-alpine
-
+FROM golang:1.15-alpine AS builder
 
 RUN apk add --no-cache ca-certificates
 
@@ -10,6 +9,8 @@ COPY internal /etc/go/internal
 COPY pkg /etc/go/pkg
 RUN cd /etc/go/cmd/webhook-interceptor && CGO_ENABLED=0 go build -o /usr/local/bin/webhook-interceptor
 
+FROM registry.access.redhat.com/ubi8/ubi-micro
+COPY --from=builder /usr/local/bin/webhook-interceptor /usr/local/bin/webhook-interceptor
 EXPOSE 8080
 
 CMD webhook-interceptor


### PR DESCRIPTION
Refers to #18

## Dockerfile.interceptor

### Size comparison (iterations before vs after)
```
(it. 0) localhost:5000/ods/interceptor    latest    685854ea491e    11 seconds ago    613MB
(it. 1) localhost:5000/ods/interceptor    latest    1509efa936d9    3 seconds ago     64.8MB
```

### Build image time in GH action (before vs after)
```
(it. 0) 1m25s https://github.com/opendevstack/ods-pipeline/runs/2849858751?check_suite_focus=true
(it. 1) 1m9s https://github.com/opendevstack/ods-pipeline/runs/2850280078?check_suite_focus=true
```` 

### Push image time in GH action (before vs after)
```
(it. 0) N/A (Not being pushed in GH actions yet)
(it. 1) N/A (Not being pushed in GH actions yet)
```` 

### Total time (before vs after)
```
(it. 0) - 1m25s
(it. 1) - 1m9s 🚀
```