### PR TITLE
Added multi-stage to Dockerfile.helm

### DIFF
--- a/build/package/Dockerfile.helm
+++ b/build/package/Dockerfile.helm
@@ -26,7 +26,6 @@ RUN mkdir -p /tmp/helm \
     && chmod a+x /usr/local/bin/helm \
     && helm version \
     && helm env \
-    # && sops --version \
     && rm -rf /tmp/helm
 
 # Add Go binaries
@@ -51,6 +50,7 @@ COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm
 RUN mkdir -p $HELM_PLUGINS \
     && HELM_DATA_HOME=${HELM_PLUGINS%/*} helm plugin install https://github.com/databus23/helm-diff --version v${HELM_PLUGIN_DIFF_VERSION} \
     && HELM_DATA_HOME=${HELM_PLUGINS%/*} helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_PLUGIN_SECRETS_VERSION} \
-    && ls -lah $HELM_PLUGINS
+    && ls -lah $HELM_PLUGINS \
+    && sops --version
 
 WORKDIR /go

--- a/build/package/Dockerfile.helm
+++ b/build/package/Dockerfile.helm
@@ -1,17 +1,9 @@
-FROM registry.access.redhat.com/ubi8
+FROM registry.access.redhat.com/ubi8 AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV GO_VERSION=1.16.3 \
-    HELM_VERSION=3.5.2 \
-    HELM_PLUGIN_DIFF_VERSION=3.1.3 \
-    HELM_PLUGIN_SECRETS_VERSION=3.5.0 \
-    HELM_PLUGINS=/usr/local/helm/plugins
-
-# Add CentOS 8 repositories.
-COPY build/package/yum.repos.d/centos8.repo /etc/yum.repos.d/centos8.repo
-
-RUN yum install -y git
+    HELM_VERSION=3.5.2
 
 RUN cd /tmp && \
     curl -LO https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz && \
@@ -26,8 +18,7 @@ ENV GOBIN /usr/local/bin
 RUN chmod g+w /go
 
 # Install Helm.
-RUN mkdir -p $HELM_PLUGINS \
-    && mkdir -p /tmp/helm \
+RUN mkdir -p /tmp/helm \
     && cd /tmp \
     && curl -LO https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
     && tar -zxvf helm-v${HELM_VERSION}-linux-amd64.tar.gz -C /tmp/helm \
@@ -35,17 +26,8 @@ RUN mkdir -p $HELM_PLUGINS \
     && chmod a+x /usr/local/bin/helm \
     && helm version \
     && helm env \
-    && HELM_DATA_HOME=${HELM_PLUGINS%/*} helm plugin install https://github.com/databus23/helm-diff --version v${HELM_PLUGIN_DIFF_VERSION} \
-    && HELM_DATA_HOME=${HELM_PLUGINS%/*} helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_PLUGIN_SECRETS_VERSION} \
-    && sops --version \
-    && ls -lah $HELM_PLUGINS \
+    # && sops --version \
     && rm -rf /tmp/helm
-
-# Add skopeo.
-RUN yum install -y skopeo \
-    && yum clean all \
-    && rm -rf /var/cache/yum/* \
-    && skopeo --version
 
 # Add Go binaries
 RUN mkdir -p /etc/go
@@ -54,5 +36,21 @@ COPY cmd /etc/go/cmd
 COPY internal /etc/go/internal
 COPY pkg /etc/go/pkg
 RUN cd /etc/go/cmd/deploy-with-helm && CGO_ENABLED=0 go build -o /usr/local/bin/deploy-with-helm
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+ENV HELM_PLUGIN_DIFF_VERSION=3.1.3 \
+    HELM_PLUGIN_SECRETS_VERSION=3.5.0 \
+    HELM_PLUGINS=/usr/local/helm/plugins
+
+RUN microdnf install skopeo git tar && microdnf clean all
+
+COPY --from=builder /usr/local/bin/deploy-with-helm /usr/local/bin/deploy-with-helm
+COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm
+
+RUN mkdir -p $HELM_PLUGINS \
+    && HELM_DATA_HOME=${HELM_PLUGINS%/*} helm plugin install https://github.com/databus23/helm-diff --version v${HELM_PLUGIN_DIFF_VERSION} \
+    && HELM_DATA_HOME=${HELM_PLUGINS%/*} helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_PLUGIN_SECRETS_VERSION} \
+    && ls -lah $HELM_PLUGINS
 
 WORKDIR /go


### PR DESCRIPTION
Refers to #18

## Dockerfile.helm

### Size comparison (iterations before vs after)
```
(it. 0) localhost:5000/ods/helm    latest    7842d28ef5e6    About a minute ago    1.3GB
(it. 1) localhost:5000/ods/helm    latest    c3d21e34b6e2    6 seconds ago         526MB
```

### Build image time in GH action (before vs after)
```
(it. 0) 3m6s https://github.com/opendevstack/ods-pipeline/runs/2850573872?check_suite_focus=true
(it. 1) 1m53s https://github.com/opendevstack/ods-pipeline/runs/2850955661?check_suite_focus=true
```` 

### Push image time in GH action (before vs after)
```
(it. 0) 57s https://github.com/opendevstack/ods-pipeline/runs/2850602790?check_suite_focus=true#step:7:1
(it. 1) 29s https://github.com/opendevstack/ods-pipeline/runs/2850975714?check_suite_focus=true#step:7:1
```` 

### Total time (before vs after)
```
(it. 0) 3m6s + 57s = 4m3s
(it. 1) 1m53s + 29s = 2m22s 🚀
```