### PR TITLE
Change ClusterTasks to Tasks. Updated BCs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,37 @@ clear-tmp-workspaces:
 	rm -rf test/testdata/workspaces/workspace-*
 .PHONY: clear-tmp-workspaces
 
+## Apply ImageStreams ODS manifests
+deploy-ods-image-streams:
+	oc create -f deploy/image-streams
+.PHONY: deploy-ods-image-streams
+
+## Apply BuildConfig ODS manifests
+deploy-bc-ods:
+	oc create -f deploy/build-configs
+.PHONY: deploy-bc-ods
+
+## Start BuildConfig ODS manifests
+start-bc-ods:
+	oc process -f deploy/build-configs/bc-ods-build-go.yml -p GIT_URL=https://github.com/opendevstack/ods-pipeline | oc create -f -
+	oc start-build ods-build-go
+	oc process -f deploy/build-configs/bc-ods-buildah.yml -p GIT_URL=https://github.com/opendevstack/ods-pipeline | oc create -f -
+	oc start-build ods-buildah
+	oc process -f deploy/build-configs/bc-ods-helm.yml -p GIT_URL=https://github.com/opendevstack/ods-pipeline | oc create -f -
+	oc start-build ods-helm
+	oc process -f deploy/build-configs/bc-ods-sonar.yml -p GIT_URL=https://github.com/opendevstack/ods-pipeline | oc create -f -
+	oc start-build ods-sonar
+	oc process -f deploy/build-configs/bc-ods-start.yml -p GIT_URL=https://github.com/opendevstack/ods-pipeline | oc create -f -
+	oc start-build ods-start
+	oc process -f deploy/build-configs/bc-ods-finish.yml -p GIT_URL=https://github.com/opendevstack/ods-pipeline | oc create -f -
+	oc start-build ods-finish
+.PHONY: start-bc-ods
+
+## Apply Tasks ODS manifests
+deploy-ods-tasks:
+	oc create -f deploy/tasks
+.PHONY: deploy-ods-tasks
+
 ### HELP
 ### Based on https://gist.github.com/prwhite/8168133#gistcomment-2278355.
 help:

--- a/deploy/build-configs/bc-ods-build-go.yml
+++ b/deploy/build-configs/bc-ods-build-go.yml
@@ -1,42 +1,42 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: sonarqube
+  name: ods-build-go
 parameters:
-- name: GIT_URL
-  description: "Git repository URL"
-- name: SOURCE_SERCET
-  description: "Name of source secret to access GIT_URL"
-  value: cd-user-token
+  - name: GIT_URL
+    description: "Git repository URL"
+  # - name: SOURCE_SERCET
+  #   description: "Name of source secret to access GIT_URL"
+  #   value: cd-user-token
 objects:
-- kind: BuildConfig
-  apiVersion: build.openshift.io/v1
-  metadata:
-    name: ods-build-go
-  spec:
-    nodeSelector: null
-    output:
-      to:
-        kind: ImageStreamTag
-        name: 'ods-build-go:latest'
-    resources: {}
-    successfulBuildsHistoryLimit: 5
-    failedBuildsHistoryLimit: 5
-    strategy:
-      type: Docker
-      dockerStrategy:
-        dockerfilePath: build/package/Dockerfile.go-toolset
-        from:
-          kind: DockerImage
-          name: 'registry.redhat.io/ubi8'
-        pullSecret:
-          name: registry.redhat.io
-    postCommit: {}
-    source:
-      type: Git
-      git:
-        uri: ${GIT_URL}
-        ref: master
-      sourceSecret:
-        name: ${SOURCE_SERCET}
-    runPolicy: Serial
+  - kind: BuildConfig
+    apiVersion: build.openshift.io/v1
+    metadata:
+      name: ods-build-go
+    spec:
+      nodeSelector: null
+      output:
+        to:
+          kind: ImageStreamTag
+          name: "ods-build-go:latest"
+      resources: {}
+      successfulBuildsHistoryLimit: 5
+      failedBuildsHistoryLimit: 5
+      strategy:
+        type: Docker
+        dockerStrategy:
+          dockerfilePath: build/package/Dockerfile.go-toolset
+          from:
+            kind: DockerImage
+            name: "registry.redhat.io/ubi8"
+          # pullSecret:
+          #   name: registry.redhat.io
+      postCommit: {}
+      source:
+        type: Git
+        git:
+          uri: ${GIT_URL}
+          ref: master
+        # sourceSecret:
+        #   name: ${SOURCE_SERCET}
+      runPolicy: Serial

--- a/deploy/build-configs/bc-ods-finish.yml
+++ b/deploy/build-configs/bc-ods-finish.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: ods-buildah
+  name: ods-finish
 parameters:
   - name: GIT_URL
     description: "Git repository URL"
@@ -12,23 +12,23 @@ objects:
   - kind: BuildConfig
     apiVersion: build.openshift.io/v1
     metadata:
-      name: ods-buildah
+      name: ods-finish
     spec:
       nodeSelector: null
       output:
         to:
           kind: ImageStreamTag
-          name: "ods-buildah:latest"
+          name: "ods-finish:latest"
       resources: {}
       successfulBuildsHistoryLimit: 5
       failedBuildsHistoryLimit: 5
       strategy:
         type: Docker
         dockerStrategy:
-          dockerfilePath: build/package/Dockerfile.buildah
+          dockerfilePath: build/package/Dockerfile.finish
           from:
             kind: DockerImage
-            name: "registry.redhat.io/ubi8/buildah"
+            name: "registry.redhat.io/ubi8/ubi-micro"
           # pullSecret:
           #   name: registry.redhat.io
       postCommit: {}

--- a/deploy/build-configs/bc-ods-helm.yml
+++ b/deploy/build-configs/bc-ods-helm.yml
@@ -1,42 +1,42 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: sonarqube
+  name: ods-helm
 parameters:
-- name: GIT_URL
-  description: "Git repository URL"
-- name: SOURCE_SERCET
-  description: "Name of source secret to access GIT_URL"
-  value: cd-user-token
+  - name: GIT_URL
+    description: "Git repository URL"
+  # - name: SOURCE_SERCET
+  #   description: "Name of source secret to access GIT_URL"
+  #   value: cd-user-token
 objects:
-- kind: BuildConfig
-  apiVersion: build.openshift.io/v1
-  metadata:
-    name: ods-helm
-  spec:
-    nodeSelector: null
-    output:
-      to:
-        kind: ImageStreamTag
-        name: 'ods-helm:latest'
-    resources: {}
-    successfulBuildsHistoryLimit: 5
-    failedBuildsHistoryLimit: 5
-    strategy:
-      type: Docker
-      dockerStrategy:
-        dockerfilePath: build/package/Dockerfile.helm
-        from:
-          kind: DockerImage
-          name: 'registry.redhat.io/ubi8'
-        pullSecret:
-          name: registry.redhat.io
-    postCommit: {}
-    source:
-      type: Git
-      git:
-        uri: ${GIT_URL}
-        ref: master
-      sourceSecret:
-        name: ${SOURCE_SERCET}
-    runPolicy: Serial
+  - kind: BuildConfig
+    apiVersion: build.openshift.io/v1
+    metadata:
+      name: ods-helm
+    spec:
+      nodeSelector: null
+      output:
+        to:
+          kind: ImageStreamTag
+          name: "ods-helm:latest"
+      resources: {}
+      successfulBuildsHistoryLimit: 5
+      failedBuildsHistoryLimit: 5
+      strategy:
+        type: Docker
+        dockerStrategy:
+          dockerfilePath: build/package/Dockerfile.helm
+          from:
+            kind: DockerImage
+            name: "registry.redhat.io/ubi8/ubi-minimal"
+          # pullSecret:
+          #   name: registry.redhat.io
+      postCommit: {}
+      source:
+        type: Git
+        git:
+          uri: ${GIT_URL}
+          ref: master
+        # sourceSecret:
+        #   name: ${SOURCE_SERCET}
+      runPolicy: Serial

--- a/deploy/build-configs/bc-ods-sonar.yml
+++ b/deploy/build-configs/bc-ods-sonar.yml
@@ -1,42 +1,42 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: sonarqube
+  name: ods-sonar
 parameters:
-- name: GIT_URL
-  description: "Git repository URL"
-- name: SOURCE_SERCET
-  description: "Name of source secret to access GIT_URL"
-  value: cd-user-token
+  - name: GIT_URL
+    description: "Git repository URL"
+  # - name: SOURCE_SERCET
+  #   description: "Name of source secret to access GIT_URL"
+  #   value: cd-user-token
 objects:
-- kind: BuildConfig
-  apiVersion: build.openshift.io/v1
-  metadata:
-    name: ods-sonar
-  spec:
-    nodeSelector: null
-    output:
-      to:
-        kind: ImageStreamTag
-        name: 'ods-sonar:latest'
-    resources: {}
-    successfulBuildsHistoryLimit: 5
-    failedBuildsHistoryLimit: 5
-    strategy:
-      type: Docker
-      dockerStrategy:
-        dockerfilePath: build/package/Dockerfile.sonar
-        from:
-          kind: DockerImage
-          name: 'registry.redhat.io/ubi8/openjdk-11'
-        pullSecret:
-          name: registry.redhat.io
-    postCommit: {}
-    source:
-      type: Git
-      git:
-        uri: ${GIT_URL}
-        ref: master
-      sourceSecret:
-        name: ${SOURCE_SERCET}
-    runPolicy: Serial
+  - kind: BuildConfig
+    apiVersion: build.openshift.io/v1
+    metadata:
+      name: ods-sonar
+    spec:
+      nodeSelector: null
+      output:
+        to:
+          kind: ImageStreamTag
+          name: "ods-sonar:latest"
+      resources: {}
+      successfulBuildsHistoryLimit: 5
+      failedBuildsHistoryLimit: 5
+      strategy:
+        type: Docker
+        dockerStrategy:
+          dockerfilePath: build/package/Dockerfile.sonar
+          from:
+            kind: DockerImage
+            name: "registry.redhat.io/ubi8/ubi-minimal"
+          # pullSecret:
+          #   name: registry.redhat.io
+      postCommit: {}
+      source:
+        type: Git
+        git:
+          uri: ${GIT_URL}
+          ref: master
+        # sourceSecret:
+        #   name: ${SOURCE_SERCET}
+      runPolicy: Serial

--- a/deploy/build-configs/bc-ods-start.yml
+++ b/deploy/build-configs/bc-ods-start.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: ods-buildah
+  name: ods-start
 parameters:
   - name: GIT_URL
     description: "Git repository URL"
@@ -12,23 +12,23 @@ objects:
   - kind: BuildConfig
     apiVersion: build.openshift.io/v1
     metadata:
-      name: ods-buildah
+      name: ods-start
     spec:
       nodeSelector: null
       output:
         to:
           kind: ImageStreamTag
-          name: "ods-buildah:latest"
+          name: "ods-start:latest"
       resources: {}
       successfulBuildsHistoryLimit: 5
       failedBuildsHistoryLimit: 5
       strategy:
         type: Docker
         dockerStrategy:
-          dockerfilePath: build/package/Dockerfile.buildah
+          dockerfilePath: build/package/Dockerfile.start
           from:
             kind: DockerImage
-            name: "registry.redhat.io/ubi8/buildah"
+            name: "registry.redhat.io/ubi8/ubi-minimal"
           # pullSecret:
           #   name: registry.redhat.io
       postCommit: {}

--- a/deploy/image-streams/is-ods-finish.yml
+++ b/deploy/image-streams/is-ods-finish.yml
@@ -1,0 +1,4 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: ods-finish

--- a/deploy/image-streams/is-ods-start.yml
+++ b/deploy/image-streams/is-ods-start.yml
@@ -1,0 +1,4 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: ods-start

--- a/deploy/tasks/task-ods-build-go.yml
+++ b/deploy/tasks/task-ods-build-go.yml
@@ -1,5 +1,5 @@
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   name: ods-build-go-v0-1
 spec:

--- a/deploy/tasks/task-ods-build-image.yml
+++ b/deploy/tasks/task-ods-build-image.yml
@@ -1,15 +1,15 @@
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   name: ods-build-image-v0-1
 spec:
   description: Package application into container image.
   params:
-    - default: ''
+    - default: ""
       description: Reference of the image stream buildah will produce.
       name: image-stream
       type: string
-    - default: 'image-registry.openshift-image-registry.svc:5000/ods/ods-buildah:latest'
+    - default: "image-registry.openshift-image-registry.svc:5000/ods/ods-buildah:latest"
       description: The location of the buildah builder image.
       name: builder-image
       type: string
@@ -25,25 +25,25 @@ spec:
       description: Path to the directory to use as Docker context.
       name: context-dir
       type: string
-    - default: 'true'
+    - default: "true"
       description: >-
         Verify the TLS on the registry endpoint (for push/pull to a non-TLS
         registry)
       name: tls-verify
       type: string
     - default: oci
-      description: 'The format of the built container, oci or docker'
+      description: "The format of the built container, oci or docker"
       name: format
       type: string
-    - default: ''
+    - default: ""
       description: Extra parameters passed for the build command when building images.
       name: buildah-build-extra-args
       type: string
-    - default: ''
+    - default: ""
       description: Extra parameters passed for the push command when pushing images.
       name: buildah-push-extra-args
       type: string
-    - default: 'image-registry.openshift-image-registry.svc:5000'
+    - default: "image-registry.openshift-image-registry.svc:5000"
       description: Image registry
       name: registry
       type: string

--- a/deploy/tasks/task-ods-deploy-helm.yml
+++ b/deploy/tasks/task-ods-deploy-helm.yml
@@ -1,5 +1,5 @@
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   name: ods-deploy-helm-v0-1-0
 spec:
@@ -7,7 +7,7 @@ spec:
     These tasks will install / upgrade a helm chart into your Kubernetes /
     OpenShift Cluster using Helm
   params:
-    - default: 'image-registry.openshift-image-registry.svc:5000/ods/ods-helm:latest'
+    - default: "image-registry.openshift-image-registry.svc:5000/ods/ods-helm:latest"
       description: Image to use
       name: image
       type: string
@@ -15,11 +15,11 @@ spec:
       description: Specify chart dir that will be deployed
       name: chart-dir
       type: string
-    - default: ''
+    - default: ""
       description: The helm release name
       name: release-name
       type: string
-    - default: ''
+    - default: ""
       description: The namespace of the pipeline
       name: namespace
       type: string
@@ -31,15 +31,15 @@ spec:
       description: The target to deploy into
       name: target
       type: string
-    - default: ''
+    - default: ""
       description: Project
       name: project
       type: string
-    - default: ''
+    - default: ""
       description: Repository
       name: repository
       type: string
-    - default: ''
+    - default: ""
       description: >-
         Specify the values you want to overwrite, comma separated:
         autoscaling.enabled=true,replicas=1

--- a/deploy/tasks/task-ods-finish.yml
+++ b/deploy/tasks/task-ods-finish.yml
@@ -1,5 +1,5 @@
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   name: ods-finish-v0-1-0
 spec:

--- a/deploy/tasks/task-ods-start.yml
+++ b/deploy/tasks/task-ods-start.yml
@@ -1,61 +1,61 @@
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   name: ods-start-v0-1-0
 spec:
   description: >-
     The task will clone a repo from the provided url into the workspace.
   params:
-    - default: 'gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.21.0'
+    - default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.21.0"
       description: The location of the image.
       name: image
       type: string
     - description: git url to clone
       name: url
       type: string
-    - default: ''
-      description: 'git revision to checkout (branch, tag, sha, ref…)'
+    - default: ""
+      description: "git revision to checkout (branch, tag, sha, ref…)"
       name: git-full-ref
       type: string
-    - default: ''
+    - default: ""
       description: (optional) git refspec to fetch before checking out revision
       name: refspec
       type: string
-    - default: 'true'
+    - default: "true"
       description: defines if the resource should initialize and fetch the submodules
       name: submodules
       type: string
-    - default: '1'
+    - default: "1"
       description: >-
         performs a shallow clone where only the most recent commit(s) will be
         fetched
       name: depth
       type: string
-    - default: 'true'
+    - default: "true"
       description: >-
         defines if http.sslVerify should be set to true or false in the global
         git config
       name: ssl-verify
       type: string
-    - default: 'true'
+    - default: "true"
       description: >-
         clean out the contents of the repo's destination directory (if it
         already exists) before trying to clone the repo there
       name: delete-existing
       type: string
-    - default: ''
+    - default: ""
       description: git HTTP proxy server for non-SSL requests
       name: http-proxy
       type: string
-    - default: ''
+    - default: ""
       description: git HTTPS proxy server for SSL requests
       name: https-proxy
       type: string
-    - default: ''
+    - default: ""
       description: git no proxy - opt out of proxying HTTP/HTTPS requests
       name: no-proxy
       type: string
-    - default: 'true'
+    - default: "true"
       description: log the commands used during execution
       name: verbose
       type: string
@@ -68,11 +68,11 @@ spec:
     - description: repository
       name: repository
       type: string
-    - default: ''
+    - default: ""
       description: pull request key
       name: pr-key
       type: string
-    - default: ''
+    - default: ""
       description: pull request base
       name: pr-base
       type: string

--- a/examples/demo-pipeline-run/configmap-bitbucket.yaml
+++ b/examples/demo-pipeline-run/configmap-bitbucket.yaml
@@ -1,0 +1,6 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: bitbucket
+data:
+  url: https://<BITBUCKET_URL>

--- a/examples/demo-pipeline-run/demo-pipeline-pvc.yaml
+++ b/examples/demo-pipeline-run/demo-pipeline-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: demo-pipeline-pvc
+spec:
+  storageClassName: "standard-nas-eco"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 512Mi

--- a/examples/demo-pipeline-run/demo-pipeline.yaml
+++ b/examples/demo-pipeline-run/demo-pipeline.yaml
@@ -1,0 +1,86 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: demo-pipeline
+spec:
+  tasks:
+    - name: ods-start-v0-1-0
+      params:
+        - name: image
+          value: >-
+            image-registry.openshift-image-registry.svc:5000/deleteme1-dev/ods-start:latest
+        - name: submodules
+          value: "true"
+        - name: depth
+          value: "1"
+        - name: ssl-verify
+          value: "true"
+        - name: delete-existing
+          value: "true"
+        - name: verbose
+          value: "true"
+        - name: git-full-ref
+          value: refs/heads/master
+        - name: console-url
+          value: >-
+            https://<OPENSHIFT_CONSOLE_URL>
+        - name: pipeline-run-name
+          value: demo-pipeline-run
+        - name: repository
+          value: hello-world-app
+        - name: component
+          value: hello-world-app-component
+        - name: project
+          value: deleteme1
+        - name: url
+          value: "https://<BITBUCKET_URL>/scm/deleteme1/hello-world-app.git"
+      taskRef:
+        kind: Task
+        name: ods-start-v0-1-0
+      workspaces:
+        - name: source
+          workspace: pipeline-ws-source
+    - name: ods-build-go-v0-1
+      params:
+        - name: go-image
+          value: >-
+            image-registry.openshift-image-registry.svc:5000/ods/ods-build-go:latest
+        - name: enable-cgo
+          value: "false"
+        - name: sonar-image
+          value: >-
+            image-registry.openshift-image-registry.svc:5000/ods/ods-sonar:latest
+        - name: sonar-quality-gate
+          value: "false"
+        - name: sonar-skip
+          value: "false"
+      runAfter:
+        - ods-start-v0-1-0
+      taskRef:
+        kind: Task
+        name: ods-build-go-v0-1
+      workspaces:
+        - name: source
+          workspace: pipeline-ws-source
+    - name: ods-finish-v0-1-0
+      params:
+        - name: image
+          value: >-
+            image-registry.openshift-image-registry.svc:5000/deleteme1-dev/ods-finish:latest
+        - name: aggregate-tasks-status
+          value: IDONTKNOW
+        - name: console-url
+          value: >-
+            https://<OPENSHIFT_CONSOLE_URL>
+        - name: pipeline-run-name
+          value: demo-pipeline-run
+      runAfter:
+        - ods-build-go-v0-1
+      taskRef:
+        kind: Task
+        name: ods-finish-v0-1-0
+      workspaces:
+        - name: source
+          workspace: pipeline-ws-source
+  workspaces:
+    - name: pipeline-ws-source

--- a/examples/demo-pipeline-run/pipeline-run.yaml
+++ b/examples/demo-pipeline-run/pipeline-run.yaml
@@ -1,0 +1,11 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: demo-pipeline-run-
+spec:
+  pipelineRef:
+    name: demo-pipeline
+  workspaces:
+    - name: pipeline-ws-source
+      persistentVolumeClaim:
+        claimName: demo-pipeline-pvc # this PVC must already exist

--- a/examples/demo-pipeline-run/secret-bitbucket-auth.yml
+++ b/examples/demo-pipeline-run/secret-bitbucket-auth.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+stringData:
+  password: <YOUR_BASE64_PASSWORD>
+  username: <YOUR_BITBUCKET_USERNAME>
+kind: Secret
+metadata:
+  name: bitbucket-auth
+  annotations:
+    tekton.dev/git-0: "https://<BITBUCKET_URL>"
+type: kubernetes.io/basic-auth

--- a/internal/interceptor/server.go
+++ b/internal/interceptor/server.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	taskKind    = "ClusterTask"
+	taskKind    = "Task"
 	taskVersion = "v0-1-0"
 )
 

--- a/test/tasks/ods-build-go_test.go
+++ b/test/tasks/ods-build-go_test.go
@@ -77,7 +77,7 @@ func TestTaskODSBuildGo(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			tasktesting.Run(t, tc, tasktesting.TestOpts{
-				TaskKindRef:             "ClusterTask",       // could be read from task definition
+				TaskKindRef:             "Task",              // could be read from task definition
 				TaskName:                "ods-build-go-v0-1", // could be read from task definition
 				Clients:                 c,
 				Namespace:               ns,

--- a/test/tasks/ods-build-image_test.go
+++ b/test/tasks/ods-build-image_test.go
@@ -74,7 +74,7 @@ func TestTaskODSBuildImage(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			tasktesting.Run(t, tc, tasktesting.TestOpts{
-				TaskKindRef:             "ClusterTask",          // could be read from task definition
+				TaskKindRef:             "Task",                 // could be read from task definition
 				TaskName:                "ods-build-image-v0-1", // could be read from task definition
 				Clients:                 c,
 				Namespace:               ns,

--- a/test/tasks/ods-deploy-helm_test.go
+++ b/test/tasks/ods-deploy-helm_test.go
@@ -72,7 +72,7 @@ func TestTaskODSDeployHelm(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			tasktesting.Run(t, tc, tasktesting.TestOpts{
-				TaskKindRef:             "ClusterTask",            // could be read from task definition
+				TaskKindRef:             "Task",                   // could be read from task definition
 				TaskName:                "ods-deploy-helm-v0-1-0", // could be read from task definition
 				Clients:                 c,
 				Namespace:               ns,

--- a/test/tasks/ods-finish_test.go
+++ b/test/tasks/ods-finish_test.go
@@ -82,7 +82,7 @@ func TestTaskODSFinish(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			tasktesting.Run(t, tc, tasktesting.TestOpts{
-				TaskKindRef:             "ClusterTask",       // could be read from task definition
+				TaskKindRef:             "Task",              // could be read from task definition
 				TaskName:                "ods-finish-v0-1-0", // could be read from task definition
 				Clients:                 c,
 				Namespace:               ns,

--- a/test/tasks/ods-start_test.go
+++ b/test/tasks/ods-start_test.go
@@ -64,7 +64,7 @@ func TestTaskODSStart(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			tasktesting.Run(t, tc, tasktesting.TestOpts{
-				TaskKindRef:             "ClusterTask",      // could be read from task definition
+				TaskKindRef:             "Task",             // could be read from task definition
 				TaskName:                "ods-start-v0-1-0", // could be read from task definition
 				Clients:                 c,
 				Namespace:               ns,

--- a/test/testdata/golden/interceptor/pipeline.yml
+++ b/test/testdata/golden/interceptor/pipeline.yml
@@ -7,122 +7,122 @@ metadata:
 spec:
   description: ODS
   finally:
-    - name: finish
-      taskRef:
-        kind: Task
-        name: ods-finish-v0-1-0
-      workspaces:
-        - name: source
-          workspace: shared-workspace
+  - name: finish
+    taskRef:
+      kind: Task
+      name: ods-finish-v0-1-0
+    workspaces:
+    - name: source
+      workspace: shared-workspace
   params:
-    - default: foo-bar
-      name: repository
-      type: string
-    - default: foo
-      name: project
-      type: string
-    - default: bar
-      name: component
-      type: string
-    - default: foo-cd
-      name: namespace
-      type: string
-    - default: https://bitbucket.acme.org/scm/foo/bar.git
-      name: git-repo-url
-      type: string
-    - default: main
-      name: git-ref
-      type: string
-    - default: refs/heads/main
-      name: git-full-ref
-      type: string
-    - default: ef8755f06ee4b28c96a847a95cb8ec8ed6ddd1ca
-      name: git-sha
-      type: string
-    - default: repo:refs_changed
-      name: trigger-event
-      type: string
-    - default: ""
-      name: comment
-      type: string
-    - default: "0"
-      name: pr-key
-      type: string
-    - default: ""
-      name: pr-base
-      type: string
+  - default: foo-bar
+    name: repository
+    type: string
+  - default: foo
+    name: project
+    type: string
+  - default: bar
+    name: component
+    type: string
+  - default: foo-cd
+    name: namespace
+    type: string
+  - default: https://bitbucket.acme.org/scm/foo/bar.git
+    name: git-repo-url
+    type: string
+  - default: main
+    name: git-ref
+    type: string
+  - default: refs/heads/main
+    name: git-full-ref
+    type: string
+  - default: ef8755f06ee4b28c96a847a95cb8ec8ed6ddd1ca
+    name: git-sha
+    type: string
+  - default: repo:refs_changed
+    name: trigger-event
+    type: string
+  - default: ""
+    name: comment
+    type: string
+  - default: "0"
+    name: pr-key
+    type: string
+  - default: ""
+    name: pr-base
+    type: string
   tasks:
-    - name: start
-      params:
-        - name: url
-          value: $(params.git-repo-url)
-        - name: git-ref
-          value: $(params.git-ref)
-        - name: git-full-ref
-          value: $(params.git-full-ref)
-        - name: project
-          value: $(params.project)
-        - name: component
-          value: $(params.component)
-        - name: repository
-          value: $(params.repository)
-        - name: pr-key
-          value: $(params.pr-key)
-        - name: pr-base
-          value: $(params.pr-base)
-      taskRef:
-        kind: Task
-        name: ods-start-v0-1-0
-      workspaces:
-        - name: source
-          workspace: shared-workspace
-    - name: go-helm-build
-      params:
-        - name: DOCKER_CONTEXT
-          value: docker
-        - name: TLSVERIFY
-          value: "false"
-        - name: IMAGE_STREAM
-          value: go-helm
-      runAfter:
-        - start
-      taskRef:
-        kind: Task
-        name: ods-build-go
-      workspaces:
-        - name: source
-          workspace: shared-workspace
-    - name: go-helm-deploy
-      params:
-        - name: RELEASE_NAME
-          value: go-helm
-        - name: RELEASE_NAMESPACE
-          value: $(params.project)-dev
-        - name: PROJECT
-          value: $(params.project)
-        - name: REPOSITORY
-          value: michael-go-helm
-        - name: NAMESPACE
-          value: $(params.namespace)
-      runAfter:
-        - go-helm-build
-      taskRef:
-        kind: Task
-        name: ods-deploy-helm
-      workspaces:
-        - name: source
-          workspace: shared-workspace
-    - name: go-helm-finalize
-      params:
-        - name: IMAGE_STREAM
-          value: go-helm
-      runAfter:
-        - go-helm-deploy
-      taskRef:
-        kind: Task
-        name: ods-finalize-docgen
-      workspaces:
-        - name: source
-          workspace: shared-workspace
+  - name: start
+    params:
+    - name: url
+      value: $(params.git-repo-url)
+    - name: git-ref
+      value: $(params.git-ref)
+    - name: git-full-ref
+      value: $(params.git-full-ref)
+    - name: project
+      value: $(params.project)
+    - name: component
+      value: $(params.component)
+    - name: repository
+      value: $(params.repository)
+    - name: pr-key
+      value: $(params.pr-key)
+    - name: pr-base
+      value: $(params.pr-base)
+    taskRef:
+      kind: ClusterTask
+      name: ods-start-v0-1-0
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+  - name: go-helm-build
+    params:
+    - name: DOCKER_CONTEXT
+      value: docker
+    - name: TLSVERIFY
+      value: "false"
+    - name: IMAGE_STREAM
+      value: go-helm
+    runAfter:
+    - start
+    taskRef:
+      kind: Task
+      name: ods-build-go
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+  - name: go-helm-deploy
+    params:
+    - name: RELEASE_NAME
+      value: go-helm
+    - name: RELEASE_NAMESPACE
+      value: $(params.project)-dev
+    - name: PROJECT
+      value: $(params.project)
+    - name: REPOSITORY
+      value: michael-go-helm
+    - name: NAMESPACE
+      value: $(params.namespace)
+    runAfter:
+    - go-helm-build
+    taskRef:
+      kind: Task
+      name: ods-deploy-helm
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+  - name: go-helm-finalize
+    params:
+    - name: IMAGE_STREAM
+      value: go-helm
+    runAfter:
+    - go-helm-deploy
+    taskRef:
+      kind: Task
+      name: ods-finalize-docgen
+    workspaces:
+    - name: source
+      workspace: shared-workspace
   workspaces:
-    - name: shared-workspace
+  - name: shared-workspace

--- a/test/testdata/golden/interceptor/pipeline.yml
+++ b/test/testdata/golden/interceptor/pipeline.yml
@@ -7,122 +7,122 @@ metadata:
 spec:
   description: ODS
   finally:
-  - name: finish
-    taskRef:
-      kind: ClusterTask
-      name: ods-finish-v0-1-0
-    workspaces:
-    - name: source
-      workspace: shared-workspace
+    - name: finish
+      taskRef:
+        kind: Task
+        name: ods-finish-v0-1-0
+      workspaces:
+        - name: source
+          workspace: shared-workspace
   params:
-  - default: foo-bar
-    name: repository
-    type: string
-  - default: foo
-    name: project
-    type: string
-  - default: bar
-    name: component
-    type: string
-  - default: foo-cd
-    name: namespace
-    type: string
-  - default: https://bitbucket.acme.org/scm/foo/bar.git
-    name: git-repo-url
-    type: string
-  - default: main
-    name: git-ref
-    type: string
-  - default: refs/heads/main
-    name: git-full-ref
-    type: string
-  - default: ef8755f06ee4b28c96a847a95cb8ec8ed6ddd1ca
-    name: git-sha
-    type: string
-  - default: repo:refs_changed
-    name: trigger-event
-    type: string
-  - default: ""
-    name: comment
-    type: string
-  - default: "0"
-    name: pr-key
-    type: string
-  - default: ""
-    name: pr-base
-    type: string
+    - default: foo-bar
+      name: repository
+      type: string
+    - default: foo
+      name: project
+      type: string
+    - default: bar
+      name: component
+      type: string
+    - default: foo-cd
+      name: namespace
+      type: string
+    - default: https://bitbucket.acme.org/scm/foo/bar.git
+      name: git-repo-url
+      type: string
+    - default: main
+      name: git-ref
+      type: string
+    - default: refs/heads/main
+      name: git-full-ref
+      type: string
+    - default: ef8755f06ee4b28c96a847a95cb8ec8ed6ddd1ca
+      name: git-sha
+      type: string
+    - default: repo:refs_changed
+      name: trigger-event
+      type: string
+    - default: ""
+      name: comment
+      type: string
+    - default: "0"
+      name: pr-key
+      type: string
+    - default: ""
+      name: pr-base
+      type: string
   tasks:
-  - name: start
-    params:
-    - name: url
-      value: $(params.git-repo-url)
-    - name: git-ref
-      value: $(params.git-ref)
-    - name: git-full-ref
-      value: $(params.git-full-ref)
-    - name: project
-      value: $(params.project)
-    - name: component
-      value: $(params.component)
-    - name: repository
-      value: $(params.repository)
-    - name: pr-key
-      value: $(params.pr-key)
-    - name: pr-base
-      value: $(params.pr-base)
-    taskRef:
-      kind: ClusterTask
-      name: ods-start-v0-1-0
-    workspaces:
-    - name: source
-      workspace: shared-workspace
-  - name: go-helm-build
-    params:
-    - name: DOCKER_CONTEXT
-      value: docker
-    - name: TLSVERIFY
-      value: "false"
-    - name: IMAGE_STREAM
-      value: go-helm
-    runAfter:
-    - start
-    taskRef:
-      kind: Task
-      name: ods-build-go
-    workspaces:
-    - name: source
-      workspace: shared-workspace
-  - name: go-helm-deploy
-    params:
-    - name: RELEASE_NAME
-      value: go-helm
-    - name: RELEASE_NAMESPACE
-      value: $(params.project)-dev
-    - name: PROJECT
-      value: $(params.project)
-    - name: REPOSITORY
-      value: michael-go-helm
-    - name: NAMESPACE
-      value: $(params.namespace)
-    runAfter:
-    - go-helm-build
-    taskRef:
-      kind: Task
-      name: ods-deploy-helm
-    workspaces:
-    - name: source
-      workspace: shared-workspace
-  - name: go-helm-finalize
-    params:
-    - name: IMAGE_STREAM
-      value: go-helm
-    runAfter:
-    - go-helm-deploy
-    taskRef:
-      kind: Task
-      name: ods-finalize-docgen
-    workspaces:
-    - name: source
-      workspace: shared-workspace
+    - name: start
+      params:
+        - name: url
+          value: $(params.git-repo-url)
+        - name: git-ref
+          value: $(params.git-ref)
+        - name: git-full-ref
+          value: $(params.git-full-ref)
+        - name: project
+          value: $(params.project)
+        - name: component
+          value: $(params.component)
+        - name: repository
+          value: $(params.repository)
+        - name: pr-key
+          value: $(params.pr-key)
+        - name: pr-base
+          value: $(params.pr-base)
+      taskRef:
+        kind: Task
+        name: ods-start-v0-1-0
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+    - name: go-helm-build
+      params:
+        - name: DOCKER_CONTEXT
+          value: docker
+        - name: TLSVERIFY
+          value: "false"
+        - name: IMAGE_STREAM
+          value: go-helm
+      runAfter:
+        - start
+      taskRef:
+        kind: Task
+        name: ods-build-go
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+    - name: go-helm-deploy
+      params:
+        - name: RELEASE_NAME
+          value: go-helm
+        - name: RELEASE_NAMESPACE
+          value: $(params.project)-dev
+        - name: PROJECT
+          value: $(params.project)
+        - name: REPOSITORY
+          value: michael-go-helm
+        - name: NAMESPACE
+          value: $(params.namespace)
+      runAfter:
+        - go-helm-build
+      taskRef:
+        kind: Task
+        name: ods-deploy-helm
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+    - name: go-helm-finalize
+      params:
+        - name: IMAGE_STREAM
+          value: go-helm
+      runAfter:
+        - go-helm-deploy
+      taskRef:
+        kind: Task
+        name: ods-finalize-docgen
+      workspaces:
+        - name: source
+          workspace: shared-workspace
   workspaces:
-  - name: shared-workspace
+    - name: shared-workspace


### PR DESCRIPTION
Below are the changes I had to do in order to prepare a demo pipeline run in the corporate OpenShift 4.7 environment:

- Renamed `ClusterTask` to `Task` as my user doesn't have cluster-admin permissions in the OCP4 cluster.
- ODS BuildConfig Templates present a `SOURCE_SERCET` param with a fixed value of `cd-user-token`. This had to be commented out as the cluster neither has such resource nor needs it to authenticate against the opendevstack/ods-pipeline repo (given it is publicly available)
- ODS BuildConfig Templates present a pullSecret `registry.redhat.io` which is not defined in the cluster so it has been commented out.
- Create some resources needed for the `PipelineRun`, see [examples/demo-pipeline-run](https://github.com/opendevstack/ods-pipeline/tree/feature/example-demo-pipeline/examples/demo-pipeline-run) e.g:
  - Bitbucket configmap and secret as it is required for the `ods-start` task.
  - A PVC for the pipeline workspace. 