### PR TITLE
adds stop-local-env and start-local-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,16 @@ run-sonarqube:
 prepare-local-env: create-kind-with-registry build-and-push-images install-tekton-pipelines run-bitbucket run-nexus run-sonarqube deploy-ods-tasks
 .PHONY: prepare-local-env
 
+## Stop local environment
+stop-local-env:
+	cd scripts && ./stop-local-env.sh
+.PHONY: stop-local-env
+
+## Restart stopped local environment
+start-local-env:
+	cd scripts && ./start-local-env.sh
+.PHONY: start-local-env
+
 ## Run testsuite.
 test: test-internal test-pkg test-tasks
 .PHONY: test

--- a/scripts/run-bitbucket.sh
+++ b/scripts/run-bitbucket.sh
@@ -44,30 +44,12 @@ docker run --name ${BITBUCKET_SERVER_CONTAINER_NAME} \
   -d --net kind -p "${BITBUCKET_SERVER_HOST_PORT}:7990" -p 7999:7999 \
   "${BITBUCKET_SERVER_IMAGE_NAME}:${BITBUCKET_SERVER_IMAGE_TAG}"
 
-BITBUCKET_URL="http://localhost:${BITBUCKET_SERVER_HOST_PORT}"
-echo "Waiting up to 4 minutes for Bitbucket to start ..."
-# https://confluence.atlassian.com/bitbucketserverkb/how-to-monitor-if-bitbucket-server-is-up-and-running-975014635.html
-n=0
-status="STARTING"
 set +e
-until [ $n -ge 24 ]; do
-    status=$(curl -s ${INSECURE} "${BITBUCKET_URL}/status" | jq -r .state)
-    if [ "${status}" == "RUNNING" ]; then
-        echo " success"
-        break
-    else
-        echo -n "."
-        sleep 10s
-        n=$((n+1))
-    fi
-done
-set -e
-if [ "${status}" != "RUNNING" ]; then
-    echo "Bitbucket did not start, got status=${status}."
+if ! "${SCRIPT_DIR}/waitfor-bitbucket.sh" ; then
     docker logs ${BITBUCKET_SERVER_CONTAINER_NAME}
     exit 1
-fi
-
+fi 
+set -e
 BITBUCKET_URL_FULL="http://${BITBUCKET_SERVER_CONTAINER_NAME}.kind:7990"
 
 echo "bitbucketUrl: '${BITBUCKET_URL_FULL}'" >> ${HELM_VALUES_FILE}

--- a/scripts/run-sonarqube.sh
+++ b/scripts/run-sonarqube.sh
@@ -39,28 +39,12 @@ docker rm -f ${CONTAINER_NAME} || true
 docker run -d --net kind --name ${CONTAINER_NAME} -e SONAR_ES_BOOTSTRAP_CHECKS_DISABLE=true -p "${HOST_PORT}:9000" sonarqube:${SONAR_IMAGE_TAG}
 
 SONARQUBE_URL="http://localhost:${HOST_PORT}"
-echo "Waiting up to 4 minutes for SonarQube to start ..."
-n=0
-health="RED"
 set +e
-until [ $n -ge 24 ]; do
-    health=$(curl -s ${INSECURE} --user "${SONAR_USERNAME}:${SONAR_PASSWORD}" \
-        "${SONARQUBE_URL}/api/system/health" | jq -r .health)
-    if [ "${health}" == "GREEN" ]; then
-        echo " success"
-        break
-    else
-        echo -n "."
-        sleep 10s
-        n=$((n+1))
-    fi
-done
-set -e
-if [ "${health}" != "GREEN" ]; then
-    echo "SonarQube did not start, got health=${health}."
+if ! "${SCRIPT_DIR}/waitfor-sonarqube.sh" ; then
     docker logs ${CONTAINER_NAME}
     exit 1
-fi
+fi 
+set -e
 
 echo "Creating token for '${SONAR_USERNAME}' ..."
 tokenResponse=$(curl ${INSECURE} -X POST -sSf --user "${SONAR_USERNAME}:${SONAR_PASSWORD}" \

--- a/scripts/start-local-env.sh
+++ b/scripts/start-local-env.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -ue
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+kind_registry='kind-registry'
+kind_control_plane='kind-control-plane'
+BITBUCKET_POSTGRES_CONTAINER_NAME="bitbucket-postgres-test"
+BITBUCKET_SERVER_CONTAINER_NAME="bitbucket-server-test"
+NEXUS_CONTAINER_NAME="nexustest"
+SQ_CONTAINER_NAME="sonarqubetest"
+
+container_names_in_start_order=( "$kind_registry" "$kind_control_plane" "$BITBUCKET_POSTGRES_CONTAINER_NAME" "$BITBUCKET_SERVER_CONTAINER_NAME" "$NEXUS_CONTAINER_NAME" 
+    "$SQ_CONTAINER_NAME" ) 
+
+for cn in "${container_names_in_start_order[@]}"; do
+    echo docker start "$cn"
+    docker start "$cn"
+done
+
+echo "Waiting for tools to start..."
+echo "If this times out you can run this script again."
+
+"$SCRIPT_DIR/waitfor-bitbucket.sh"
+"$SCRIPT_DIR/waitfor-nexus.sh"
+"$SCRIPT_DIR/waitfor-sonarqube.sh"
+
+echo "Please start k9s and see pods are all ready before using cluster."

--- a/scripts/stop-local-env.sh
+++ b/scripts/stop-local-env.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -ue
+
+reg_network='kind'
+
+kind_registry='kind-registry'
+kind_control_plane='kind-control-plane'
+BITBUCKET_POSTGRES_CONTAINER_NAME="bitbucket-postgres-test"
+BITBUCKET_SERVER_CONTAINER_NAME="bitbucket-server-test"
+NEXUS_CONTAINER_NAME="nexustest"
+SQ_CONTAINER_NAME="sonarqubetest"
+
+container_names_in_stop_order=( "$SQ_CONTAINER_NAME" "$NEXUS_CONTAINER_NAME" "$BITBUCKET_SERVER_CONTAINER_NAME" "$BITBUCKET_POSTGRES_CONTAINER_NAME" "$kind_control_plane" "$kind_registry" ) 
+
+for cn in "${container_names_in_stop_order[@]}"; do
+    echo docker stop "$cn"
+    docker stop "$cn"
+done
+
+# echo docker stop "$(docker ps -qf "network=$reg_network")"

--- a/scripts/waitfor-bitbucket.sh
+++ b/scripts/waitfor-bitbucket.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -ue
+
+# Starts a Bitbucket instance with a timebomb license (3 hours).
+# The instance is setup with an admin account (pw: admin) and an "ODSPIPELINETEST" project.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ODS_PIPELINE_DIR=${SCRIPT_DIR%/*}
+
+INSECURE=""
+BITBUCKET_SERVER_HOST_PORT="7990"
+BITBUCKET_SERVER_CONTAINER_NAME="bitbucket-server-test"
+BITBUCKET_SERVER_IMAGE_NAME="atlassian/bitbucket"
+BITBUCKET_SERVER_IMAGE_TAG="7.6.5"
+BITBUCKET_POSTGRES_HOST_PORT="15432"
+BITBUCKET_POSTGRES_CONTAINER_NAME="bitbucket-postgres-test"
+BITBUCKET_POSTGRES_IMAGE_TAG="12"
+HELM_VALUES_FILE="${ODS_PIPELINE_DIR}/deploy/cd-namespace/chart/values.generated.yaml"
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+
+    -v|--verbose) set -x;;
+
+    *) echo "Unknown parameter passed: $1"; exit 1;;
+esac; shift; done
+
+BITBUCKET_URL="http://localhost:${BITBUCKET_SERVER_HOST_PORT}"
+
+echo "Waiting up to 4 minutes for Bitbucket to start ..."
+# https://confluence.atlassian.com/bitbucketserverkb/how-to-monitor-if-bitbucket-server-is-up-and-running-975014635.html
+n=0
+status="STARTING"
+set +e
+until [ $n -ge 24 ]; do
+    status=$(curl -s ${INSECURE} "${BITBUCKET_URL}/status" | jq -r .state)
+    if [ "${status}" == "RUNNING" ]; then
+        echo " success"
+        break
+    else
+        echo -n "."
+        sleep 10s
+        n=$((n+1))
+    fi
+done
+set -e
+if [ "${status}" != "RUNNING" ]; then
+    echo "Bitbucket did not start, got status=${status}."
+    exit 1
+fi
+exit 0

--- a/scripts/waitfor-nexus.sh
+++ b/scripts/waitfor-nexus.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -ue
+
+INSECURE=""
+HOST_PORT="8081"
+NEXUS_URL=
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+
+    -v|--verbose) set -x;;
+
+    -i|--insecure) INSECURE="--insecure";;
+
+    *) echo "Unknown parameter passed: $1"; exit 1;;
+esac; shift; done
+
+NEXUS_URL="http://localhost:${HOST_PORT}"
+function waitForReady {
+    echo "Waiting up to 6 minutes for Nexus to start ..."
+    local n=0
+    local http_code=
+    set +e
+    until [ $n -ge 36 ]; do
+        http_code=$(curl ${INSECURE} -s -o /dev/null -w "%{http_code}" "${NEXUS_URL}/service/rest/v1/status/writable")
+        if [ "${http_code}" == "200" ]; then
+            echo " success"
+            break
+        else
+            echo -n "."
+            sleep 10s
+            n=$((n+1))
+        fi
+    done
+    set -e
+
+    if [ "${http_code}" != "200" ]; then
+        echo "Nexus did not start, got http_code=${http_code}."
+        exit 1
+    fi
+}
+
+waitForReady

--- a/scripts/waitfor-sonarqube.sh
+++ b/scripts/waitfor-sonarqube.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -ue
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ODS_PIPELINE_DIR=${SCRIPT_DIR%/*}
+
+INSECURE=""
+HOST_PORT="9000"
+SONAR_USERNAME="admin"
+SONAR_PASSWORD="admin"
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+
+    -v|--verbose) set -x;;
+
+    -i|--insecure) INSECURE="--insecure";;
+
+    *) echo "Unknown parameter passed: $1"; exit 1;;
+esac; shift; done
+
+
+SONARQUBE_URL="http://localhost:${HOST_PORT}"
+echo "Waiting up to 4 minutes for SonarQube to start ..."
+n=0
+health="RED"
+set +e
+until [ $n -ge 24 ]; do
+    health=$(curl -s ${INSECURE} --user "${SONAR_USERNAME}:${SONAR_PASSWORD}" \
+        "${SONARQUBE_URL}/api/system/health" | jq -r .health)
+    if [ "${health}" == "GREEN" ]; then
+        echo " success"
+        break
+    else
+        echo -n "."
+        sleep 10s
+        n=$((n+1))
+    fi
+done
+set -e
+if [ "${health}" != "GREEN" ]; then
+    echo "SonarQube did not start, got health=${health}."
+    exit 1
+fi


### PR DESCRIPTION
Added make targets:

```
  stop-local-env                      Stop local environment
  start-local-env                     Restart stopped local environment
```

These are meant to stop all containers, which is done in reverse order of starting to free some resources.
Once stopped one can restart containers, previously stopped and then check that bitbucket, nexus, SonarQube is up. In case this times out, one can simply run `make start-local-env` again. Finally one should use k9s to check that the cluster has settled and is healthy. 
 
closes #40 