### PR TITLE
Add support to query for Bitbucket branches

### DIFF
--- a/pkg/bitbucket/branches.go
+++ b/pkg/bitbucket/branches.go
@@ -1,0 +1,62 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+)
+
+type Branch struct {
+	ID              string `json:"id"`
+	DisplayId       string `json:"displayId"`
+	Type            string `json:"type"`
+	LatestCommit    string `json:"latestCommit"`
+	LatestChangeset string `json:"latestChangeset"`
+	IsDefault       bool   `json:"isDefault"`
+}
+
+type BranchPage struct {
+	Size       int  `json:"size"`
+	Limit      int  `json:"limit"`
+	IsLastPage bool `json:"isLastPage"`
+	Values     []Branch
+	Start      int `json:"start"`
+}
+
+type BranchListParams struct {
+	Base         string `json:"base"`
+	Details      bool   `json:"details"`
+	FilterText   string `json:"filterText"`
+	OrderBy      string `json:"orderBy"`
+	BoostMatches bool   `json:"boostMatches"`
+}
+
+// BranchList retrieves the branches matching the supplied filterText param.
+// The authenticated user must have REPO_READ permission for the specified repository to call this resource.
+// https://docs.atlassian.com/bitbucket-server/rest/7.14.0/bitbucket-rest.html#idp211
+func (c *Client) BranchList(projectKey string, repositorySlug string, params BranchListParams) (*BranchPage, error) {
+
+	q := url.Values{}
+	q.Add("base", params.Base)
+	q.Add("details", fmt.Sprintf("%v", params.Details))
+	q.Add("filterText", params.FilterText)
+	q.Add("orderBy", params.OrderBy)
+	q.Add("boostMatches", fmt.Sprintf("%v", params.BoostMatches))
+
+	urlPath := fmt.Sprintf(
+		"/rest/api/1.0/projects/%s/repos/%s/branches?%s",
+		projectKey,
+		repositorySlug,
+		q.Encode(),
+	)
+	_, response, err := c.get(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	var branchPage BranchPage
+	err = json.Unmarshal(response, &branchPage)
+	if err != nil {
+		return nil, err
+	}
+	return &branchPage, nil
+}

--- a/pkg/bitbucket/branches_test.go
+++ b/pkg/bitbucket/branches_test.go
@@ -1,0 +1,26 @@
+package bitbucket
+
+import (
+	"testing"
+
+	"github.com/opendevstack/pipeline/test/testserver"
+)
+
+func TestBranchList(t *testing.T) {
+	srv, cleanup := testserver.NewTestServer(t)
+	defer cleanup()
+	bitbucketClient := testClient(srv.Server.URL)
+
+	srv.EnqueueResponse(
+		t, "/rest/api/1.0/projects/myproject/repos/my-repo/branches",
+		200, "bitbucket/branch-list.json",
+	)
+
+	l, err := bitbucketClient.BranchList("myproject", "my-repo", BranchListParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if l.Size != 1 {
+		t.Fatalf("got %d, want %d", l.Size, 1)
+	}
+}

--- a/pkg/bitbucket/commits.go
+++ b/pkg/bitbucket/commits.go
@@ -115,8 +115,8 @@ type CommitListParams struct {
 func (c *Client) CommitList(projectKey string, repositorySlug string, params CommitListParams) (*CommitPage, error) {
 
 	q := url.Values{}
-	q.Add("api_key", "key_from_environment_or_flag")
-	q.Add("another_thing", "foo & bar")
+	q.Add("since", params.Since)
+	q.Add("until", params.Until)
 
 	urlPath := fmt.Sprintf(
 		"/rest/api/1.0/projects/%s/repos/%s/commits?%s",

--- a/test/testdata/fixtures/bitbucket/branch-list.json
+++ b/test/testdata/fixtures/bitbucket/branch-list.json
@@ -1,0 +1,16 @@
+{
+    "size": 1,
+    "limit": 25,
+    "isLastPage": true,
+    "values": [
+        {
+            "id": "refs/heads/main",
+            "displayId": "main",
+            "type": "BRANCH",
+            "latestCommit": "8d51122def5632836d1cb1026e879069e10a1e13",
+            "latestChangeset": "8d51122def5632836d1cb1026e879069e10a1e13",
+            "isDefault": true
+        }
+    ],
+    "start": 0
+}


### PR DESCRIPTION
We'll need this once we have a version parameter for the pipeline. Then we can use this endpoint to query for branches, e.g. when we have `version=1.0.0` we want to check if there is a `release/1.0.0` branch in a repo referenced in `ods.yml`.