### PR TITLE
Remove Bitbucket PR params

### DIFF
--- a/cmd/sonar/main.go
+++ b/cmd/sonar/main.go
@@ -14,8 +14,6 @@ func main() {
 	sonarqubeURLFlag := flag.String("sonar-url", os.Getenv("SONAR_URL"), "sonar-url")
 	sonarqubeEditionFlag := flag.String("sonar-edition", os.Getenv("SONAR_EDITION"), "sonar-edition")
 	qualityGateFlag := flag.Bool("quality-gate", false, "require quality gate pass")
-	bitbucketAccessTokenFlag := flag.String("bitbucket-access-token", os.Getenv("BITBUCKET_ACCESS_TOKEN"), "bitbucket-access-token")
-	bitbucketURLFlag := flag.String("bitbucket-url", os.Getenv("BITBUCKET_URL"), "bitbucket-url")
 	flag.Parse()
 
 	ctxt := &pipelinectxt.ODSContext{}
@@ -45,12 +43,6 @@ func main() {
 		sonarProject,
 		ctxt.GitRef,
 		ctxt.GitCommitSHA,
-		&sonar.BitbucketServer{
-			URL:        *bitbucketURLFlag,
-			Token:      *bitbucketAccessTokenFlag,
-			Project:    ctxt.Project,
-			Repository: ctxt.Repository,
-		},
 		prInfo,
 	)
 	if err != nil {

--- a/deploy/central/tasks/task-ods-build-go.yaml
+++ b/deploy/central/tasks/task-ods-build-go.yaml
@@ -53,16 +53,6 @@ spec:
             secretKeyRef:
               key: password
               name: ods-sonar-auth
-        - name: BITBUCKET_URL
-          valueFrom:
-            configMapKeyRef:
-              key: url
-              name: ods-bitbucket
-        - name: BITBUCKET_ACCESS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              key: password
-              name: ods-bitbucket-auth
       resources: {}
       script: |
         if [ "$(params.sonar-skip)" = "true" ]; then

--- a/pkg/sonar/scan.go
+++ b/pkg/sonar/scan.go
@@ -6,20 +6,13 @@ import (
 	"github.com/opendevstack/pipeline/internal/command"
 )
 
-type BitbucketServer struct {
-	URL        string
-	Token      string
-	Project    string
-	Repository string
-}
-
 type PullRequest struct {
 	Key    string
 	Branch string
 	Base   string
 }
 
-func (c *Client) Scan(project, branch, commit string, bb *BitbucketServer, pr *PullRequest) (string, error) {
+func (c *Client) Scan(project, branch, commit string, pr *PullRequest) (string, error) {
 	scannerParams := []string{
 		fmt.Sprintf("-Dsonar.host.url=%s", c.clientConfig.BaseURL),
 		"-Dsonar.scm.provider=git",
@@ -30,14 +23,9 @@ func (c *Client) Scan(project, branch, commit string, bb *BitbucketServer, pr *P
 	if c.clientConfig.Debug {
 		scannerParams = append(scannerParams, "-X")
 	}
-	if bb != nil && pr != nil {
+	if pr != nil {
 		scannerParams = append(
 			scannerParams,
-			"-Dsonar.pullrequest.provider=Bitbucket Server",
-			fmt.Sprintf("-Dsonar.pullrequest.bitbucketserver.serverUrl=%s", bb.URL),
-			fmt.Sprintf("-Dsonar.pullrequest.bitbucketserver.token.secured=%s", bb.Token),
-			fmt.Sprintf("-Dsonar.pullrequest.bitbucketserver.project=%s", bb.Project),
-			fmt.Sprintf("-Dsonar.pullrequest.bitbucketserver.repository=%s", bb.Repository),
 			fmt.Sprintf("-Dsonar.pullrequest.key=%s", pr.Key),
 			fmt.Sprintf("-Dsonar.pullrequest.branch=%s", pr.Branch),
 			fmt.Sprintf("-Dsonar.pullrequest.base=%s", pr.Base),


### PR DESCRIPTION
SonarQube 8.0 and later do not support dynamically setting PR decoration
parameters. PR decoration now needs to be set up via API calls by an
administrator in advance of scanning.

Closes #68.