### PR TITLE
Check task logs in tests

### DIFF
--- a/pkg/tasktesting/helper.go
+++ b/pkg/tasktesting/helper.go
@@ -15,7 +15,6 @@ import (
 	"github.com/opendevstack/pipeline/internal/random"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
 	"knative.dev/pkg/test/logging"
 	"sigs.k8s.io/yaml"
 )
@@ -178,7 +177,8 @@ func CollectTaskResultInfo(tr *v1beta1.TaskRun, logf logging.FormatLogger) {
 		logf("error: no taskrun")
 		return
 	}
-	logf("Status: %s\n", tr.Status.GetCondition(apis.ConditionSucceeded).Status)
-	logf("Reason: %s\n", tr.Status.GetCondition(apis.ConditionSucceeded).GetReason())
-	logf("Message: %s\n", tr.Status.GetCondition(apis.ConditionSucceeded).GetMessage())
+	logf("TaskRun: %v\n", tr)
+	// logf("Status: %s\n", tr.Status.GetCondition(apis.ConditionSucceeded).Status)
+	// logf("Reason: %s\n", tr.Status.GetCondition(apis.ConditionSucceeded).GetReason())
+	// logf("Message: %s\n", tr.Status.GetCondition(apis.ConditionSucceeded).GetMessage())
 }

--- a/test/tasks/ods-finish_test.go
+++ b/test/tasks/ods-finish_test.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"fmt"
 	"log"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,6 +57,23 @@ func TestTaskODSFinish(t *testing.T) {
 				PostRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
 					checkBuildStatus(t, ctxt.ODS.GitCommitSHA, "SUCCESSFUL")
 					checkArtifactsAreInNexus(t, ctxt)
+				},
+			},
+			"stops gracefully when context cannot be read": {
+				WorkspaceDirMapping: map[string]string{"source": "empty"},
+				PreRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
+					ctxt.Params = map[string]string{
+						"pipeline-run-name":      "foo",
+						"aggregate-tasks-status": "Failed",
+					}
+				},
+				WantRunSuccess: false,
+				PostRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
+					want := "Unable to continue as pipeline context cannot be read"
+
+					if !strings.Contains(string(ctxt.CollectedLogs), want) {
+						t.Fatalf("Want:\n%s\n\nGot:\n%s", want, string(ctxt.CollectedLogs))
+					}
 				},
 			},
 		},


### PR DESCRIPTION
Refers to #127 

The flaky issue that was happening was:

TaskRun gets marked as 'done' before we can collect any logs. Ideally, we want to mark the task as 'done' only after the container logs had been captured.