### PR TITLE
Use "OpenDevStack" as SQ report author

### DIFF
--- a/cmd/sonar/main.go
+++ b/cmd/sonar/main.go
@@ -76,7 +76,7 @@ func main() {
 	fmt.Println("Generating reports ...")
 	stdout, err = sonarClient.GenerateReports(
 		sonarProject,
-		"author",
+		"OpenDevStack",
 		ctxt.GitRef,
 		rootPath,
 		artifactPrefix,


### PR DESCRIPTION
In ods-jenkins-shared-library we use the Git commit author here.
However, we do not use the Git commit author for other reports such as
Aqua security scan. In general, the author of the latest commit may or
may not be responsible for issues detected in the SQ scan, and the
author is certainly not actually creating the report. Therefore it might
make more sense to simply use "OpenDevStack" as the author.

Closes #151.