### PR TITLE
Implement end-to-end test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,3 +161,4 @@ jobs:
           go test -v ./internal/... | sed ''/PASS/s//$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/''
           go test -v ./pkg/... | sed ''/PASS/s//$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/''
           go test -timeout 30m -v ./test/tasks/... -always-keep-tmp-workspaces | sed ''/PASS/s//$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/''
+          go test -timeout 10m -v ./test/e2e/... | sed ''/PASS/s//$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/''

--- a/internal/kubernetes/services.go
+++ b/internal/kubernetes/services.go
@@ -1,0 +1,84 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+)
+
+func CreateNodePortService(clientset *kubernetes.Clientset, name string, selectors map[string]string, port, targetPort int32, namespace string) (*v1.Service, error) {
+
+	log.Printf("Create node port service %s", name)
+	svc, err := clientset.CoreV1().Services(namespace).Create(context.TODO(),
+		&v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: map[string]string{"app.kubernetes.io/managed-by": "ods-pipeline"},
+			},
+			Spec: v1.ServiceSpec{
+				ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
+				Ports: []v1.ServicePort{
+					{
+						Name:       fmt.Sprintf("%d-%d", port, targetPort),
+						NodePort:   port,
+						Port:       port,
+						Protocol:   v1.ProtocolTCP,
+						TargetPort: intstr.FromInt(int(targetPort)),
+					},
+				},
+				Selector: map[string]string{
+					"eventlistener": "ods-pipeline",
+				},
+				SessionAffinity: v1.ServiceAffinityNone,
+				Type:            v1.ServiceTypeNodePort,
+			},
+		}, metav1.CreateOptions{})
+
+	return svc, err
+}
+
+// ServiceHasReadyPods returns false if no pod is assigned to given service
+// or if one or more pods are not "Running"
+// or one or more of any pods containers are not "ready".
+func ServiceHasReadyPods(clientset *kubernetes.Clientset, svc *v1.Service) (bool, string, error) {
+	podList, err := servicePods(clientset, svc)
+	if err != nil {
+		return false, "error", err
+	}
+	for _, pod := range podList.Items {
+		phase := pod.Status.Phase
+		if phase != "Running" {
+			return false, fmt.Sprintf("pod %s is in phase %+v", pod.Name, phase), nil
+		}
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			if !containerStatus.Ready {
+				return false, fmt.Sprintf("container %s in pod %s is not ready", containerStatus.Name, pod.Name), nil
+			}
+		}
+	}
+	return true, "ok", nil
+}
+
+func servicePods(clientset *kubernetes.Clientset, svc *v1.Service) (*v1.PodList, error) {
+	podClient := clientset.CoreV1().Pods(svc.Namespace)
+	selector := []string{}
+	for key, value := range svc.Spec.Selector {
+		selector = append(selector, fmt.Sprintf("%s=%s", key, value))
+	}
+	pods, err := podClient.List(
+		context.TODO(),
+		metav1.ListOptions{
+			LabelSelector: strings.Join(selector, ","),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return pods.DeepCopy(), nil
+}

--- a/pkg/tasktesting/bitbucket.go
+++ b/pkg/tasktesting/bitbucket.go
@@ -10,6 +10,10 @@ import (
 	kclient "k8s.io/client-go/kubernetes"
 )
 
+const (
+	BitbucketProjectKey = "ODSPIPELINETEST"
+)
+
 // BitbucketClientOrFatal returns a Bitbucket client, configured based on ConfigMap/Secret in the given namespace.
 func BitbucketClientOrFatal(t *testing.T, c *kclient.Clientset, namespace string) *bitbucket.Client {
 	bitbucketSecret, err := kubernetes.GetSecret(c, namespace, "ods-bitbucket-auth")

--- a/pkg/tasktesting/helper.go
+++ b/pkg/tasktesting/helper.go
@@ -18,6 +18,12 @@ import (
 	"knative.dev/pkg/test/logging"
 )
 
+const (
+	StorageClassName = "standard" // if using KinD, set it to "standard"
+	StorageCapacity  = "1Gi"
+	StorageSourceDir = "/files" // this is the dir *within* the KinD container that mounts to ${ODS_PIPELINE_DIR}/test
+)
+
 type SetupOpts struct {
 	SourceDir        string
 	StorageCapacity  string
@@ -42,9 +48,7 @@ func Setup(t *testing.T, opts SetupOpts) (*k.Clients, string) {
 		t.Error(err)
 	}
 
-	installCDNamespaceResources(
-		t, namespace, "pipeline", "./chart/values.kind.yaml,./chart/values.generated.yaml",
-	)
+	installCDNamespaceResources(t, namespace, "pipeline", "./chart/values.kind.yaml,./chart/values.generated.yaml")
 
 	return clients, namespace
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,250 @@
+package e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opendevstack/pipeline/internal/command"
+	"github.com/opendevstack/pipeline/internal/kubernetes"
+	"github.com/opendevstack/pipeline/pkg/bitbucket"
+	"github.com/opendevstack/pipeline/pkg/tasktesting"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	tekton "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s "k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/apis"
+)
+
+func TestWebhookInterceptor(t *testing.T) {
+
+	// Setup namespace to run tests in.
+	c, ns := tasktesting.Setup(t,
+		tasktesting.SetupOpts{
+			SourceDir:        tasktesting.StorageSourceDir,
+			StorageCapacity:  tasktesting.StorageCapacity,
+			StorageClassName: tasktesting.StorageClassName,
+		},
+	)
+
+	// Cleanup namespace at the end.
+	tasktesting.CleanupOnInterrupt(func() { tasktesting.TearDown(t, c, ns) }, t.Logf)
+	defer tasktesting.TearDown(t, c, ns)
+
+	// Create NodePort service which Bitbucket can post its webhook to.
+	var nodePort int32 = 30950
+	_, err := kubernetes.CreateNodePortService(
+		c.KubernetesClientSet,
+		"el-nodeport",
+		map[string]string{"eventlistener": "ods-pipeline"},
+		nodePort,
+		8000,
+		ns,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Initialize workspace with basic app.
+	wsDir, err := tasktesting.InitWorkspace("source", "hello-world-app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Workspace is in %s", wsDir)
+	odsContext := tasktesting.SetupBitbucketRepo(
+		t, c.KubernetesClientSet, ns, wsDir, tasktesting.BitbucketProjectKey,
+	)
+
+	// The webhook URL needs to be the address of the KinD control plane on the node port.
+	ipAddress, err := kindControlPlaneIP()
+	if err != nil {
+		t.Fatal(err)
+	}
+	webhookURL := fmt.Sprintf("http://%s:%d", ipAddress, nodePort)
+	t.Logf("Bitbucket webhook URL will be set to %s", webhookURL)
+
+	// Create webhook in Bitbucket.
+	webhookSecret, err := kubernetes.GetSecretKey(
+		c.KubernetesClientSet, ns, "ods-bitbucket-webhook", "secret",
+	)
+	if err != nil {
+		t.Fatalf("could not get Bitbucket webhook secret: %s", err)
+	}
+	bitbucketClient := tasktesting.BitbucketClientOrFatal(t, c.KubernetesClientSet, ns)
+	_, err = bitbucketClient.WebhookCreate(
+		odsContext.Project,
+		odsContext.Repository,
+		bitbucket.WebhookCreatePayload{
+			Name:          "test",
+			URL:           webhookURL,
+			Active:        true,
+			Events:        []string{"repo:refs_changed"},
+			Configuration: bitbucket.WebhookConfiguration{Secret: webhookSecret},
+		})
+	if err != nil {
+		t.Fatalf("could not create Bitbucket webhook: %s", err)
+	}
+
+	// Push a commit, which should trigger a webhook, which in turn should start a pipeline run.
+	filename := "ods.yml"
+	fileContent := `pipeline:
+  tasks:
+  - name: build-image
+    taskRef:
+      kind: ClusterTask
+      name: ods-build-image
+    params:
+    - name: tls-verify
+      value: 'false'
+    workspaces:
+    - name: source
+      workspace: shared-workspace`
+
+	err = ioutil.WriteFile(filepath.Join(wsDir, filename), []byte(fileContent), 0644)
+	if err != nil {
+		t.Fatalf("could not write file=%s: %s", filename, err)
+	}
+	requiredServices := []string{"ods-pipeline", "el-ods-pipeline", "el-nodeport"}
+	serviceTimeout := time.Minute
+	for _, serviceName := range requiredServices {
+		t.Logf("Waiting %s for service %s to have ready pods ...\n", serviceTimeout, serviceName)
+		err = waitForServiceToBeReady(t, c.KubernetesClientSet, ns, serviceName, serviceTimeout)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Log("Sleeping for 10s to make it work - unsure why needed ...")
+	time.Sleep(10 * time.Second)
+	t.Log("Pushing file to Bitbucket ...")
+	tasktesting.PushFileToBitbucketOrFatal(t, c.KubernetesClientSet, ns, wsDir, "master", "ods.yml")
+	triggerTimeout := time.Minute
+	t.Logf("Waiting %s for pipeline run to be triggered ...", triggerTimeout)
+	pr, err := waitForPipelineRunToBeTriggered(c.TektonClientSet, ns, triggerTimeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Triggered pipeline run %s\n", pr.Name)
+	runTimeout := 3 * time.Minute
+	t.Logf("Waiting %s for pipeline run to succeed ...", runTimeout)
+	gotReason, err := waitForPipelineRunToBeDone(c.TektonClientSet, ns, pr.Name, runTimeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotReason != "Succeeded" {
+		t.Logf("Want pipeline run reason to be 'Succeeded' but got '%s'", gotReason)
+		logs, err := pipelineRunLogs(ns, pr.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log(logs)
+		t.Fatal()
+	}
+}
+
+func waitForServiceToBeReady(t *testing.T, clientset *k8s.Clientset, ns, name string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	svc, err := clientset.CoreV1().Services(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	for {
+		time.Sleep(2 * time.Second)
+		ready, reason, err := kubernetes.ServiceHasReadyPods(clientset, svc)
+		if err != nil {
+			return err
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if ready {
+			break
+		}
+		t.Logf("still waiting: %s ...", reason)
+	}
+	return nil
+}
+
+func waitForPipelineRunToBeTriggered(clientset *tekton.Clientset, ns string, timeout time.Duration) (*tektonv1beta1.PipelineRun, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var pipelineRunList *v1beta1.PipelineRunList
+	for {
+		time.Sleep(2 * time.Second)
+		prs, err := clientset.TektonV1beta1().PipelineRuns(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if len(prs.Items) > 0 {
+			pipelineRunList = prs
+			break
+		}
+	}
+	if len(pipelineRunList.Items) != 1 {
+		return nil, errors.New("did not get exactly one pipeline run")
+	}
+	return &pipelineRunList.Items[0], nil
+}
+
+func waitForPipelineRunToBeDone(clientset *tekton.Clientset, ns, pr string, timeout time.Duration) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var reason string
+	for {
+		time.Sleep(2 * time.Second)
+		pr, err := clientset.TektonV1beta1().PipelineRuns(ns).Get(ctx, pr, metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		if pr.IsDone() {
+			reason = pr.Status.GetCondition(apis.ConditionSucceeded).GetReason()
+			break
+		}
+	}
+	return reason, nil
+}
+
+func kindControlPlaneIP() (string, error) {
+	stdout, stderr, err := command.Run(
+		"docker",
+		[]string{"inspect", "-f", "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}", "kind-control-plane"},
+	)
+	if err != nil {
+		return "", fmt.Errorf("could not get IP address of KinD control plane: %s, err: %s", string(stderr), err)
+	}
+	return strings.TrimSpace(string(stdout)), nil
+}
+
+func pipelineRunLogs(namespace, name string) (string, error) {
+	if !tknInstalled() {
+		return "", errors.New("tkn is not installed, cannot show logs")
+	}
+	stdout, stderr, err := command.Run(
+		"tkn",
+		[]string{"pr", "logs", "-n", namespace, name},
+	)
+	if err != nil {
+		return "", fmt.Errorf("could not get logs of pipelinerun: %s, err: %s", string(stderr), err)
+	}
+	return string(stdout), nil
+}
+
+func tknInstalled() bool {
+	_, err := exec.LookPath("tkn")
+	return err == nil
+}

--- a/test/tasks/common_test.go
+++ b/test/tasks/common_test.go
@@ -21,11 +21,7 @@ import (
 var alwaysKeepTmpWorkspacesFlag = flag.Bool("always-keep-tmp-workspaces", false, "Whether to keep temporary workspaces from taskruns even when test is successful")
 
 const (
-	bitbucketProjectKey = "ODSPIPELINETEST"
-	taskKindRef         = "ClusterTask"
-	storageClasName     = "standard" // if using KinD, set it to "standard"
-	storageCapacity     = "1Gi"
-	storageSourceDir    = "/files" // this is the dir *within* the KinD container that mounts to ${ODS_PIPELINE_DIR}/test
+	taskKindRef = "ClusterTask"
 )
 
 func checkODSContext(t *testing.T, repoDir string, want *pipelinectxt.ODSContext) {
@@ -97,9 +93,9 @@ func getFileContentLean(filename string) (string, error) {
 func runTaskTestCases(t *testing.T, taskName string, testCases map[string]tasktesting.TestCase) {
 	c, ns := tasktesting.Setup(t,
 		tasktesting.SetupOpts{
-			SourceDir:        storageSourceDir,
-			StorageCapacity:  storageCapacity,
-			StorageClassName: storageClasName,
+			SourceDir:        tasktesting.StorageSourceDir,
+			StorageCapacity:  tasktesting.StorageCapacity,
+			StorageClassName: tasktesting.StorageClassName,
 		},
 	)
 

--- a/test/tasks/ods-finish_test.go
+++ b/test/tasks/ods-finish_test.go
@@ -20,7 +20,9 @@ func TestTaskODSFinish(t *testing.T) {
 				WorkspaceDirMapping: map[string]string{"source": "hello-world-app-with-artifacts"},
 				PreRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
 					wsDir := ctxt.Workspaces["source"]
-					ctxt.ODS = tasktesting.SetupBitbucketRepo(t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace, wsDir, bitbucketProjectKey)
+					ctxt.ODS = tasktesting.SetupBitbucketRepo(
+						t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace, wsDir, tasktesting.BitbucketProjectKey,
+					)
 					ctxt.Params = map[string]string{
 						"pipeline-run-name":      "foo",
 						"aggregate-tasks-status": "None",
@@ -36,7 +38,9 @@ func TestTaskODSFinish(t *testing.T) {
 				WorkspaceDirMapping: map[string]string{"source": "hello-world-app-with-artifacts"},
 				PreRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
 					wsDir := ctxt.Workspaces["source"]
-					ctxt.ODS = tasktesting.SetupBitbucketRepo(t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace, wsDir, bitbucketProjectKey)
+					ctxt.ODS = tasktesting.SetupBitbucketRepo(
+						t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace, wsDir, tasktesting.BitbucketProjectKey,
+					)
 					ctxt.Params = map[string]string{
 						"pipeline-run-name":      "foo",
 						"aggregate-tasks-status": "Succeeded",

--- a/test/tasks/ods-start_test.go
+++ b/test/tasks/ods-start_test.go
@@ -23,7 +23,9 @@ func TestTaskODSStart(t *testing.T) {
 				WorkspaceDirMapping: map[string]string{"source": "hello-world-app"},
 				PreRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
 					wsDir := ctxt.Workspaces["source"]
-					ctxt.ODS = tasktesting.SetupBitbucketRepo(t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace, wsDir, bitbucketProjectKey)
+					ctxt.ODS = tasktesting.SetupBitbucketRepo(
+						t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace, wsDir, tasktesting.BitbucketProjectKey,
+					)
 					ctxt.Params = map[string]string{
 						"url":               ctxt.ODS.GitURL,
 						"git-full-ref":      "refs/heads/master",
@@ -57,7 +59,9 @@ func TestTaskODSStart(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					subCtxt := tasktesting.SetupBitbucketRepo(t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace, tempDir, bitbucketProjectKey)
+					subCtxt := tasktesting.SetupBitbucketRepo(
+						t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace, tempDir, tasktesting.BitbucketProjectKey,
+					)
 					subrepoContext = subCtxt
 					err = os.RemoveAll(tempDir)
 					if err != nil {
@@ -67,7 +71,9 @@ func TestTaskODSStart(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					ctxt.ODS = tasktesting.SetupBitbucketRepo(t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace, wsDir, bitbucketProjectKey)
+					ctxt.ODS = tasktesting.SetupBitbucketRepo(
+						t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace, wsDir, tasktesting.BitbucketProjectKey,
+					)
 
 					nexusClient := tasktesting.NexusClientOrFatal(t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace)
 					groupBase := fmt.Sprintf("/%s/%s/%s", subCtxt.Project, subCtxt.Repository, subCtxt.GitCommitSHA)
@@ -126,7 +132,9 @@ func TestTaskODSStart(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					tasktesting.SetupBitbucketRepo(t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace, tempDir, bitbucketProjectKey)
+					tasktesting.SetupBitbucketRepo(
+						t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace, tempDir, tasktesting.BitbucketProjectKey,
+					)
 					err = os.RemoveAll(tempDir)
 					if err != nil {
 						t.Fatal(err)
@@ -135,7 +143,9 @@ func TestTaskODSStart(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					ctxt.ODS = tasktesting.SetupBitbucketRepo(t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace, wsDir, bitbucketProjectKey)
+					ctxt.ODS = tasktesting.SetupBitbucketRepo(
+						t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace, wsDir, tasktesting.BitbucketProjectKey,
+					)
 					ctxt.Params = map[string]string{
 						"url":               ctxt.ODS.GitURL,
 						"git-full-ref":      "refs/heads/master",


### PR DESCRIPTION
This proves that pushing a commit in Bitbucket triggers a pipeline run building that commit successfully.

Closes #82.

TODO:

- [x] undo `--wait` in Helm install
- [ ] fix the 10s sleep time
- [x] get the IP address of the KinD control plane dynamically
- [ ] check for build status in Bitbucket? Depends on #115.
- [x] if the pipeline run fails, it would be great to display logs to help with debugging
- [x] add E2E test to GitHub Actions