### PR TITLE
Rename task param docker-dir to output-dir

### DIFF
--- a/build/package/scripts/build-go.sh
+++ b/build/package/scripts/build-go.sh
@@ -4,7 +4,7 @@ set -eu
 ENABLE_CGO="false"
 GO_OS=""
 GO_ARCH=""
-DOCKER_DIR="docker"
+OUTPUT_DIR="docker"
 WORKING_DIR="."
 ARTIFACT_PREFIX=""
 DEBUG="false"
@@ -24,8 +24,8 @@ while [[ "$#" -gt 0 ]]; do
     --go-arch) GO_ARCH="$2"; shift;;
     --go-arch=*) GO_ARCH="${1#*=}";;
 
-    --docker-dir) DOCKER_DIR="$2"; shift;;
-    --docker-dir=*) DOCKER_DIR="${1#*=}";;
+    --output-dir) OUTPUT_DIR="$2"; shift;;
+    --output-dir=*) OUTPUT_DIR="${1#*=}";;
 
     --debug) DEBUG="$2"; shift;;
     --debug=*) DEBUG="${1#*=}";;
@@ -80,7 +80,7 @@ if [ -s go-lint-report.txt ]; then
 fi
 
 echo "Building ..."
-go build -gcflags "all=-trimpath=$(pwd)" -o "${DOCKER_DIR}/app"
+go build -gcflags "all=-trimpath=$(pwd)" -o "${OUTPUT_DIR}/app"
 
 echo "Testing ..."
 if [ -f "${ROOT_DIR}/.ods/artifacts/xunit-reports/${ARTIFACT_PREFIX}report.xml" ]; then

--- a/build/package/scripts/build-python.sh
+++ b/build/package/scripts/build-python.sh
@@ -13,7 +13,7 @@ urlencode() {
     done
 }
 
-DOCKER_DIR="docker"
+OUTPUT_DIR="docker"
 MAX_LINE_LENGTH="120"
 WORKING_DIR="."
 ARTIFACT_PREFIX=""
@@ -28,8 +28,8 @@ while [[ "$#" -gt 0 ]]; do
     --max-line-length) MAX_LINE_LENGTH="$2"; shift;;
     --max-line-length=*) MAX_LINE_LENGTH="${1#*=}";;
 
-    --docker-dir) DOCKER_DIR="$2"; shift;;
-    --docker-dir=*) DOCKER_DIR="${1#*=}";;
+    --output-dir) OUTPUT_DIR="$2"; shift;;
+    --output-dir=*) OUTPUT_DIR="${1#*=}";;
 
     --debug) DEBUG="$2"; shift;;
     --debug=*) DEBUG="${1#*=}";;
@@ -79,6 +79,6 @@ mkdir -p "${ROOT_DIR}/.ods/artifacts/code-coverage"
 cat coverage.xml
 cp coverage.xml "${ROOT_DIR}/.ods/artifacts/code-coverage/${ARTIFACT_PREFIX}coverage.xml"
 
-echo "Copying src and requirements.txt to ${DOCKER_DIR}/app ..."
-cp -rv src "${DOCKER_DIR}/app"
-cp -rv requirements.txt "${DOCKER_DIR}/app"
+echo "Copying src and requirements.txt to ${OUTPUT_DIR}/app ..."
+cp -rv src "${OUTPUT_DIR}/app"
+cp -rv requirements.txt "${OUTPUT_DIR}/app"

--- a/build/package/scripts/build-typescript.sh
+++ b/build/package/scripts/build-typescript.sh
@@ -13,7 +13,7 @@ urlencode() {
     done
 }
 
-DOCKER_DIR="docker"
+OUTPUT_DIR="docker"
 WORKING_DIR="."
 ARTIFACT_PREFIX=""
 DEBUG="false"
@@ -24,8 +24,8 @@ while [[ "$#" -gt 0 ]]; do
     --working-dir) WORKING_DIR="$2"; shift;;
     --working-dir=*) WORKING_DIR="${1#*=}";;
 
-    --docker-dir) DOCKER_DIR="$2"; shift;;
-    --docker-dir=*) DOCKER_DIR="${1#*=}";;
+    --output-dir) OUTPUT_DIR="$2"; shift;;
+    --output-dir=*) OUTPUT_DIR="${1#*=}";;
 
     --debug) DEBUG="$2"; shift;;
     --debug=*) DEBUG="${1#*=}";;
@@ -59,11 +59,11 @@ fi;
 echo "Building ..."
 npm ci
 npm run build
-mkdir -p "${DOCKER_DIR}/dist"
-cp -r dist "${DOCKER_DIR}/dist"
+mkdir -p "${OUTPUT_DIR}/dist"
+cp -r dist "${OUTPUT_DIR}/dist"
 
-echo "Copying node_modules to ${DOCKER_DIR}/dist/node_modules ..."
-cp -r node_modules "${DOCKER_DIR}/dist/node_modules"
+echo "Copying node_modules to ${OUTPUT_DIR}/dist/node_modules ..."
+cp -r node_modules "${OUTPUT_DIR}/dist/node_modules"
 
 echo "Testing ..."
 npm run test

--- a/deploy/central/tasks-chart/templates/task-ods-build-go.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-go.yaml
@@ -43,10 +43,10 @@ spec:
       description: "`GOARCH` variable (the execution architecture such as `arm`, `amd64`)."
       type: string
       default: "amd64"
-    - name: docker-dir
+    - name: output-dir
       description: >-
-        Path to the directory to use as Docker context, relative to `working-dir`.
-        The resulting Go binary will be copied there.
+        Path to the directory into which the resulting Go binary should be copied, relative to `working-dir`.
+        This directory may then later be used as Docker context for example.
       type: string
       default: docker
     - name: sonar-quality-gate
@@ -76,7 +76,7 @@ spec:
           --enable-cgo=$(params.enable-cgo) \
           --go-os=$(params.go-os) \
           --go-arch=$(params.go-arch) \
-          --docker-dir=$(params.docker-dir) \
+          --output-dir=$(params.output-dir) \
           --debug=${DEBUG}
       workingDir: $(workspaces.source.path)
     - name: scan-with-sonar

--- a/deploy/central/tasks-chart/templates/task-ods-build-python.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-python.yaml
@@ -11,10 +11,10 @@ spec:
         without leading `./` and trailing `/`.
       type: string
       default: "."
-    - name: docker-dir
+    - name: output-dir
       description: >-
-        Path to the directory to use as Docker context, relative to `working-dir`.
-        The resulting Go binary will be copied there.
+        Path to the directory into which outputs should be placed, relative to `working-dir`.
+        This directory may then later be used as Docker context for example.
       type: string
       default: docker
     - name: max-line-length
@@ -61,7 +61,7 @@ spec:
         build-python \
           --working-dir=$(params.working-dir) \
           --max-line-length=$(params.max-line-length) \
-          --docker-dir=$(params.docker-dir) \
+          --output-dir=$(params.output-dir) \
           --debug=${DEBUG}
       workingDir: $(workspaces.source.path)
     - name: scan-with-sonar

--- a/deploy/central/tasks-chart/templates/task-ods-build-typescript.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-typescript.yaml
@@ -11,10 +11,10 @@ spec:
         without leading `./` and trailing `/`.
       type: string
       default: "."
-    - name: docker-dir
+    - name: output-dir
       description: >-
-        Path to the directory to use as Docker context, relative to `working-dir`.
-        The resulting Go binary will be copied there.
+        Path to the directory into which outputs should be placed, relative to `working-dir`.
+        This directory may then later be used as Docker context for example.
       type: string
       default: docker
     - name: sonar-quality-gate
@@ -56,7 +56,7 @@ spec:
         # build-typescript is build/package/scripts/build-typescript.sh.
         build-typescript \
           --working-dir=$(params.working-dir) \
-          --docker-dir=$(params.docker-dir) \
+          --output-dir=$(params.output-dir) \
           --debug=${DEBUG}
       workingDir: $(workspaces.source.path)
     - name: scan-with-sonar

--- a/docs/tasks/ods-build-go.adoc
+++ b/docs/tasks/ods-build-go.adoc
@@ -53,9 +53,9 @@ without leading `./` and trailing `/`.
 | `GOARCH` variable (the execution architecture such as `arm`, `amd64`).
 
 
-| docker-dir
+| output-dir
 | docker
-| Path to the directory to use as Docker context, relative to `working-dir`. The resulting Go binary will be copied there.
+| Path to the directory into which the resulting Go binary should be copied, relative to `working-dir`. This directory may then later be used as Docker context for example.
 
 
 | sonar-quality-gate

--- a/docs/tasks/ods-build-python.adoc
+++ b/docs/tasks/ods-build-python.adoc
@@ -18,9 +18,9 @@ without leading `./` and trailing `/`.
 
 
 
-| docker-dir
+| output-dir
 | docker
-| Path to the directory to use as Docker context, relative to `working-dir`. The resulting Go binary will be copied there.
+| Path to the directory into which outputs should be placed, relative to `working-dir`. This directory may then later be used as Docker context for example.
 
 
 | max-line-length

--- a/docs/tasks/ods-build-typescript.adoc
+++ b/docs/tasks/ods-build-typescript.adoc
@@ -18,9 +18,9 @@ without leading `./` and trailing `/`.
 
 
 
-| docker-dir
+| output-dir
 | docker
-| Path to the directory to use as Docker context, relative to `working-dir`. The resulting Go binary will be copied there.
+| Path to the directory into which outputs should be placed, relative to `working-dir`. This directory may then later be used as Docker context for example.
 
 
 | sonar-quality-gate


### PR DESCRIPTION
Closes #165.

`ods-build-image` will still use `docker-dir` as in this case it actually refers to "Docker".