### PR TITLE
Provide params to control resource constraints

### DIFF
--- a/deploy/central/tasks-chart/templates/task-ods-build-go.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-go.yaml
@@ -57,6 +57,22 @@ spec:
       description: Whether to skip SonarQube analysis or not.
       type: string
       default: "false"
+    - name: cpu-request
+      description: Minimum amount of CPU compute resources required, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "100m"
+    - name: cpu-limit
+      description: Maximum amount of CPU compute resources allowed, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "1"
+    - name: memory-request
+      description: Minimum amount of memory compute resources required, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "512Mi"
+    - name: memory-limit
+      description: Maximum amount of memory compute resources allowed, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "1Gi"
   steps:
     - name: build-go-binary
       # Image is built from build/package/Dockerfile.go-toolset.
@@ -67,7 +83,13 @@ spec:
             configMapKeyRef:
               key: debug
               name: ods-pipeline
-      resources: {}
+      resources:
+        requests:
+          memory: '$(params.memory-request)'
+          cpu: '$(params.cpu-request)'
+        limits:
+          memory: '$(params.memory-limit)'
+          cpu: '$(params.cpu-limit)'
       script: |
 
         # build-go is build/package/scripts/build-go.sh.
@@ -93,7 +115,13 @@ spec:
             secretKeyRef:
               key: password
               name: ods-sonar-auth
-      resources: {}
+      resources:
+        requests:
+          memory: '$(params.memory-request)'
+          cpu: '$(params.cpu-request)'
+        limits:
+          memory: '$(params.memory-limit)'
+          cpu: '$(params.cpu-limit)'
       script: |
         if [ "$(params.sonar-skip)" = "true" ]; then
           echo "Skipping SonarQube analysis"

--- a/deploy/central/tasks-chart/templates/task-ods-build-python.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-python.yaml
@@ -29,6 +29,22 @@ spec:
       description: Whether to skip the SonarQube analysis or not.
       type: string
       default: "false"
+    - name: cpu-request
+      description: Minimum amount of CPU compute resources required, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "100m"
+    - name: cpu-limit
+      description: Maximum amount of CPU compute resources allowed, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "1"
+    - name: memory-request
+      description: Minimum amount of memory compute resources required, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "512Mi"
+    - name: memory-limit
+      description: Maximum amount of memory compute resources allowed, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "1Gi"
   steps:
     - name: build-python
       # Image is built from build/package/Dockerfile.python-toolset.
@@ -54,7 +70,13 @@ spec:
             configMapKeyRef:
               key: debug
               name: ods-pipeline
-      resources: {}
+      resources:
+        requests:
+          memory: '$(params.memory-request)'
+          cpu: '$(params.cpu-request)'
+        limits:
+          memory: '$(params.memory-limit)'
+          cpu: '$(params.cpu-limit)'
       script: |
 
         # build-python is build/package/scripts/build-python.sh.
@@ -78,7 +100,13 @@ spec:
             secretKeyRef:
               key: password
               name: ods-sonar-auth
-      resources: {}
+      resources:
+        requests:
+          memory: '$(params.memory-request)'
+          cpu: '$(params.cpu-request)'
+        limits:
+          memory: '$(params.memory-limit)'
+          cpu: '$(params.cpu-limit)'
       script: |
         if [ "$(params.sonar-skip)" = "true" ]; then
           echo "Skipping SonarQube analysis"

--- a/deploy/central/tasks-chart/templates/task-ods-build-typescript.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-typescript.yaml
@@ -25,6 +25,22 @@ spec:
       description: Whether to skip the SonarQube analysis or not.
       type: string
       default: "false"
+    - name: cpu-request
+      description: Minimum amount of CPU compute resources required, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "100m"
+    - name: cpu-limit
+      description: Maximum amount of CPU compute resources allowed, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "1"
+    - name: memory-request
+      description: Minimum amount of memory compute resources required, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "2Gi"
+    - name: memory-limit
+      description: Maximum amount of memory compute resources allowed, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "3Gi"
   steps:
     - name: build-typescript
       # Image is built from build/package/Dockerfile.typescript-toolset.
@@ -50,7 +66,13 @@ spec:
             configMapKeyRef:
               key: debug
               name: ods-pipeline
-      resources: {}
+      resources:
+        requests:
+          memory: '$(params.memory-request)'
+          cpu: '$(params.cpu-request)'
+        limits:
+          memory: '$(params.memory-limit)'
+          cpu: '$(params.cpu-limit)'
       script: |
 
         # build-typescript is build/package/scripts/build-typescript.sh.
@@ -73,7 +95,13 @@ spec:
             secretKeyRef:
               key: password
               name: ods-sonar-auth
-      resources: {}
+      resources:
+        requests:
+          memory: '$(params.memory-request)'
+          cpu: '$(params.cpu-request)'
+        limits:
+          memory: '$(params.memory-limit)'
+          cpu: '$(params.cpu-limit)'
       script: |
         if [ "$(params.sonar-skip)" = "true" ]; then
           echo "Skipping SonarQube analysis"

--- a/deploy/central/tasks-chart/templates/task-ods-deploy-helm.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-deploy-helm.yaml
@@ -39,17 +39,33 @@ spec:
       description: The Helm release name. If empty, the release name is simply the name of the chart.
       type: string
       default: ''
-    - name: overwrite-values
-      description: >-
-        Specify the values you want to overwrite, comma separated.
-        Example: `autoscaling.enabled=true,replicas=1`
+    - name: cpu-request
+      description: Minimum amount of CPU compute resources required, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
       type: string
-      default: ''
+      default: "100m"
+    - name: cpu-limit
+      description: Maximum amount of CPU compute resources allowed, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "500m"
+    - name: memory-request
+      description: Minimum amount of memory compute resources required, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "128Mi"
+    - name: memory-limit
+      description: Maximum amount of memory compute resources allowed, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "256Mi"
   steps:
     - name: helm-upgrade-from-repo
       # Image is built from build/package/Dockerfile.helm.
       image: '{{ .Values.registry }}/{{ .Values.namespace }}/ods-helm:{{ .Values.imageTag }}'
-      resources: {}
+      resources:
+        requests:
+          memory: '$(params.memory-request)'
+          cpu: '$(params.cpu-request)'
+        limits:
+          memory: '$(params.memory-limit)'
+          cpu: '$(params.cpu-limit)'
       script: |
         # deploy-with-helm is built from /cmd/deploy-with-helm/main.go.
         deploy-with-helm \

--- a/deploy/central/tasks-chart/templates/task-ods-finish.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-finish.yaml
@@ -18,6 +18,22 @@ spec:
     - name: aggregate-tasks-status
       description: Aggregate status of all tasks.
       default: "None"
+    - name: cpu-request
+      description: Minimum amount of CPU compute resources required, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "100m"
+    - name: cpu-limit
+      description: Maximum amount of CPU compute resources allowed, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "500m"
+    - name: memory-request
+      description: Minimum amount of memory compute resources required, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "128Mi"
+    - name: memory-limit
+      description: Maximum amount of memory compute resources allowed, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "256Mi"
   steps:
     - name: ods-finish
       # Image is built from build/package/Dockerfile.finish.
@@ -63,7 +79,13 @@ spec:
             configMapKeyRef:
               key: consoleUrl
               name: ods-cluster
-      resources: {}
+      resources:
+        requests:
+          memory: '$(params.memory-request)'
+          cpu: '$(params.cpu-request)'
+        limits:
+          memory: '$(params.memory-limit)'
+          cpu: '$(params.cpu-limit)'
       workingDir: $(workspaces.source.path)
       script: |
 

--- a/deploy/central/tasks-chart/templates/task-ods-package-image.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-package-image.yaml
@@ -54,6 +54,22 @@ spec:
       description: Whether the Aqua security scan needs to pass for the task to succeed.
       type: string
       default: "false"
+    - name: cpu-request
+      description: Minimum amount of CPU compute resources required, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "100m"
+    - name: cpu-limit
+      description: Maximum amount of CPU compute resources allowed, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "1"
+    - name: memory-request
+      description: Minimum amount of memory compute resources required, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "1Gi"
+    - name: memory-limit
+      description: Maximum amount of memory compute resources allowed, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "2Gi"
   results:
     - description: Digest of the image just built.
       name: image-digest
@@ -97,7 +113,13 @@ spec:
             configMapKeyRef:
               key: debug
               name: ods-pipeline
-      resources: {}
+      resources:
+        requests:
+          memory: '$(params.memory-request)'
+          cpu: '$(params.cpu-request)'
+        limits:
+          memory: '$(params.memory-limit)'
+          cpu: '$(params.cpu-limit)'
       script: |
 
         #  ods-build-push-image is built from cmd/build-push-image/main.go.

--- a/deploy/central/tasks-chart/templates/task-ods-start.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-start.yaml
@@ -94,6 +94,22 @@ spec:
     - name: pipeline-run-name
       description: Name of pipeline run.
       type: string
+    - name: cpu-request
+      description: Minimum amount of CPU compute resources required, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "100m"
+    - name: cpu-limit
+      description: Maximum amount of CPU compute resources allowed, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "500m"
+    - name: memory-request
+      description: Minimum amount of memory compute resources required, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "128Mi"
+    - name: memory-limit
+      description: Maximum amount of memory compute resources allowed, as per https://kubernetes.io/docs/concepts/configuration/manage-resources-containers.
+      type: string
+      default: "256Mi"
   results:
     - description: The commit SHA that was fetched by this task.
       name: commit
@@ -144,7 +160,13 @@ spec:
             configMapKeyRef:
               key: consoleUrl
               name: ods-cluster
-      resources: {}
+      resources:
+        requests:
+          memory: '$(params.memory-request)'
+          cpu: '$(params.cpu-request)'
+        limits:
+          memory: '$(params.memory-limit)'
+          cpu: '$(params.cpu-limit)'
       workingDir: $(workspaces.source.path)
       script: |
 

--- a/internal/docs/tasks.go
+++ b/internal/docs/tasks.go
@@ -62,7 +62,7 @@ func parseTasks(helmTemplateOutput []byte) ([]*tekton.ClusterTask, error) {
 		var t tekton.ClusterTask
 		err := yaml.Unmarshal(taskBytes, &t)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("cannot unmarshal tasks: %w", err)
 		}
 		if len(t.Name) > 0 {
 			tasks = append(tasks, &t)


### PR DESCRIPTION
WIP as the docs are out of date, and they cannot be updated because
unmarshalling fails Tekton validation as noted in
https://github.com/tektoncd/pipeline/issues/4080.

We could probably bring this further by removing parameters and defining sensible defaults.