### PR TITLE
Enable Helm deploy to deploy to remote clusters

### DIFF
--- a/docs/ods-configuration.adoc
+++ b/docs/ods-configuration.adoc
@@ -137,12 +137,10 @@ The value of `name` may freely be chosen. The `stage` must be one of `dev`, `qa`
 
 Environments may also be located external to the cluster in which the pipeline runs. In this case, an environment may specify further fields:
 
-* `url`: API URL of the target cluster
-* `secretRef`: Name of the Secret resource holding the API user credentials
+* `apiServer`: API server of the target cluster, including scheme
+* `apiCredentialsSecret`: Name of the Secret resource holding the API user credentials in field `token`
 * `registryHost`: Hostname of the target registry
 * `config`: Additional configuration of the target in the form of a map. This information may be used by custom tasks.
-
-WARNING: External environments are not implemented in `ods-deploy-helm` yet, see link:https://github.com/opendevstack/ods-pipeline/issues/63[issue #63].
 
 === `branchToEnvironmentMapping`
 

--- a/docs/software-requirements.adoc
+++ b/docs/software-requirements.adoc
@@ -209,6 +209,7 @@ a| The task shall push images into the target namespace.
 
 * The images that are pushed are determined by the artifacts in `.ods/artifacts/image-digests`. Each artifact contains information from where to get the images.
 * The target namespace is selected from the given `environment`.
+* The target registry may also be external to the cluster in which the pipeline runs. The registry shall be identified by the `registryHost` field of the environment configuration, and the credential token of `apiCredentialsSecret` shall be used to authenticate.
 
 | REQ-TASK-DEPLOY-HELM-3
 a| The task shall upgrade (or install) a Helm chart.
@@ -222,6 +223,7 @@ a| The task shall upgrade (or install) a Helm chart.
 * Any encrypted secrets files shall be decrypted on the fly, using the private key provided by the `Secret` identified by the `private-key-secret` parameter (defaulting to `helm-secrets-private-key`). The secret shall expose the private key under the `sops.asc` field.
 * The "app version" shall be set to the Git commit SHA and the "version" shall be set to given `version` if any, otherwise the chart version in `Chart.yaml`.
 * Charts in any of the respositories configured in `ods.y(a)ml` shall be packaged according to the same rules and added as a subchart.
+* The target namespace may also be external to the cluster in which the pipeline runs. The API server shall be identified by the `apiServer` field of the environment configuration, and the credential token of `apiCredentialsSecret` shall be used to authenticate.
 |===
 
 == Shared Task Requirements

--- a/pkg/config/ods.go
+++ b/pkg/config/ods.go
@@ -73,8 +73,10 @@ type Environment struct {
 	Name string `json:"name"`
 	// Kind of the environment to deploy to. One of "dev", "qa", "prod".
 	Stage Stage `json:"stage"`
-	// API URL of the target cluster.
-	URL string `json:"url"`
+	// API server of the target cluster, including scheme.
+	APIServer string `json:"apiServer"`
+	// Name of the Secret resource holding the API user credentials.
+	APICredentialsSecret string `json:"apiCredentialsSecret"`
 	// Hostname of the target registry. If not given, the registy of the source
 	// image is used.
 	RegistryHost string `json:"registryHost"`
@@ -82,11 +84,13 @@ type Environment struct {
 	RegistryTLSVerify *bool `json:"registryVerify"`
 	// Target K8s namespace (OpenShift project) on the target cluster to deploy into.
 	Namespace string `json:"namespace"`
-	// Name of the Secret resource holding the API user credentials.
-	SecretRef string `json:"secretRef"`
 	// Additional configuration of the target. This may be used by tasks outside
 	// the ODS catalog.
 	Config map[string]interface{} `json:"config"`
+	// APIToken holds the token of the environment, if any.
+	// The value is retrieved from the "token" field in the secret referenced by APICredentialsSecret.
+	// Cannot be set from JSON.
+	APIToken string `json:"-"`
 }
 
 func (o *ODS) Validate() error {

--- a/pkg/tasktesting/run.go
+++ b/pkg/tasktesting/run.go
@@ -30,6 +30,8 @@ type TestCase struct {
 	WantRunSuccess      bool
 	PreRunFunc          func(t *testing.T, ctxt *TaskRunContext)
 	PostRunFunc         func(t *testing.T, ctxt *TaskRunContext)
+	ExcludeOnShort      bool
+	Timeout             time.Duration
 }
 
 type TaskRunContext struct {

--- a/test/tasks/common_test.go
+++ b/test/tasks/common_test.go
@@ -104,12 +104,18 @@ func runTaskTestCases(t *testing.T, taskName string, testCases map[string]taskte
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			if testing.Short() && tc.ExcludeOnShort {
+				t.Skip()
+			}
+			if tc.Timeout == 0 {
+				tc.Timeout = 5 * time.Minute
+			}
 			tasktesting.Run(t, tc, tasktesting.TestOpts{
 				TaskKindRef:             taskKindRef, // could be read from task definition
 				TaskName:                taskName,    // could be read from task definition
 				Clients:                 c,
 				Namespace:               ns,
-				Timeout:                 5 * time.Minute, // depending on  the task we may need to increase or decrease it
+				Timeout:                 tc.Timeout,
 				AlwaysKeepTmpWorkspaces: *alwaysKeepTmpWorkspacesFlag,
 			})
 		})


### PR DESCRIPTION
Closes #63.

Note that this isn't tested automatically yet. The PR contains a few building blocks that might be used. PR #218 explores one way to test this functionality, but it fails to verify certificates so doesn't quite work yet.