### PR TITLE
adds cleanup env cluster and docker images to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,11 @@ test-tasks:
 	go test -v -count=1 ./test/tasks/...
 .PHONY: test-tasks
 
+## Clean cluster and docker images.
+clean-up-env:
+	cd scripts && ./clean-up-kind-cluster-and-docker-images.sh
+.PHONY: clean-up-cluster
+
 ## Clear temporary workspaces created in testruns.
 clear-tmp-workspaces:
 	rm -rf test/testdata/workspaces/workspace-*

--- a/scripts/clean-up-kind-cluster-and-docker-images.sh
+++ b/scripts/clean-up-kind-cluster-and-docker-images.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -o errexit
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ODS_PIPELINE_DIR=${SCRIPT_DIR%/*}
+
+# desired cluster name; default is "kind"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+RECREATE_KIND_CLUSTER="false"
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+
+    -v|--verbose) set -x;;
+
+    --recreate) RECREATE_KIND_CLUSTER="true";;
+
+    *) echo "Unknown parameter passed: $1"; exit 1;;
+esac; shift; done
+
+kind_version=$(kind version)
+reg_name='kind-registry'
+reg_port='5000'
+reg_ip_selector='{{.NetworkSettings.Networks.kind.IPAddress}}'
+reg_network='kind'
+
+echo "Removing kind cluster ${KIND_CLUSTER_NAME} ..."
+kind delete cluster --name "${KIND_CLUSTER_NAME}"
+echo "... done!"
+echo
+
+echo "Stopping all docker containers in docker network $(reg_network) ..."
+docker ps -qf "network=kind"
+docker stop $(docker ps -qf "network=kind")
+echo "... done!"
+echo
+
+echo "Removing all docker images in docker network $(reg_network) ..."
+docker ps -af "network=kind"
+docker rm $(docker ps -aqf "network=kind")
+echo "... done!"
+echo

--- a/scripts/clean-up-kind-cluster-and-docker-images.sh
+++ b/scripts/clean-up-kind-cluster-and-docker-images.sh
@@ -14,8 +14,6 @@ while [[ "$#" -gt 0 ]]; do
 
     -v|--verbose) set -x;;
 
-    --recreate) RECREATE_KIND_CLUSTER="true";;
-
     *) echo "Unknown parameter passed: $1"; exit 1;;
 esac; shift; done
 


### PR DESCRIPTION
This addresses the discussion about make down/cleanup: https://github.com/opendevstack/ods-pipeline/discussions/39

This PR adds to `Makefile` the target `clean-up-env`. It provides following functionality:
- it removes the kind cluster
- it  stops all docker images in the network equal `kind` and removes those images from docker registry. 
