### PR TITLE
Support pre-test scripts for Go and Python

### DIFF
--- a/build/package/scripts/build-go.sh
+++ b/build/package/scripts/build-go.sh
@@ -7,6 +7,7 @@ GO_ARCH=""
 OUTPUT_DIR="docker"
 WORKING_DIR="."
 ARTIFACT_PREFIX=""
+PRE_TEST_SCRIPT=""
 DEBUG="false"
 
 while [[ "$#" -gt 0 ]]; do
@@ -26,6 +27,9 @@ while [[ "$#" -gt 0 ]]; do
 
     --output-dir) OUTPUT_DIR="$2"; shift;;
     --output-dir=*) OUTPUT_DIR="${1#*=}";;
+
+    --pre-test-script) PRE_TEST_SCRIPT="$2"; shift;;
+    --pre-test-script=*) PRE_TEST_SCRIPT="${1#*=}";;
 
     --debug) DEBUG="$2"; shift;;
     --debug=*) DEBUG="${1#*=}";;
@@ -81,6 +85,11 @@ fi
 
 echo "Building ..."
 go build -gcflags "all=-trimpath=$(pwd)" -o "${OUTPUT_DIR}/app"
+
+if [ -n "${PRE_TEST_SCRIPT}" ]; then
+  echo "Executing pre-test script ..."
+  ./${PRE_TEST_SCRIPT}
+fi
 
 echo "Testing ..."
 if [ -f "${ROOT_DIR}/.ods/artifacts/xunit-reports/${ARTIFACT_PREFIX}report.xml" ]; then

--- a/build/package/scripts/build-go.sh
+++ b/build/package/scripts/build-go.sh
@@ -83,9 +83,6 @@ if [ -s go-lint-report.txt ]; then
   exit $exitcode
 fi
 
-echo "Building ..."
-go build -gcflags "all=-trimpath=$(pwd)" -o "${OUTPUT_DIR}/app"
-
 if [ -n "${PRE_TEST_SCRIPT}" ]; then
   echo "Executing pre-test script ..."
   ./${PRE_TEST_SCRIPT}
@@ -120,5 +117,10 @@ else
     echo "No code coverage found"
     exit 1
   fi
-  exit $exitcode
+  if [ $exitcode != 0 ]; then
+    exit $exitcode
+  fi
 fi
+
+echo "Building ..."
+go build -gcflags "all=-trimpath=$(pwd)" -o "${OUTPUT_DIR}/app"

--- a/build/package/scripts/build-python.sh
+++ b/build/package/scripts/build-python.sh
@@ -17,6 +17,7 @@ OUTPUT_DIR="docker"
 MAX_LINE_LENGTH="120"
 WORKING_DIR="."
 ARTIFACT_PREFIX=""
+PRE_TEST_SCRIPT=""
 DEBUG="false"
 
 while [[ "$#" -gt 0 ]]; do
@@ -27,6 +28,9 @@ while [[ "$#" -gt 0 ]]; do
 
     --max-line-length) MAX_LINE_LENGTH="$2"; shift;;
     --max-line-length=*) MAX_LINE_LENGTH="${1#*=}";;
+
+    --pre-test-script) PRE_TEST_SCRIPT="$2"; shift;;
+    --pre-test-script=*) PRE_TEST_SCRIPT="${1#*=}";;
 
     --output-dir) OUTPUT_DIR="$2"; shift;;
     --output-dir=*) OUTPUT_DIR="${1#*=}";;
@@ -67,6 +71,11 @@ pip check
 echo "Linting ..."
 mypy src
 flake8 --max-line-length="${MAX_LINE_LENGTH}" src
+
+if [ -n "${PRE_TEST_SCRIPT}" ]; then
+  echo "Executing pre-test script ..."
+  ./${PRE_TEST_SCRIPT}
+fi
 
 echo "Testing ..."
 rm report.xml coverage.xml &>/dev/null || true

--- a/deploy/central/tasks-chart/templates/task-ods-build-go.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-go.yaml
@@ -49,6 +49,10 @@ spec:
         This directory may then later be used as Docker context for example.
       type: string
       default: docker
+    - name: pre-test-script
+      description: Script to execute before running tests, relative to the working directory.
+      type: string
+      default: ""
     - name: sonar-quality-gate
       description: Whether the SonarQube quality gate needs to pass for the task to succeed.
       type: string
@@ -76,6 +80,7 @@ spec:
           --enable-cgo=$(params.enable-cgo) \
           --go-os=$(params.go-os) \
           --go-arch=$(params.go-arch) \
+          --pre-test-script=$(params.pre-test-script) \
           --output-dir=$(params.output-dir) \
           --debug=${DEBUG}
       workingDir: $(workspaces.source.path)

--- a/deploy/central/tasks-chart/templates/task-ods-build-python.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-python.yaml
@@ -21,6 +21,10 @@ spec:
       description: Maximum line length.
       type: string
       default: "120"
+    - name: pre-test-script
+      description: Script to execute before running tests, relative to the working directory.
+      type: string
+      default: ""
     - name: sonar-quality-gate
       description: Whether quality gate needs to pass.
       type: string
@@ -61,6 +65,7 @@ spec:
         build-python \
           --working-dir=$(params.working-dir) \
           --max-line-length=$(params.max-line-length) \
+          --pre-test-script=$(params.pre-test-script) \
           --output-dir=$(params.output-dir) \
           --debug=${DEBUG}
       workingDir: $(workspaces.source.path)

--- a/docs/software-requirements.adoc
+++ b/docs/software-requirements.adoc
@@ -89,21 +89,16 @@ a| The task shall build a Go module based Go binary into `docker/app`:
 | REQ-TASK-BUILD-GO-4
 a| The task shall run `go test`, creating code coverage and xUnit report.
 
+* A shell script shall be executed prior to the tests if specified by the `pre-test-script` task parameter.
 * All packages except vendored ones shall be tested.
 * The artifacts shall be placed in the working directory (for SonarQube to pick them up) and in `.ods/artifacts`.
 * If tests already ran for the commit being built, testing shall be skipped and the existing artifacts shall be copied into the working directory.
 
 | REQ-TASK-BUILD-GO-5
-a| The task shall run `sonar-scanner` on the sources, communicating with the SonarQube server specified by the `ods-sonar` config map and the `ods-sonar-auth` secret:
-
-* The project name shall be fixed to `<PROJECT>-<COMPONENT>`
-* If the server edition supports it, the branch parameter shall be set, unless the branch being built belongs to an open PR, in which case PR analysis parameter shall be sent instead.
+| See REQ-TASK-SHARED-1.
 
 | REQ-TASK-BUILD-GO-6
-a| The task shall be able to run in a subdirectory of the checked out repository.
-
-* Generated artifacts shall be prefixed with `<SUBDIRECTORY>-`
-* The SonarQube project shall be suffixed with `-<SUBDIRECTORY>`
+| See REQ-TASK-SHARED-2.
 
 |===
 
@@ -132,16 +127,51 @@ a| The task shall copy the generated unit test coverage report into the folder `
 * The artifacts shall be placed in the working directory (for SonarQube to pick them up) and in .ods/artifacts.
 
 | REQ-TASK-BUILD-GRADLE-5
-a| The task shall run `sonar-scanner` on the sources, communicating with the SonarQube server specified by the `ods-sonar` config map and the `ods-sonar-auth` secret:
-
-* The project name shall be fixed to `<PROJECT>-<COMPONENT>`
-* If the server edition supports it, the branch parameter shall be set, unless the branch being built belongs to an open PR, in which case PR analysis parameter shall be sent instead.
+| See REQ-TASK-SHARED-1.
 
 | REQ-TASK-BUILD-GRADLE-6
-a| The task shall be able to run in a subdirectory of the checked out repository.
+| See REQ-TASK-SHARED-2.
 
-* Generated artifacts shall be prefixed with `<SUBDIRECTORY>-`
-* The SonarQube project shall be suffixed with `-<SUBDIRECTORY>`
+|===
+
+=== `ods-build-python`
+
+[cols="1,3"]
+|===
+| REQ-TASK-BUILD-PYTHON-1
+| TODO
+
+| REQ-TASK-BUILD-PYTHON-2
+a| The task shall run `mypy` and `flake8` to lint source code and fail if there are any findings.
+
+* The maximum allowed line length shall default to 120 and be defined by the `max-line-length` task parameter.
+
+| REQ-TASK-BUILD-PYTHON-3
+a| The task shall run `pytest`, creating code coverage and xUnit reports.
+
+* A shell script shall be executed prior to the tests if specified by the `pre-test-script` task parameter.
+* The artifacts shall be placed in the working directory (for SonarQube to pick them up) and in `.ods/artifacts`.
+
+| REQ-TASK-BUILD-PYTHON-4
+| See REQ-TASK-SHARED-1.
+
+| REQ-TASK-BUILD-PYTHON-5
+| See REQ-TASK-SHARED-2.
+
+|===
+
+=== `ods-build-typescript`
+
+[cols="1,3"]
+|===
+| REQ-TASK-BUILD-TYPESCRIPT-1
+| TODO
+
+| REQ-TASK-BUILD-TYPESCRIPT-2
+| See REQ-TASK-SHARED-1.
+
+| REQ-TASK-BUILD-TYPESCRIPT-3
+| See REQ-TASK-SHARED-2.
 
 |===
 
@@ -192,4 +222,24 @@ a| The task shall upgrade (or install) a Helm chart.
 * Any encrypted secrets files shall be decrypted on the fly, using the private key provided by the `Secret` identified by the `private-key-secret` parameter (defaulting to `helm-secrets-private-key`). The secret shall expose the private key under the `sops.asc` field.
 * The "app version" shall be set to the Git commit SHA and the "version" shall be set to given `version` if any, otherwise the chart version in `Chart.yaml`.
 * Charts in any of the respositories configured in `ods.y(a)ml` shall be packaged according to the same rules and added as a subchart.
+|===
+
+== Shared Task Requirements
+
+Tasks above may refer to these shared requirements.
+
+[cols="1,3"]
+|===
+| REQ-TASK-SHARED-1
+a| The task shall run `sonar-scanner` on the sources, communicating with the SonarQube server specified by the `ods-sonar` config map and the `ods-sonar-auth` secret:
+
+* The project name shall be fixed to `<PROJECT>-<COMPONENT>`
+* If the server edition supports it, the branch parameter shall be set, unless the branch being built belongs to an open PR, in which case PR analysis parameter shall be sent instead.
+
+| REQ-TASK-SHARED-2
+a| The task shall be able to run in a subdirectory of the checked out repository.
+
+* Generated artifacts shall be prefixed with `<SUBDIRECTORY>-`
+* The SonarQube project shall be suffixed with `-<SUBDIRECTORY>`
+
 |===

--- a/docs/software-requirements.adoc
+++ b/docs/software-requirements.adoc
@@ -79,20 +79,20 @@ a| The task shall store context information under `.ods` for each checked out re
 | The task shall run golanglint-ci and fail if there are any findings.
 
 | REQ-TASK-BUILD-GO-3
-a| The task shall build a Go module based Go binary into `docker/app`:
-
-* The destination directory shall be customizable
-* Paths in stack traces shall be trimmed
-* The target operating system (`GOOS`) and architecture (`GOARCH`) shall be customizable
-* CGO shall be disabled by default but shall be enablable by parameter.
-
-| REQ-TASK-BUILD-GO-4
 a| The task shall run `go test`, creating code coverage and xUnit report.
 
 * A shell script shall be executed prior to the tests if specified by the `pre-test-script` task parameter.
 * All packages except vendored ones shall be tested.
 * The artifacts shall be placed in the working directory (for SonarQube to pick them up) and in `.ods/artifacts`.
 * If tests already ran for the commit being built, testing shall be skipped and the existing artifacts shall be copied into the working directory.
+
+| REQ-TASK-BUILD-GO-4
+a| The task shall build a Go module based Go binary into `docker/app`:
+
+* The destination directory shall be customizable
+* Paths in stack traces shall be trimmed
+* The target operating system (`GOOS`) and architecture (`GOARCH`) shall be customizable
+* CGO shall be disabled by default but shall be enablable by parameter.
 
 | REQ-TASK-BUILD-GO-5
 | See REQ-TASK-SHARED-1.

--- a/docs/tasks/ods-build-go.adoc
+++ b/docs/tasks/ods-build-go.adoc
@@ -57,6 +57,11 @@ without leading `./` and trailing `/`.
 | Path to the directory into which the resulting Go binary should be copied, relative to `working-dir`. This directory may then later be used as Docker context for example.
 
 
+| pre-test-script
+| 
+| Script to execute before running tests, relative to the working directory.
+
+
 | sonar-quality-gate
 | false
 | Whether the SonarQube quality gate needs to pass for the task to succeed.

--- a/docs/tasks/ods-build-python.adoc
+++ b/docs/tasks/ods-build-python.adoc
@@ -27,6 +27,11 @@ without leading `./` and trailing `/`.
 | Maximum line length.
 
 
+| pre-test-script
+| 
+| Script to execute before running tests, relative to the working directory.
+
+
 | sonar-quality-gate
 | false
 | Whether quality gate needs to pass.

--- a/test/tasks/ods-build-go_test.go
+++ b/test/tasks/ods-build-go_test.go
@@ -146,5 +146,25 @@ func TestTaskODSBuildGo(t *testing.T) {
 					checkFileContent(t, wsDir, ".ods/artifacts/lint-reports/report.txt", wantLintReportContent)
 				},
 			},
+			"build go app with pre-test script": {
+				WorkspaceDirMapping: map[string]string{"source": "go-sample-app"},
+				PreRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
+					wsDir := ctxt.Workspaces["source"]
+					ctxt.ODS = tasktesting.SetupGitRepo(t, ctxt.Namespace, wsDir)
+					ctxt.Params = map[string]string{
+						"sonar-skip":      "true",
+						"pre-test-script": "pre-test-script.sh",
+					}
+				},
+				WantRunSuccess: true,
+				PostRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
+					wsDir := ctxt.Workspaces["source"]
+
+					wantFile := "docker/test.txt"
+					if _, err := os.Stat(filepath.Join(wsDir, wantFile)); os.IsNotExist(err) {
+						t.Fatalf("Want %s, but got nothing", wantFile)
+					}
+				},
+			},
 		})
 }

--- a/test/tasks/ods-build-python_test.go
+++ b/test/tasks/ods-build-python_test.go
@@ -108,5 +108,25 @@ func TestTaskODSBuildPython(t *testing.T) {
 					checkSonarQualityGate(t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace, sonarProject, true, "OK")
 				},
 			},
+			"build python flask app with pre-test script": {
+				WorkspaceDirMapping: map[string]string{"source": "python-flask-sample-app"},
+				PreRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
+					wsDir := ctxt.Workspaces["source"]
+					ctxt.ODS = tasktesting.SetupGitRepo(t, ctxt.Namespace, wsDir)
+					ctxt.Params = map[string]string{
+						"sonar-skip":      "true",
+						"pre-test-script": "pre-test-script.sh",
+					}
+				},
+				WantRunSuccess: true,
+				PostRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
+					wsDir := ctxt.Workspaces["source"]
+
+					wantFile := "docker/test.txt"
+					if _, err := os.Stat(filepath.Join(wsDir, wantFile)); os.IsNotExist(err) {
+						t.Fatalf("Want %s, but got nothing", wantFile)
+					}
+				},
+			},
 		})
 }

--- a/test/testdata/workspaces/go-sample-app/pre-test-script.sh
+++ b/test/testdata/workspaces/go-sample-app/pre-test-script.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eu
+
+echo "hello" > docker/test.txt

--- a/test/testdata/workspaces/python-flask-sample-app/pre-test-script.sh
+++ b/test/testdata/workspaces/python-flask-sample-app/pre-test-script.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eu
+
+echo "hello" > docker/test.txt


### PR DESCRIPTION
Closes #136.

I assume we do not need this for NPM and Gradle, because those allow to
customize what is executed as a test (e.g. by adding a dependency to the
`test` task in `build.gradle`).

FYI @renedupont This would cover your use case of running migrations before tests.

In general, both this PR and #210 are far from ideal solutions, but the only way I see right now. I propose to go forward with both, and see how bad it is in reality.