### PR TITLE
Enable Helm deploy to deploy to remote clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 test/testdata/workspaces/workspace-*
+ods.external.yaml

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,13 @@ run-sonarqube:
 prepare-local-env: create-kind-with-registry build-and-push-images install-tekton-pipelines run-bitbucket run-nexus run-sonarqube install-ods-tasks-kind
 .PHONY: prepare-local-env
 
+## Recreate KinD cluster including Tekton tasks.
+recreate-kind-cluster:
+	cd scripts && ./kind-with-registry.sh --recreate
+	cd scripts && ./install-tekton-pipelines.sh
+	cd scripts && ./install-ods-tasks-kind.sh
+.PHONY: recreate-kind-cluster
+
 ## Stop local environment.
 stop-local-env:
 	cd scripts && ./stop-local-env.sh

--- a/docs/development.adoc
+++ b/docs/development.adoc
@@ -36,3 +36,30 @@ go test -run ^TestTaskODSBuildImage github.com/opendevstack/pipeline/test/tasks 
 Be aware that depending on the tested task, some local services (e.g. Bitbucket) need to run for the test to succeed. These are all started via `make prepare-local-env`, but more fine-grained control is possible too. Unfortunately these test dependencies are not expressed explicitly yet, see tracking issue https://github.com/opendevstack/ods-pipeline/issues/99.
 
 Also, if you make changes to the images backing the tasks (be it by changing the `Dockerfile` or by changing the scripts/commands installed there), make sure to rebuild and push the affected images to the KinD registry for your changes to take effect. You can do this e.g. through `./scripts/build-and-push-images.sh --image finish` (the name of the image flag is the suffix of the respective Dockerfile).
+
+=== Testing deployment to external cluster
+
+The `ods-deploy-helm` task is able to deploy to external clusters. This functionality is covered by tests as well, but they are hidden behind the `external` build flag by default. To run those tests, you must run `go test` with `--tags=external`, and provide information about the external cluster to use as the test does not setup the external cluster automatically.
+
+First, you need to create a ODS configuration file containing one environment describing the external cluster you want to use, e.g.:
+
+.ods.external.yaml
+[source,yaml]
+----
+environments:
+- name: dev
+  stage: dev
+  namespace: foo-dev
+  apiServer: https://api.example.openshiftapps.com:6443
+  registryHost: default-route-openshift-image-registry.apps.example.openshiftapps.com
+----
+
+If you place this file in the root of the `ods-pipeline` repository, it will automtically be ignored by Git. Note that the `namespace` specified will be used to deploy the Helm release into. As the Helm release name is set to the random workspace name, clashes with existing resources is unlikely. Nonetheless, it is always recommended to use an empty namespace setup solely for the purpose of testing.
+
+Finally, you need to run the tests, passing the configuration created earlier and the token of a serviceaccount with enough permissions in the target namespace:
+
+```
+go test --tags=external -run ^TestTaskODSDeployHelmExternal$ github.com/opendevstack/pipeline/test/tasks -v -external-cluster-token=*** -external-cluster-config=ods.external.yaml
+```
+
+The above command runs only the external deployment test, but you may also remove this limitation (by removing `-run ^TestTaskODSDeployHelmExternal$`) and run the whole test suite including the external deployment test.

--- a/docs/ods-configuration.adoc
+++ b/docs/ods-configuration.adoc
@@ -137,12 +137,10 @@ The value of `name` may freely be chosen. The `stage` must be one of `dev`, `qa`
 
 Environments may also be located external to the cluster in which the pipeline runs. In this case, an environment may specify further fields:
 
-* `url`: API URL of the target cluster
-* `secretRef`: Name of the Secret resource holding the API user credentials
+* `apiServer`: API server of the target cluster, including scheme
+* `apiCredentialsSecret`: Name of the Secret resource holding the API user credentials in field `token`
 * `registryHost`: Hostname of the target registry
 * `config`: Additional configuration of the target in the form of a map. This information may be used by custom tasks.
-
-WARNING: External environments are not implemented in `ods-deploy-helm` yet, see link:https://github.com/opendevstack/ods-pipeline/issues/63[issue #63].
 
 === `branchToEnvironmentMapping`
 

--- a/docs/software-requirements.adoc
+++ b/docs/software-requirements.adoc
@@ -209,6 +209,7 @@ a| The task shall push images into the target namespace.
 
 * The images that are pushed are determined by the artifacts in `.ods/artifacts/image-digests`. Each artifact contains information from where to get the images.
 * The target namespace is selected from the given `environment`.
+* The target registry may also be external to the cluster in which the pipeline runs. The registry shall be identified by the `registryHost` field of the environment configuration, and the credential token of `apiCredentialsSecret` shall be used to authenticate.
 
 | REQ-TASK-DEPLOY-HELM-3
 a| The task shall upgrade (or install) a Helm chart.
@@ -222,6 +223,7 @@ a| The task shall upgrade (or install) a Helm chart.
 * Any encrypted secrets files shall be decrypted on the fly, using the private key provided by the `Secret` identified by the `private-key-secret` parameter (defaulting to `helm-secrets-private-key`). The secret shall expose the private key under the `sops.asc` field.
 * The "app version" shall be set to the Git commit SHA and the "version" shall be set to given `version` if any, otherwise the chart version in `Chart.yaml`.
 * Charts in any of the respositories configured in `ods.y(a)ml` shall be packaged according to the same rules and added as a subchart.
+* The target namespace may also be external to the cluster in which the pipeline runs. The API server shall be identified by the `apiServer` field of the environment configuration, and the credential token of `apiCredentialsSecret` shall be used to authenticate.
 |===
 
 == Shared Task Requirements

--- a/go.sum
+++ b/go.sum
@@ -473,7 +473,6 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
@@ -745,7 +744,6 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/vdemeester/k8s-pkg-credentialprovider v1.19.7/go.mod h1:K2nMO14cgZitdwBqdQps9tInJgcaXcU/7q5F59lpbNI=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=

--- a/pkg/config/ods.go
+++ b/pkg/config/ods.go
@@ -34,13 +34,13 @@ var ODSFileCandidates = []string{ODSYAMLFile, ODSYMLFile}
 type ODS struct {
 	// Repositories specifies the subrepositores, making the current repository
 	// an "umbrella" repository.
-	Repositories []Repository `json:"repositories"`
+	Repositories []Repository `json:"repositories,omitempty"`
 	// Environments allows you to specify target environments to deploy to.
 	Environments []Environment `json:"environments"`
 	// BranchToEnvironmentMapping configures which branch should be deployed to which environment.
-	BranchToEnvironmentMapping []BranchToEnvironmentMapping `json:"branchToEnvironmentMapping"`
+	BranchToEnvironmentMapping []BranchToEnvironmentMapping `json:"branchToEnvironmentMapping,omitempty"`
 	// Pipeline allows to define the Tekton pipeline tasks.
-	Pipeline Pipeline `json:"pipeline"`
+	Pipeline Pipeline `json:"pipeline,omitempty"`
 	// Version is the application version and must follow SemVer.
 	Version string `json:"version,omitempty"`
 }
@@ -81,16 +81,22 @@ type Environment struct {
 	// image is used.
 	RegistryHost string `json:"registryHost"`
 	// Whether to verify TLS for the target registry.
-	RegistryTLSVerify *bool `json:"registryVerify"`
+	RegistryTLSVerify *bool `json:"registryVerify,omitempty"`
 	// Target K8s namespace (OpenShift project) on the target cluster to deploy into.
 	Namespace string `json:"namespace"`
 	// Additional configuration of the target. This may be used by tasks outside
 	// the ODS catalog.
-	Config map[string]interface{} `json:"config"`
+	Config map[string]interface{} `json:"config,omitempty"`
 	// APIToken holds the token of the environment, if any.
 	// The value is retrieved from the "token" field in the secret referenced by APICredentialsSecret.
 	// Cannot be set from JSON.
 	APIToken string `json:"-"`
+}
+
+// Pipeline represents a Tekton pipeline.
+type Pipeline struct {
+	Tasks   []tekton.PipelineTask `json:"tasks,omitempty"`
+	Finally []tekton.PipelineTask `json:"finally,omitempty"`
 }
 
 func (o *ODS) Validate() error {
@@ -124,12 +130,6 @@ func (o *ODS) Environment(environment string) (*Environment, error) {
 	}
 
 	return nil, fmt.Errorf("no environment matched '%s', have: %s", environment, strings.Join(envs, ", "))
-}
-
-// Pipeline represents a Tekton pipeline.
-type Pipeline struct {
-	Tasks   []tekton.PipelineTask `json:"tasks"`
-	Finally []tekton.PipelineTask `json:"finally"`
 }
 
 // Read reads an ods config from given byte slice or errors.

--- a/pkg/config/ods.go
+++ b/pkg/config/ods.go
@@ -73,8 +73,10 @@ type Environment struct {
 	Name string `json:"name"`
 	// Kind of the environment to deploy to. One of "dev", "qa", "prod".
 	Stage Stage `json:"stage"`
-	// API URL of the target cluster.
-	URL string `json:"url"`
+	// API server of the target cluster, including scheme.
+	APIServer string `json:"apiServer"`
+	// Name of the Secret resource holding the API user credentials.
+	APICredentialsSecret string `json:"apiCredentialsSecret"`
 	// Hostname of the target registry. If not given, the registy of the source
 	// image is used.
 	RegistryHost string `json:"registryHost"`
@@ -82,11 +84,13 @@ type Environment struct {
 	RegistryTLSVerify *bool `json:"registryVerify"`
 	// Target K8s namespace (OpenShift project) on the target cluster to deploy into.
 	Namespace string `json:"namespace"`
-	// Name of the Secret resource holding the API user credentials.
-	SecretRef string `json:"secretRef"`
 	// Additional configuration of the target. This may be used by tasks outside
 	// the ODS catalog.
 	Config map[string]interface{} `json:"config"`
+	// APIToken holds the token of the environment, if any.
+	// The value is retrieved from the "token" field in the secret referenced by APICredentialsSecret.
+	// Cannot be set from JSON.
+	APIToken string `json:"-"`
 }
 
 func (o *ODS) Validate() error {

--- a/pkg/tasktesting/run.go
+++ b/pkg/tasktesting/run.go
@@ -34,7 +34,6 @@ type TestCase struct {
 	WantRunSuccess      bool
 	PreRunFunc          func(t *testing.T, ctxt *TaskRunContext)
 	PostRunFunc         func(t *testing.T, ctxt *TaskRunContext)
-	ExcludeOnShort      bool
 	Timeout             time.Duration
 }
 

--- a/pkg/tasktesting/run.go
+++ b/pkg/tasktesting/run.go
@@ -34,6 +34,8 @@ type TestCase struct {
 	WantRunSuccess      bool
 	PreRunFunc          func(t *testing.T, ctxt *TaskRunContext)
 	PostRunFunc         func(t *testing.T, ctxt *TaskRunContext)
+	ExcludeOnShort      bool
+	Timeout             time.Duration
 }
 
 type TaskRunContext struct {

--- a/test/tasks/common_test.go
+++ b/test/tasks/common_test.go
@@ -108,12 +108,18 @@ func runTaskTestCases(t *testing.T, taskName string, testCases map[string]taskte
 			if tc.TaskVariant != "" {
 				taskName = fmt.Sprintf("%s-%s", taskName, tc.TaskVariant)
 			}
+			if testing.Short() && tc.ExcludeOnShort {
+				t.Skip()
+			}
+			if tc.Timeout == 0 {
+				tc.Timeout = 5 * time.Minute
+			}
 			tasktesting.Run(t, tc, tasktesting.TestOpts{
 				TaskKindRef:             taskKindRef,
 				TaskName:                taskName,
 				Clients:                 c,
 				Namespace:               ns,
-				Timeout:                 5 * time.Minute, // depending on  the task we may need to increase or decrease it
+				Timeout:                 tc.Timeout,
 				AlwaysKeepTmpWorkspaces: *alwaysKeepTmpWorkspacesFlag,
 			})
 		})

--- a/test/tasks/common_test.go
+++ b/test/tasks/common_test.go
@@ -108,9 +108,6 @@ func runTaskTestCases(t *testing.T, taskName string, testCases map[string]taskte
 			if tc.TaskVariant != "" {
 				taskName = fmt.Sprintf("%s-%s", taskName, tc.TaskVariant)
 			}
-			if testing.Short() && tc.ExcludeOnShort {
-				t.Skip()
-			}
 			if tc.Timeout == 0 {
 				tc.Timeout = 5 * time.Minute
 			}

--- a/test/tasks/ods-deploy-helm_external_test.go
+++ b/test/tasks/ods-deploy-helm_external_test.go
@@ -1,0 +1,142 @@
+// +build external
+
+package tasks
+
+import (
+	"flag"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/opendevstack/pipeline/internal/command"
+	"github.com/opendevstack/pipeline/internal/kubernetes"
+	"github.com/opendevstack/pipeline/internal/projectpath"
+	"github.com/opendevstack/pipeline/internal/random"
+	"github.com/opendevstack/pipeline/pkg/artifact"
+	"github.com/opendevstack/pipeline/pkg/config"
+	"github.com/opendevstack/pipeline/pkg/pipelinectxt"
+	"github.com/opendevstack/pipeline/pkg/tasktesting"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// To test deployment to external cluster, you must provide the token for a
+// serviceaccount in an externa cluster, and a matching configuration like this:
+//
+// environments:
+// - name: dev
+//   stage: dev
+//   namespace: foobar
+//   apiServer: https://api.example.openshift.com:443
+//   registryHost: default-route-openshift-image-registry.apps.example.openshiftapps.com
+//
+// You do not need to specify "apiCredentialsSecret", it is set automatically to
+// the secret created from the token given via -external-cluster-token.
+//
+// The test will not create or delete any namespaces. It will install a Helm
+// release into the specified namespace, and delete the release again after the
+// test. The Helm release and related resources are prefixed with the temporary
+// workspace directory (e.g. "workspace-476709422") so any clashes even in none-
+// empty namespace are very unlikely. Nonetheless, it is always recommended to
+// use an empty namespace setup solely for the purpose of testing.
+var (
+	externalClusterTokenFlag  = flag.String("external-cluster-token", "", "Token of serviceaccount in external cluster")
+	externalClusterConfigFlag = flag.String("external-cluster-config", "", "ods.yaml describing external cluster")
+)
+
+func TestTaskODSDeployHelmExternal(t *testing.T) {
+	var externalEnv *config.Environment
+	var imageStream string
+	runTaskTestCases(t,
+		"ods-deploy-helm",
+		map[string]tasktesting.TestCase{
+			"external deployment": {
+				Timeout:             10 * time.Minute,
+				WorkspaceDirMapping: map[string]string{"source": "helm-sample-app"},
+				PreRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
+					wsDir := ctxt.Workspaces["source"]
+
+					if *externalClusterConfigFlag == "" || *externalClusterTokenFlag == "" {
+						t.Fatal(
+							"-external-cluster-token and -external-cluster-config are required to run this test. " +
+								"Use -short to skip this test.",
+						)
+					}
+
+					t.Log("Create token secret for external cluster")
+					secret, err := kubernetes.CreateSecret(ctxt.Clients.KubernetesClientSet, ctxt.Namespace, &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: "ext"},
+						Data: map[string][]byte{
+							"token": []byte(*externalClusterTokenFlag),
+						},
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					t.Log("Create private key secret for sample app")
+					createSampleAppPrivateKeySecret(t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace)
+
+					t.Log("Read ods.yaml from flag and write into working dir")
+					externalClusterConfig := *externalClusterConfigFlag
+					if !filepath.IsAbs(externalClusterConfig) {
+						externalClusterConfig = filepath.Join(projectpath.Root, externalClusterConfig)
+					}
+					o, err := config.ReadFromFile(externalClusterConfig)
+					if err != nil {
+						t.Fatal(err)
+					}
+					externalEnv := o.Environments[0]
+					externalEnv.APICredentialsSecret = secret.Name
+					externalEnv.APIToken = *externalClusterTokenFlag
+					o.Environments[0] = externalEnv
+					err = createODSYML(wsDir, o)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					imageStream = random.PseudoString()
+					tag := "latest"
+					fullTag := fmt.Sprintf("localhost:5000/%s/%s:%s", ctxt.Namespace, imageStream, tag)
+					buildAndPushImageWithLabel(t, ctxt, fullTag, wsDir)
+					ia := artifact.Image{
+						Image:      fmt.Sprintf("kind-registry.kind:5000/%s/%s:%s", ctxt.Namespace, imageStream, tag),
+						Registry:   "kind-registry.kind:5000",
+						Repository: ctxt.Namespace,
+						Name:       imageStream,
+						Tag:        tag,
+						Digest:     "abc",
+					}
+					imageArtifactFilename := fmt.Sprintf("%s.json", imageStream)
+					err = pipelinectxt.WriteJsonArtifact(ia, filepath.Join(wsDir, pipelinectxt.ImageDigestsPath), imageArtifactFilename)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					ctxt.ODS = tasktesting.SetupGitRepo(t, ctxt.Namespace, wsDir)
+				},
+				WantRunSuccess: true,
+				PostRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
+					t.Log("Check image")
+					_, _, err := command.Run("skopeo", []string{
+						"inspect",
+						fmt.Sprintf("--registry-token=%s", externalEnv.APIToken),
+						fmt.Sprintf("docker://%s/%s/%s:%s", externalEnv.RegistryHost, ctxt.Namespace, imageStream, "latest"),
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					t.Log("Remove Helm release again")
+					command.Run("helm", []string{
+						fmt.Sprintf("--kube-apiserver=%s", externalEnv.APIServer),
+						fmt.Sprintf("--kube-token=%s", externalEnv.APIToken),
+						fmt.Sprintf("--namespace=%s", externalEnv.Namespace),
+						"uninstall",
+						ctxt.ODS.Component,
+					})
+				},
+			},
+		},
+	)
+}

--- a/test/tasks/ods-deploy-helm_test.go
+++ b/test/tasks/ods-deploy-helm_test.go
@@ -58,14 +58,7 @@ func TestTaskODSDeployHelm(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					secret, err := readPrivateKeySecret()
-					if err != nil {
-						t.Fatal(err)
-					}
-					_, err = kubernetes.CreateSecret(ctxt.Clients.KubernetesClientSet, ctxt.Namespace, secret)
-					if err != nil {
-						t.Fatal(err)
-					}
+					createSampleAppPrivateKeySecret(t, ctxt.Clients.KubernetesClientSet, ctxt.Namespace)
 				},
 				WantRunSuccess: true,
 				PostRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
@@ -117,6 +110,17 @@ func TestTaskODSDeployHelm(t *testing.T) {
 			},
 		},
 	)
+}
+
+func createSampleAppPrivateKeySecret(t *testing.T, clientset *k8s.Clientset, ctxtNamespace string) {
+	secret, err := readPrivateKeySecret()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = kubernetes.CreateSecret(clientset, ctxtNamespace, secret)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func createReleaseNamespace(clientset *k8s.Clientset, ctxtNamespace string) (string, error) {

--- a/test/tasks/ods-package-image_test.go
+++ b/test/tasks/ods-package-image_test.go
@@ -33,7 +33,8 @@ func TestTaskODSPackageImage(t *testing.T) {
 				PreRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
 					wsDir := ctxt.Workspaces["source"]
 					ctxt.ODS = tasktesting.SetupGitRepo(t, ctxt.Namespace, wsDir)
-					buildAndPushImageWithLabel(t, ctxt, wsDir)
+					tag := getDockerImageTag(t, ctxt, wsDir)
+					buildAndPushImageWithLabel(t, ctxt, tag, wsDir)
 				},
 				WantRunSuccess: true,
 				PostRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
@@ -52,8 +53,7 @@ func TestTaskODSPackageImage(t *testing.T) {
 // will pick up the existing image.
 // The image is labelled with "tasktestrun=true" so that it is possible to
 // verify that the image has not been rebuild in the task.
-func buildAndPushImageWithLabel(t *testing.T, ctxt *tasktesting.TaskRunContext, wsDir string) {
-	tag := getDockerImageTag(t, ctxt, wsDir)
+func buildAndPushImageWithLabel(t *testing.T, ctxt *tasktesting.TaskRunContext, tag, wsDir string) {
 	t.Logf("Build image %s ahead of taskrun", tag)
 	_, stderr, err := command.Run("docker", []string{
 		"build", "--label", "tasktestrun=true", "-t", tag, filepath.Join(wsDir, "docker"),

--- a/test/testdata/workspaces/helm-app-with-dependencies/.ods/repos/database/chart/templates/deployment.yaml
+++ b/test/testdata/workspaces/helm-app-with-dependencies/.ods/repos/database/chart/templates/deployment.yaml
@@ -19,8 +19,6 @@ spec:
           securityContext: {}
           image: "{{.Values.image.registry}}/{{.Values.image.namespace | default .Release.Namespace}}/{{.Values.image.repository | default .Chart.Name}}:{{.Values.image.tag | default .Chart.AppVersion}}"
           imagePullPolicy: {{.Values.image.pullPolicy}}
-          command: ["/bin/sh"]
-          args: ["-c", "{{.Values.bootCommand}}"]
           ports:
             - name: http
               containerPort: 8080

--- a/test/testdata/workspaces/helm-app-with-dependencies/.ods/repos/database/chart/values.yaml
+++ b/test/testdata/workspaces/helm-app-with-dependencies/.ods/repos/database/chart/values.yaml
@@ -7,17 +7,15 @@ replicaCount: 1
 image:
   registry: index.docker.io
   # Overrides the image namespace whose default is the release namespace.
-  namespace: library
+  namespace: crccheck
   # Overrides the image repository whose default is the chart name.
-  repository: busybox
+  repository: hello-world
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 
 nameOverride: ""
 fullnameOverride: ""
-
-bootCommand: "echo 'Hello' > /var/www/index.html && httpd -f -p 8080 -h /var/www/"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/test/testdata/workspaces/helm-app-with-dependencies/chart/values.yaml
+++ b/test/testdata/workspaces/helm-app-with-dependencies/chart/values.yaml
@@ -7,12 +7,12 @@ replicaCount: 1
 image:
   registry: index.docker.io
   # Overrides the image namespace whose default is the release namespace.
-  namespace: library
+  namespace: crccheck
   # Overrides the image repository whose default is the chart name.
-  repository: nginx
+  repository: hello-world
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.21-alpine"
+  tag: "latest"
 
 nameOverride: ""
 fullnameOverride: ""

--- a/test/testdata/workspaces/helm-sample-app/chart/values.yaml
+++ b/test/testdata/workspaces/helm-sample-app/chart/values.yaml
@@ -7,12 +7,12 @@ replicaCount: 1
 image:
   registry: index.docker.io
   # Overrides the image namespace whose default is the release namespace.
-  namespace: library
+  namespace: crccheck
   # Overrides the image repository whose default is the chart name.
-  repository: nginx
+  repository: hello-world
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.21-alpine"
+  tag: "latest"
 
 nameOverride: ""
 fullnameOverride: ""

--- a/test/testdata/workspaces/helm-sample-app/docker/Dockerfile
+++ b/test/testdata/workspaces/helm-sample-app/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM busybox
+
+COPY message.txt message.txt
+
+CMD [ "cat", "message.txt" ]

--- a/test/testdata/workspaces/helm-sample-app/docker/message.txt
+++ b/test/testdata/workspaces/helm-sample-app/docker/message.txt
@@ -1,0 +1,1 @@
+Hello World


### PR DESCRIPTION
Closes #63.

During testing I also found out that #83 is not actually needed. When using `skopeo copy`, it just works as expected 🎉 

Also, this closes #100 as I needed to change the images used to work In OpenShift 😄 

This replaces #207 and #218.