### PR TITLE
fixed link in repository layout doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Fixed link in Repository Layout Docs ([233](https://github.com/opendevstack/ods-pipeline/pull/233))
-
 ## [0.1.0] - 2021-10-05
 
 Initial version.


### PR DESCRIPTION
The repository layout docs were using Markdown instead of AsciiDoc syntax to display the link to the `Standard Go Project Layout`.
The link is now displayed correctly.

Tasks: 
- [x] Updated design documents in `docs/design` directory (if required)
- [x] Updated user-facing documentation in `docs` directory (if required)
- [x] Ran tests (e.g. `make test`)
- [x] Updated changelog
