### PR TITLE
Fix base image of ods-gradle-toolset build config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Note that changes which ONLY affect documentation or the testsuite will not be
 listed in the changelog.
 
 ## [Unreleased]
+### Fixed
+
+- Incorrect ods-gradle-toolset base image in BuildConfig ([#250](https://github.com/opendevstack/ods-pipeline/issues/250))
 
 ## [0.1.0] - 2021-10-05
 

--- a/deploy/central/images-chart/templates/bc-ods-gradle-toolset.yaml
+++ b/deploy/central/images-chart/templates/bc-ods-gradle-toolset.yaml
@@ -17,7 +17,7 @@ spec:
       dockerfilePath: build/package/Dockerfile.gradle-toolset
       from:
         kind: DockerImage
-        name: 'registry.redhat.io/ubi8:8.4'
+        name: 'registry.redhat.io/ubi8/openjdk-11:1.10'
       pullSecret:
         name: registry.redhat.io
   postCommit: {}


### PR DESCRIPTION
The Dockerfile uses `registry.access.redhat.com/ubi8/openjdk-11:1.10` as
base image, and the `BuildConfig` should use the same image, provided
through `registry.redhat.io`.

Fixes #250.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
