### PR TITLE
Avoid uploading artifacts again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ listed in the changelog.
 - Generating a SonarQube report fails when PR exists for scanned branch ([#227](https://github.com/opendevstack/ods-pipeline/issues/227))
 - Generating a SonarQube report fails when background task does not finish immediately ([#227](https://github.com/opendevstack/ods-pipeline/issues/227))
 - Quality Gate check fails due to incorrect API authentication (detected while working on #227)
+- Uploading of artifacts in `ods-finish` may fail when artifact is already present from previous pipeline run ([#255](https://github.com/opendevstack/ods-pipeline/issues/255))
 
 ## [0.1.0] - 2021-10-05
 

--- a/pkg/nexus/client.go
+++ b/pkg/nexus/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/opendevstack/pipeline/pkg/logging"
+	"github.com/opendevstack/pipeline/pkg/pipelinectxt"
 	nexusrm "github.com/sonatype-nexus-community/gonexus/rm"
 )
 
@@ -75,6 +76,18 @@ func (c *Client) URL() string {
 // Username returns the username used by this client.
 func (c *Client) Username() string {
 	return c.clientConfig.Username
+}
+
+// ArtifactGroupBase returns the group base in which aritfacts are stored for
+// the given ODS pipeline context.
+func ArtifactGroupBase(ctxt *pipelinectxt.ODSContext) string {
+	return fmt.Sprintf("/%s/%s/%s", ctxt.Project, ctxt.Repository, ctxt.GitCommitSHA)
+}
+
+// ArtifactGroup returns the group in which aritfacts are stored for the given
+// ODS pipeline context and the subdir.
+func ArtifactGroup(ctxt *pipelinectxt.ODSContext, subdir string) string {
+	return ArtifactGroupBase(ctxt) + "/" + subdir
 }
 
 func (c *Client) logger() logging.LeveledLoggerInterface {

--- a/scripts/nexus/createRepos.json
+++ b/scripts/nexus/createRepos.json
@@ -20,8 +20,8 @@
   repository.createPyPiHosted('pypi-private', 'pypi-private', true, WritePolicy.ALLOW_ONCE);
   repository.createPyPiGroup('pypi-all', ['pypi-registry', 'pypi-private'], 'default');
   repository.createRawHosted('leva-documentation', 'leva-documentation', false, WritePolicy.ALLOW);
-  repository.createRawHosted('ods-temporary-artifacts', 'ods-temporary-artifacts', false, WritePolicy.ALLOW);
-  repository.createRawHosted('ods-permanent-artifacts', 'ods-permanent-artifacts', false, WritePolicy.ALLOW);
+  repository.createRawHosted('ods-temporary-artifacts', 'ods-temporary-artifacts', false, WritePolicy.ALLOW_ONCE);
+  repository.createRawHosted('ods-permanent-artifacts', 'ods-permanent-artifacts', false, WritePolicy.ALLOW_ONCE);
   repositoryManager = repository.repositoryManager;
   repository = repositoryManager.get('maven-public');
   config = repository.configuration.copy();

--- a/test/tasks/common_test.go
+++ b/test/tasks/common_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -50,6 +51,12 @@ func checkFileContent(t *testing.T, wsDir, filename, want string) {
 	}
 	if got != want {
 		t.Fatalf("got '%s', want '%s' in file %s", got, want, filename)
+	}
+}
+
+func checkFileExists(t *testing.T, filename string) {
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		t.Fatal(err)
 	}
 }
 

--- a/test/testdata/workspaces/hello-world-app-with-artifacts/.ods/artifacts/manifest.json
+++ b/test/testdata/workspaces/hello-world-app-with-artifacts/.ods/artifacts/manifest.json
@@ -1,0 +1,4 @@
+{
+    "sourceRepository": "ods-temporary-artifacts",
+    "artifacts": []
+}


### PR DESCRIPTION
If the WritePolicy is set to ALLOW_ONCE (which it should be) then
uploading the same asset errors. To avoid this, we maintain a manifest
of downloaded assets and only upload artifacts which are not present in
Nexus yet.

Fixes #255.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
