### PR TITLE
Hide confusing error message in Helm output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ listed in the changelog.
 ### Changed
 
 - Automatically roll webhook interceptor deployment when related config map or secret changes ([#252](https://github.com/opendevstack/ods-pipeline/issues/252))
+- Hide confusing error message in Helm output ([#262](https://github.com/opendevstack/ods-pipeline/issues/262))
 
 ## [0.1.1] - 2021-10-28
 ### Fixed

--- a/test/tasks/ods-deploy-helm_test.go
+++ b/test/tasks/ods-deploy-helm_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/opendevstack/pipeline/internal/kubernetes"
@@ -90,6 +91,16 @@ func TestTaskODSDeployHelm(t *testing.T) {
 					_, err = checkDeployment(ctxt.Clients.KubernetesClientSet, separateReleaseNamespace, resourceName)
 					if err != nil {
 						t.Fatal(err)
+					}
+
+					// Verify log output massaging
+					doNotWantLogMsg := "/usr/local/helm/plugins/helm-secrets/scripts/commands/helm.sh: line 34: xargs: command not found"
+					if strings.Contains(string(ctxt.CollectedLogs), doNotWantLogMsg) {
+						t.Fatalf("Do not want:\n%s\n\nGot:\n%s", doNotWantLogMsg, string(ctxt.CollectedLogs))
+					}
+					wantLogMsg := "plugin \"diff\" identified at least one change"
+					if !strings.Contains(string(ctxt.CollectedLogs), wantLogMsg) {
+						t.Fatalf("Want:\n%s\n\nGot:\n%s", wantLogMsg, string(ctxt.CollectedLogs))
 					}
 				},
 			},


### PR DESCRIPTION
Closes #262.

Changes the following:
```
+   selector:
+     app.kubernetes.io/name: helm-sample-database
+     app.kubernetes.io/instance: workspace-660240491

[helm-secrets] Decrypt: ./chart/secrets.yaml
Error: identified at least one change, exiting with non-zero exit code (detailed-exitcode parameter enabled)
Error: plugin "diff" exited with error

/usr/local/helm/plugins/helm-secrets/scripts/commands/helm.sh: line 34: xargs: command not found
Error: plugin "secrets" exited with error

Upgrading Helm release to helm-app-with-dependencies-0.1.0+f82c84f08dcd7b6ae20449b329b4da19945052d9.tgz...
```

to:

```
+   selector:
+     app.kubernetes.io/name: helm-sample-database
+     app.kubernetes.io/instance: workspace-660240491

plugin "diff" identified at least one change

Upgrading Helm release to helm-app-with-dependencies-0.1.0+f82c84f08dcd7b6ae20449b329b4da19945052d9.tgz...
```


Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
