### PR TITLE
Artifact download binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 test/testdata/workspaces/workspace-*
 ods.external.yaml
+/artifact-download

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Note that changes which ONLY affect documentation or the testsuite will not be
 listed in the changelog.
 
 ## [Unreleased]
+### Added
+
+- Provide separate binary to download all artifacts related to one version easily ([#167](https://github.com/opendevstack/ods-pipeline/issues/167))
+
 ### Changed
 
 - Automatically roll webhook interceptor deployment when related config map or secret changes ([#252](https://github.com/opendevstack/ods-pipeline/issues/252))

--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,11 @@ clear-tmp-workspaces:
 	rm -rf test/testdata/workspaces/workspace-*
 .PHONY: clear-tmp-workspaces
 
+## Build artifact-download binary.
+build-artifact-download:
+	cd cmd/artifact-download && CGO_ENABLED=0 go build -o ../../artifact-download
+.PHONY: build-artifact-download
+
 ### HELP
 ### Based on https://gist.github.com/prwhite/8168133#gistcomment-2278355.
 help:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The documentation provided by ODS pipeline has three audiences:
 * [ODS.YAML Reference](/docs/ods-configuration.adoc)
 * [Task Reference](/docs/tasks)
 * [Working with secrets in Helm](/docs/helm-secrets.adoc)
+* [Accessing artifacts](/docs/accessing-artifacts.adoc)
 * [Debugging](/docs/debugging.adoc)
 * [Authoring Tasks](/docs/authoring-tasks.adoc)
 * [Example Project](/docs/example-project.adoc)

--- a/cmd/artifact-download/main.go
+++ b/cmd/artifact-download/main.go
@@ -1,0 +1,308 @@
+// Package main provides a programm to download all artifacts related to a
+// version easily. The artifacts are expected to be in Nexus repositories,
+// and placed into the local filesystem. The program not only considers the
+// given repository but also any configured subrepositories.
+//
+// There are two main modes of the program:
+// (1) users supply (OpenShift) namespace, (Bitbucket) project, (Git) repository
+//     and a tag such as "v1.0.0".
+// (2) users run this program from the root of a Git repository and only supply
+//     (OpenShift) namespace and tag=WIP. In this case the latest artifacts are
+//     downloaded.
+// Mode (1) is the main use case, mode (2) is provided as a convenience feature
+// for developers.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/opendevstack/pipeline/internal/installation"
+	"github.com/opendevstack/pipeline/internal/repository"
+	"github.com/opendevstack/pipeline/pkg/bitbucket"
+	"github.com/opendevstack/pipeline/pkg/config"
+	"github.com/opendevstack/pipeline/pkg/logging"
+	"github.com/opendevstack/pipeline/pkg/nexus"
+	"github.com/opendevstack/pipeline/pkg/pipelinectxt"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// options configures the program.
+// The struct is filled from the flags this program handles.
+type options struct {
+	kubeconfig      string
+	namespace       string
+	project         string
+	repository      string
+	version         bool
+	tag             string
+	outputDirectory string
+	debug           bool
+}
+
+// bitbucketArtifactClientInterface is a helper interface that contains the
+// methods this program uses on the Bitbucket client. The interface is used
+// in testing to mock a Bitbucket client.
+type bitbucketArtifactClientInterface interface {
+	bitbucket.BranchClientInterface
+	bitbucket.TagClientInterface
+	bitbucket.RawClientInterface
+}
+
+func main() {
+	workingDir := "."
+
+	kcDefault, err := kubeconfigDefault()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	opts := options{}
+	flag.StringVar(&opts.kubeconfig, "kubeconfig", kcDefault, "Path to kube config file")
+	flag.StringVar(&opts.namespace, "namespace", "", "Namespace of ods-pipeline user installation (required)")
+	flag.StringVar(&opts.project, "project", "", "Bitbucket project key of repository")
+	flag.StringVar(&opts.repository, "repository", "", "Bitbucket repository key")
+	flag.StringVar(&opts.tag, "tag", "", "Git tag to retrieve artifacts for, e.g. v1.0.0 (required)")
+	flag.StringVar(&opts.outputDirectory, "output", "artifacts-out", "Directory to place outputs into")
+	flag.BoolVar(&opts.debug, "debug", (os.Getenv("DEBUG") == "true"), "Enable debug mode")
+	flag.BoolVar(&opts.version, "version", false, "Display version of binary")
+	flag.Parse()
+
+	if opts.version {
+		fmt.Println("0.1.1")
+		os.Exit(0)
+	}
+
+	var logger logging.LeveledLoggerInterface
+	if opts.debug {
+		logger = &logging.LeveledLogger{Level: logging.LevelDebug}
+	} else {
+		logger = &logging.LeveledLogger{Level: logging.LevelInfo}
+	}
+
+	// Validate flags
+	if opts.kubeconfig == "" {
+		logUsageAndExit("-kubeconfig is required")
+	}
+	if opts.namespace == "" {
+		logUsageAndExit("-namespace is required")
+	}
+	if opts.tag == "" {
+		logUsageAndExit("-tag is required")
+	}
+	if opts.tag != pipelinectxt.WIP {
+		if opts.project == "" {
+			logUsageAndExit("-project is required when version is not WIP")
+		}
+		if opts.repository == "" {
+			logUsageAndExit("-repository is required when version is not WIP")
+		}
+	}
+
+	// Kubernetes client
+	c, err := newKubernetesClientset(opts.kubeconfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Nexus client
+	ncc, err := installation.NewNexusClientConfig(c, opts.namespace, logger)
+	if err != nil {
+		log.Fatalf("Could not create Nexus client config: %s. Are you logged into the cluster?", err)
+	}
+	nexusClient, err := nexus.NewClient(ncc)
+	if err != nil {
+		log.Fatal(err)
+	}
+	nr, err := installation.GetNexusRepositories(c, opts.namespace)
+	if err != nil {
+		log.Fatalf("Could not get Nexus repositories: %s. Are you logged into the cluster?", err)
+	}
+
+	// Bitbucket client
+	bcc, err := installation.NewBitbucketClientConfig(c, opts.namespace, logger)
+	if err != nil {
+		log.Fatalf("Could not create Bitbucket client config: %s. Are you logged into the cluster?", err)
+	}
+	bitbucketClient := bitbucket.NewClient(bcc)
+
+	err = run(logger, opts, nexusClient, nr, bitbucketClient, workingDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// run is the actual main method.
+func run(
+	logger logging.LeveledLoggerInterface,
+	opts options,
+	nexusClient nexus.ClientInterface,
+	nr *installation.NexusRepositories,
+	bitbucketClient bitbucketArtifactClientInterface,
+	workingDir string) error {
+	// Context
+	ctxt, err := getODSContext(opts, bitbucketClient, workingDir)
+	if err != nil {
+		return err
+	}
+
+	err = downloadArtifacts(logger, opts, ctxt, nexusClient, nr)
+	if err != nil {
+		return err
+	}
+
+	// Read ods.yaml file to detect any subrepositories.
+	odsConfig, err := getODSConfig(opts, bitbucketClient, workingDir)
+	if err != nil {
+		return err
+	}
+
+	if len(odsConfig.Repositories) > 0 {
+		for _, subrepo := range odsConfig.Repositories {
+			subrepoCtxt, err := getSubrepoODSContext(ctxt, subrepo, opts, bitbucketClient)
+			if err != nil {
+				return err
+			}
+			err = downloadArtifacts(logger, opts, subrepoCtxt, nexusClient, nr)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// kubeconfigDefault returns the default location of the Kubernetes config file.
+func kubeconfigDefault() (string, error) {
+	var kubeconfigDefault string
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	if homeDir != "" {
+		kubeconfigDefault = filepath.Join(homeDir, ".kube", "config")
+	}
+	return kubeconfigDefault, nil
+}
+
+// newKubernetesClientset creates a new Kubernetes clientset from given
+// kubeconfig.
+func newKubernetesClientset(kubeconfig string) (*kubernetes.Clientset, error) {
+	// use the current context in kubeconfig
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("could not build config: %w", err)
+	}
+
+	// create the Kubernetes clientset
+	kubernetesClientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("could not create client for config: %w", err)
+	}
+
+	return kubernetesClientset, nil
+}
+
+// downloadArtifacts downloads the artifact group related to given ODS context.
+func downloadArtifacts(
+	logger logging.LeveledLoggerInterface,
+	opts options,
+	ctxt *pipelinectxt.ODSContext,
+	nexusClient nexus.ClientInterface,
+	nr *installation.NexusRepositories) error {
+	artifactsDir := filepath.Join(opts.outputDirectory, opts.tag, ctxt.Repository)
+	if _, err := os.Stat(artifactsDir); err == nil {
+		return fmt.Errorf("output directory %s already exists", artifactsDir)
+	}
+	group := pipelinectxt.ArtifactGroupBase(ctxt)
+	_, err := pipelinectxt.DownloadGroup(
+		nexusClient, []string{nr.Permanent, nr.Temporary}, group, artifactsDir, logger,
+	)
+	return err
+}
+
+// getODSContext assembles an ODS context from given options. If the version is WIP,
+// the information is gathered from the Git repository in working directory.
+// If the version is not WIP, the information is retrieved from given options
+// and the Bitbucket repository.
+func getODSContext(opts options, bitbucketClient bitbucket.TagClientInterface, workingDir string) (*pipelinectxt.ODSContext, error) {
+	ctxt := &pipelinectxt.ODSContext{
+		Namespace: opts.namespace,
+	}
+
+	if opts.tag == pipelinectxt.WIP {
+		err := ctxt.Assemble(workingDir)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		ctxt.Project = opts.project
+		ctxt.Repository = opts.repository
+		tag, err := bitbucketClient.TagGet(ctxt.Project, ctxt.Repository, opts.tag)
+		if err != nil {
+			return nil, err
+		}
+		ctxt.GitCommitSHA = tag.LatestCommit
+	}
+	return ctxt, nil
+}
+
+// getODSConfig reads an ods.y(a)ml file, either from the current directory (if
+// tag=WIP) or the remote Bitbucket project identified in the options.
+func getODSConfig(opts options, bitbucketClient bitbucket.RawClientInterface, workingDir string) (*config.ODS, error) {
+	if opts.tag == pipelinectxt.WIP {
+		return config.ReadFromDir(workingDir)
+	}
+	return repository.GetODSConfig(
+		bitbucketClient,
+		opts.project,
+		opts.repository,
+		opts.tag,
+	)
+}
+
+// getSubrepoODSContext returns an ODS context for the given subrepo.
+// The ODS context points to a Git commit, which is either retrieved from the
+// best matching branch (if tag=WIP) or the Git tag identified by options.tag.
+func getSubrepoODSContext(
+	ctxt *pipelinectxt.ODSContext,
+	subrepo config.Repository,
+	opts options,
+	bitbucketClient bitbucketArtifactClientInterface) (*pipelinectxt.ODSContext, error) {
+	subrepoCtxt := ctxt.Copy()
+	subrepoCtxt.Repository = subrepo.Name
+	// For WIP versions, select the best matching branches of subrepositories,
+	// and retrieve the latest commit from those branches.
+	if opts.tag == pipelinectxt.WIP {
+		br, err := repository.BestMatchingBranch(bitbucketClient, subrepoCtxt.Project, subrepo, pipelinectxt.WIP)
+		if err != nil {
+			return nil, err
+		}
+		latestCommit, err := repository.LatestCommitForBranch(bitbucketClient, subrepoCtxt.Project, subrepo.Name, br)
+		if err != nil {
+			return nil, err
+		}
+		subrepoCtxt.GitCommitSHA = latestCommit
+	} else {
+		// For non-WIP versions, retrieve the latest commit from given tag.
+		tag, err := bitbucketClient.TagGet(subrepoCtxt.Project, subrepoCtxt.Repository, opts.tag)
+		if err != nil {
+			return nil, err
+		}
+		subrepoCtxt.GitCommitSHA = tag.LatestCommit
+	}
+	return subrepoCtxt, nil
+}
+
+// logUsageAndExit prints given message followed by flag usage, then exits with exit code 2.
+func logUsageAndExit(msg string) {
+	log.Println(msg)
+	log.Println("Usage:")
+	flag.PrintDefaults()
+	os.Exit(2)
+}

--- a/cmd/artifact-download/main_test.go
+++ b/cmd/artifact-download/main_test.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/opendevstack/pipeline/internal/gittest"
+	"github.com/opendevstack/pipeline/internal/installation"
+	"github.com/opendevstack/pipeline/pkg/bitbucket"
+	"github.com/opendevstack/pipeline/pkg/config"
+	"github.com/opendevstack/pipeline/pkg/logging"
+	"github.com/opendevstack/pipeline/pkg/nexus"
+	"github.com/opendevstack/pipeline/pkg/pipelinectxt"
+)
+
+func TestGetODSContextFromDir(t *testing.T) {
+	sha := "7f96ec9fcf097e5b21687d402bc70370ac247d8a"
+	dir, cleanup, err := gittest.CreateFakeGitRepoDir(
+		"https://example.bitbucket.com/scm/ODS/ods-pipeline.git",
+		"master",
+		sha,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	opts := options{
+		namespace: "foo-cd",
+		tag:       pipelinectxt.WIP, // for WIP version, ODS context is from dir
+	}
+	// As context is read from dir, no Bitbucket client should be required.
+	ctxt, err := getODSContext(opts, nil, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantContext := &pipelinectxt.ODSContext{
+		Namespace:       "foo-cd",
+		Project:         "ods",
+		Repository:      "ods-pipeline",
+		Component:       "pipeline",
+		GitCommitSHA:    sha,
+		GitFullRef:      "refs/heads/master",
+		GitRef:          "master",
+		GitURL:          "https://example.bitbucket.com/scm/ODS/ods-pipeline.git",
+		Version:         "WIP",
+		Environment:     "",
+		PullRequestBase: "",
+		PullRequestKey:  "",
+	}
+	if diff := cmp.Diff(wantContext, ctxt); diff != "" {
+		t.Fatalf("context mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGetODSContextFromBitbucketRepo(t *testing.T) {
+	sha := "7f96ec9fcf097e5b21687d402bc70370ac247d8a"
+	opts := options{
+		namespace:  "foo-cd",
+		project:    "foo",
+		repository: "bar",
+		tag:        "v1.0.0",
+	}
+
+	bitbucketClient := &bitbucket.TestClient{
+		Tags: []bitbucket.Tag{
+			{
+				DisplayID:    "v1.0.0",
+				LatestCommit: sha,
+			},
+		},
+	}
+	// As context is read from fake Bitbucket, dir value is unused.
+	ctxt, err := getODSContext(opts, bitbucketClient, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantContext := &pipelinectxt.ODSContext{
+		Namespace:    "foo-cd",
+		Project:      "foo",
+		Repository:   "bar",
+		GitCommitSHA: sha,
+	}
+	if diff := cmp.Diff(wantContext, ctxt); diff != "" {
+		t.Fatalf("context mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGetSubrepoODSContext(t *testing.T) {
+	ctxt := &pipelinectxt.ODSContext{
+		Namespace:    "foo-cd",
+		Project:      "foo",
+		Repository:   "bar",
+		GitCommitSHA: "7f96ec9fcf097e5b21687d402bc70370ac247d8a",
+	}
+
+	tests := map[string]struct {
+		opts     options
+		subrepo  config.Repository
+		branches []bitbucket.Branch
+		tags     []bitbucket.Tag
+		wantCtxt *pipelinectxt.ODSContext
+	}{
+		"tag given": {
+			opts: options{
+				namespace:  "foo-cd",
+				project:    "foo",
+				repository: "bar",
+				tag:        "v1.0.0",
+			},
+			subrepo: config.Repository{Name: "baz"},
+			tags: []bitbucket.Tag{
+				{
+					DisplayID:    "v1.0.0",
+					LatestCommit: "f31532481bf29dffe02367f050f4a3f4dd7845ed",
+				},
+			},
+			wantCtxt: &pipelinectxt.ODSContext{
+				Namespace:    "foo-cd",
+				Project:      "foo",
+				Repository:   "baz",
+				GitCommitSHA: "f31532481bf29dffe02367f050f4a3f4dd7845ed",
+			},
+		},
+		"WIP given and no configured branch": {
+			opts: options{
+				namespace:  "foo-cd",
+				project:    "foo",
+				repository: "bar",
+				tag:        pipelinectxt.WIP,
+			},
+			subrepo: config.Repository{Name: "baz"},
+			branches: []bitbucket.Branch{
+				{
+					ID:           "refs/heads/master",
+					LatestCommit: "af31532481bf29dffe02367f050f4a3f4dd7845ed",
+				},
+			},
+			wantCtxt: &pipelinectxt.ODSContext{
+				Namespace:    "foo-cd",
+				Project:      "foo",
+				Repository:   "baz",
+				GitCommitSHA: "af31532481bf29dffe02367f050f4a3f4dd7845ed",
+			},
+		},
+		"WIP given and configured branch": {
+			opts: options{
+				namespace:  "foo-cd",
+				project:    "foo",
+				repository: "bar",
+				tag:        pipelinectxt.WIP,
+			},
+			subrepo: config.Repository{Name: "baz", Branch: "production"},
+			branches: []bitbucket.Branch{
+				{
+					ID:           "refs/heads/master",
+					LatestCommit: "af31532481bf29dffe02367f050f4a3f4dd7845ed",
+				},
+				{
+					ID:           "refs/heads/production",
+					LatestCommit: "bf31532481bf29dffe02367f050f4a3f4dd7845ed",
+				},
+			},
+			wantCtxt: &pipelinectxt.ODSContext{
+				Namespace:    "foo-cd",
+				Project:      "foo",
+				Repository:   "baz",
+				GitCommitSHA: "bf31532481bf29dffe02367f050f4a3f4dd7845ed",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			bitbucketClient := &bitbucket.TestClient{
+				Branches: tc.branches,
+				Tags:     tc.tags,
+			}
+			got, err := getSubrepoODSContext(ctxt, tc.subrepo, tc.opts, bitbucketClient)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.wantCtxt, got); diff != "" {
+				t.Fatalf("context mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRun(t *testing.T) {
+	logger := &logging.LeveledLogger{Level: logging.LevelDebug}
+	project := "foo"
+	repository := "bar"
+	tag := "v1.0.0"
+	commitSHA := "f31532481bf29dffe02367f050f4a3f4dd7845ed"
+	artifactType := "deployment"
+	artifactName := "diff-dev.txt"
+
+	// Bitbucket client with corresponding Git tag and empty ods.yaml.
+	bitbucketClient := &bitbucket.TestClient{
+		Tags: []bitbucket.Tag{
+			{
+				DisplayID:    tag,
+				LatestCommit: commitSHA,
+			},
+		},
+		Files: map[string][]byte{
+			"ods.yaml": []byte("repositories: []"),
+		},
+	}
+
+	// Nexus client with corresponding artifact asset.
+	nexusClient := &nexus.TestClient{
+		URLs: map[string][]string{
+			nexus.PermanentRepositoryDefault: {
+				fmt.Sprintf(
+					"https://nexus.example.com/%s%s/%s",
+					nexus.PermanentRepositoryDefault,
+					nexus.ArtifactGroup(project, repository, commitSHA, artifactType),
+					artifactName,
+				),
+			},
+		},
+	}
+
+	// Temporary output directory.
+	artifactsDir, err := ioutil.TempDir(".", "test-artifacts-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(artifactsDir)
+
+	// Program options.
+	opts := options{
+		namespace:       "foo-cd",
+		project:         project,
+		repository:      repository,
+		tag:             tag,
+		outputDirectory: artifactsDir,
+	}
+
+	// Run main function and check for error / downloaded file.
+	err = run(
+		logger,
+		opts,
+		nexusClient,
+		&installation.NexusRepositories{
+			Permanent: nexus.PermanentRepositoryDefault,
+			Temporary: nexus.TemporaryRepositoryDefault,
+		},
+		bitbucketClient,
+		".",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantOutfile := filepath.Join(artifactsDir, tag, repository, artifactType, artifactName)
+	if _, err := os.Stat(wantOutfile); os.IsNotExist(err) {
+		t.Fatalf("expected artifact downloaded to %s, got none", wantOutfile)
+	}
+}

--- a/docs/accessing-artifacts.adoc
+++ b/docs/accessing-artifacts.adoc
@@ -1,0 +1,52 @@
+= Accessing artifacts
+
+ODS Pipeline creates and retains artifacts recording information related to a pipeline run. Those artifacts can be test reports, scan results, image digests, deployment records, etc. They are created during a pipeline run, associated with the commit being built and stored in Nexus. This document will describe how you can access the artifacts later on. A typical use case for this is attaching artifacts to verification reports for your (medical device) software.
+
+== Artifact Storage
+
+Artifacts are stored in Nexus. Nexus is setup with two `raw` repositories, one for temporary storage (named `ods-temporary-artifacts` by default), and one for permanent storage (named `ods-permanent-artifacts` by default). When a pipeline runs, the selected target environment determines where artifacts are stored:
+
+* temporary: no environment or environment of stage `dev`
+* permanent: environment of stage `qa` or `prod`
+
+The permanent repository should have no cleanup policy or one that matches the overall retention policy required by the software product you are building. In contrast, the temporary repository might have a cleanup policy that is much shorter (however cleanup is neither enforced nor expected by ODS pipeline).
+
+== Downloading Artifacts
+
+While artifacts are plain Nexus assets and can therefore be downloaded via standard means (e.g. via `curl` or in the Nexus web interface), this would be very time consuming when there are many artifacts. To make it fast and easy to download all artifacts related to a certain version in one go, ODS pipelines ships with the `artifact-download` binary. This binary can be built from this repository via `make build-artifact-download` or simply downloaded pre-built from the GitHub release page.
+
+Usage is simple:
+```
+artifact-download \
+  --namespace my-project-cd \
+  --project my-project \
+  --repository my-repo \
+  --tag v1.0.0
+```
+
+The binary will then fetch artifacts for repository `bar` in Bitbucket project `foo`, as well as for any subrepositories that might be configured, and download them into `artifacts-out`. Example:
+
+```
+artifacts-out/
+├─ v1.0.0/
+│  ├─ my-repo/
+│  │  ├─ xunit-reports/
+│  │  │  ├─ report.xml
+│  │  │  ├─ index.html
+│  │  ├─ sonarqube-analysis/
+│  │  │  ├─ analysis-report.md
+│  │  │  ├─ issues-report.csv
+│  ├─ my-subrepo/
+│  │  ├─ xunit-reports/
+│  │  │  ├─ report.xml
+│  │  │  ├─ index.html
+│  │  ├─ sonarqube-analysis/
+│  │  │  ├─ analysis-report.md
+│  │  │  ├─ issues-report.csv
+```
+
+IMPORTANT: Using `artifact-download` requires to be logged into your cluster (`oc login ...`) in the terminal. The binary fetches all required credentials (e.g. to access Bitbucket) from the specified namespace.
+
+See `artifact-download --help` for all options, e.g. how to specify another output directory.
+
+TIP: While the primary use case of `artifact-download` is to download artifacts for final versions, it may also be used to look at the latest artifacts of a checked out repository. From inside a Git repository, run `artifact-download --namespace foo-cd --tag=WIP`.

--- a/docs/design/software-architecture.adoc
+++ b/docs/design/software-architecture.adoc
@@ -123,6 +123,24 @@ image::http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubuse
 | Nexus
 |
 
+| Binary `artifact-download`
+| Retrieve configuration and secrets
+| HTTP / JSON API
+| OpenShift
+|
+
+| Binary `artifact-download`
+| Retrieve Git revisions
+| HTTP / JSON API
+| Bitbucket
+|
+
+| Binary `artifact-download`
+| Download artifacts
+| HTTP / JSON API
+| Nexus
+|
+
 
 |===
 

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -319,6 +319,24 @@ For Git commits which message instructs to skip CI, no pipelines are triggererd.
 A pipeline is created or updated corresponding to the Git branch received in the webhook request. The pipeline name is made out of the component and the sanitized branch. A maximum of 63 characters is respected. Tasks (including `finally` tasks) of the pipline are read from the ODS config file in the repository.
 |===
 
+===== Artifact Download
+
+[cols="1,1,3"]
+|===
+| SDS-DLD-1
+| `artifact-download` binary
+a| The binary receives flags from the user identifying:
+
+* OpenShift namespace
+* Git repository (project/repository)
+* Git tag
+
+The OpenShift namespace is used to retrieve configuration and secrets required to communicate with Bitbucket and Nexus. The `ods.yaml` of the Git repository is retrieved at given Git tag to detect any subrepositories. If the given tag is `WIP`, the repository information is not retrieved from Bitbucket but located from the `.git` directory in the working directory.
+
+For all repositories in scope, the artifacts in the corresponding groups in Nexus are downloaded to the local host. The files are placed into `artifacts-out/<TAG>` (customizable via `--output`).
+|===
+
+
 === Third-party components
 
 [cols="1,1,1,2,1"]

--- a/docs/design/software-requirements-specification.adoc
+++ b/docs/design/software-requirements-specification.adoc
@@ -266,6 +266,17 @@ a| The task shall be able to run in a subdirectory of the checked out repository
 
 |===
 
+=== Aritfact Download Requirements
+
+[cols="1,3"]
+|===
+| SRS-DLD-1
+a| The binary shall download all artifacts belonging to one repository/version.
+
+* If the repository configures subrepositories, those shall be downloaded as well.
+
+|===
+
 == Appendix
 
 N/A

--- a/docs/design/stakeholder-requirements.adoc
+++ b/docs/design/stakeholder-requirements.adoc
@@ -67,6 +67,9 @@ Stakeholder requirements describe what the tool shall be able to accomplish and 
 
 | SHR-9
 | The pipeline shall provide feedback about its status to users.
+
+| SHR-10
+| ODS pipeline shall provide easy access to artifacts of each version.
 |===
 
 == Appendix

--- a/internal/repository/config_test.go
+++ b/internal/repository/config_test.go
@@ -1,28 +1,16 @@
 package repository
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/opendevstack/pipeline/pkg/bitbucket"
 	"github.com/opendevstack/pipeline/pkg/config"
 )
 
-type fakeRawClient struct {
-	// files contains byte slices for filenames
-	files map[string][]byte
-}
-
-func (c *fakeRawClient) RawGet(project, repository, filename, gitFullRef string) ([]byte, error) {
-	if f, ok := c.files[filename]; ok {
-		return f, nil
-	}
-	return nil, fmt.Errorf("%s not found", filename)
-}
-
 func TestGetODSConfig(t *testing.T) {
-	bitbucketClient := &fakeRawClient{}
+	bitbucketClient := &bitbucket.TestClient{}
 
 	tests := map[string]struct {
 		files   map[string][]byte
@@ -65,7 +53,7 @@ func TestGetODSConfig(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			bitbucketClient.files = tc.files
+			bitbucketClient.Files = tc.files
 			// As context is read from fake Bitbucket, dir value is unused.
 			got, err := GetODSConfig(bitbucketClient, "foo", "bar", "refs/heads/master")
 			if tc.wantErr == "" && err != nil {

--- a/pkg/bitbucket/test_client.go
+++ b/pkg/bitbucket/test_client.go
@@ -1,0 +1,46 @@
+package bitbucket
+
+import (
+	"errors"
+	"fmt"
+)
+
+// TestClient returns mocked branches and tags.
+type TestClient struct {
+	Branches []Branch
+	Tags     []Tag
+	// Files contains byte slices for filenames
+	Files map[string][]byte
+}
+
+func (c *TestClient) BranchList(projectKey string, repositorySlug string, params BranchListParams) (*BranchPage, error) {
+	return &BranchPage{
+		Values: c.Branches,
+	}, nil
+}
+
+func (c *TestClient) TagList(projectKey string, repositorySlug string, params TagListParams) (*TagPage, error) {
+	return &TagPage{
+		Values: c.Tags,
+	}, nil
+}
+
+func (c *TestClient) TagGet(projectKey string, repositorySlug string, name string) (*Tag, error) {
+	for _, t := range c.Tags {
+		if t.DisplayID == name {
+			return &t, nil
+		}
+	}
+	return nil, fmt.Errorf("no tag %s", name)
+}
+
+func (c *TestClient) TagCreate(projectKey string, repositorySlug string, payload TagCreatePayload) (*Tag, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *TestClient) RawGet(project, repository, filename, gitFullRef string) ([]byte, error) {
+	if f, ok := c.Files[filename]; ok {
+		return f, nil
+	}
+	return nil, fmt.Errorf("%s not found", filename)
+}

--- a/pkg/nexus/test_client.go
+++ b/pkg/nexus/test_client.go
@@ -1,0 +1,27 @@
+package nexus
+
+import (
+	"errors"
+	"io/ioutil"
+)
+
+type TestClient struct {
+	// URLs contains URLs per repository
+	URLs map[string][]string
+}
+
+// Download writes a dummy string into outfile.
+func (c *TestClient) Download(url, outfile string) (int64, error) {
+	return 0, ioutil.WriteFile(outfile, []byte("test"), 0644)
+}
+
+// Search responds with pre-registered URLs for repository.
+// group is ignored.
+func (c *TestClient) Search(repository, group string) ([]string, error) {
+	return c.URLs[repository], nil
+}
+
+// Upload is not needed for the test cases below.
+func (c *TestClient) Upload(repository, group, file string) error {
+	return errors.New("not implemented")
+}

--- a/pkg/pipelinectxt/artifacts_test.go
+++ b/pkg/pipelinectxt/artifacts_test.go
@@ -1,7 +1,6 @@
 package pipelinectxt
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -13,29 +12,8 @@ import (
 	"github.com/opendevstack/pipeline/pkg/nexus"
 )
 
-type fakeNexusClient struct {
-	// urls contains URLs per repository
-	urls map[string][]string
-}
-
-// Download writes a dummy string into outfile.
-func (c *fakeNexusClient) Download(url, outfile string) (int64, error) {
-	return 0, ioutil.WriteFile(outfile, []byte("test"), 0644)
-}
-
-// Search responds with pre-registered URLs for repository.
-// group is ignored.
-func (c *fakeNexusClient) Search(repository, group string) ([]string, error) {
-	return c.urls[repository], nil
-}
-
-// Upload is not needed for the test cases below.
-func (c *fakeNexusClient) Upload(repository, group, file string) error {
-	return errors.New("not implemented")
-}
-
 func TestDownloadGroup(t *testing.T) {
-	nexusClient := &fakeNexusClient{}
+	nexusClient := &nexus.TestClient{}
 	repositories := []string{nexus.PermanentRepositoryDefault, nexus.TemporaryRepositoryDefault}
 	group := "/my-project/my-repo/20d69cffd00080e20fa2f1419026a301cd0eecac"
 	artifactType := "my-type"
@@ -88,7 +66,7 @@ func TestDownloadGroup(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			nexusClient.urls = tc.urls
+			nexusClient.URLs = tc.urls
 			am, err := DownloadGroup(nexusClient, repositories, group, artifactsDir, logger)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Provide binary to download all artifacts related to one version easily.

Closes #167.

The PR has two commits to make it easier to review: f3922184b86be9cfc4a66fc7291f36a35fdc93b4 contains preparatory refactoring to make testing of the binary easier.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
