### PR TITLE
'Wait for...' scripts not waiting for the expected 5 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ listed in the changelog.
 - Release branches of subrepos are not detected ([#269](https://github.com/opendevstack/ods-pipeline/pull/269))
 - `Directory` values in the artifact manifest (`.ods/artifacts/manifest.json`) contain an erronous leading slash. This should only be an issue if you relied on this value in a custom task. ([#269](https://github.com/opendevstack/ods-pipeline/pull/269))
 - `ods-finish` does not upload artifacts of subrepos ([#257](https://github.com/opendevstack/ods-pipeline/issues/257))
+- Waitfor-...sh scripts are not waiting for the expected 5 minutes ([#280](https://github.com/opendevstack/ods-pipeline/issues/280))
 
 ## [0.1.1] - 2021-10-28
 ### Fixed

--- a/scripts/restart-bitbucket.sh
+++ b/scripts/restart-bitbucket.sh
@@ -33,7 +33,7 @@ until [ $n -ge 18 ]; do
         break
     else
         echo -n "."
-        sleep 10s
+        sleep 10
         n=$((n+1))
     fi
 done

--- a/scripts/waitfor-bitbucket.sh
+++ b/scripts/waitfor-bitbucket.sh
@@ -29,7 +29,7 @@ until [ $n -ge 30 ]; do
         break
     else
         echo -n "."
-        sleep 10s
+        sleep 10
         n=$((n+1))
     fi
 done

--- a/scripts/waitfor-nexus.sh
+++ b/scripts/waitfor-nexus.sh
@@ -28,7 +28,7 @@ function waitForReady {
             break
         else
             echo -n "."
-            sleep 10s
+            sleep 10
             n=$((n+1))
         fi
     done

--- a/scripts/waitfor-sonarqube.sh
+++ b/scripts/waitfor-sonarqube.sh
@@ -30,7 +30,7 @@ until [ $n -ge 30 ]; do
         break
     else
         echo -n "."
-        sleep 10s
+        sleep 10
         n=$((n+1))
     fi
 done


### PR DESCRIPTION
This fixes the issue that on macOS 12.0.1 Monterey the wait-for-scripts were not going to sleep, resulting in them not waiting for the respective service to start which causes an error.

Fixes #280 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
