### PR TITLE
Detect images to be built automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ listed in the changelog.
 
 - Provide separate binary to download all artifacts related to one version easily ([#167](https://github.com/opendevstack/ods-pipeline/issues/167))
 - Allow namespaced installation. This provides a way to give ODS pipeline a try without requiring the buy-in from a cluster admin. The OpenShift Pipelines operator is still required though. See [#263](https://github.com/opendevstack/ods-pipeline/issues/263).
-- Automated check if the Docker host has enough memory [#283](https://github.com/opendevstack/ods-pipeline/issues/283)
+- Automated check if the Docker host has enough memory ([#283](https://github.com/opendevstack/ods-pipeline/issues/283))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ listed in the changelog.
 - Automatically roll webhook interceptor deployment when related config map or secret changes ([#252](https://github.com/opendevstack/ods-pipeline/issues/252))
 - Hide confusing error message in Helm output ([#262](https://github.com/opendevstack/ods-pipeline/issues/262))
 - Update gcc (from 8.4 to 8.5), skopeo (from 1.3 to 1.4) and buildah (from 1.21 to 1.22) in container images ([#276](https://github.com/opendevstack/ods-pipeline/pull/276))
+- Iterating over Dockerfiles in build/package instead of using hardcoded list ([#286](https://github.com/opendevstack/ods-pipeline/issues/286))
 
 ### Fixed
 

--- a/scripts/build-and-push-images.sh
+++ b/scripts/build-and-push-images.sh
@@ -10,7 +10,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ODS_PIPELINE_DIR=${SCRIPT_DIR%/*}
 
 SKIP_BUILD="false"
-IMAGES="buildah finish go-toolset gradle-toolset helm sonar start webhook-interceptor python-toolset"
 http_proxy="${http_proxy:-}"
 https_proxy="${https_proxy:-}"
 
@@ -29,7 +28,8 @@ esac; shift; done
 
 cd $ODS_PIPELINE_DIR
 
-for image in $IMAGES; do
+for file in build/package/Dockerfile.*; do
+    image=${file##*Dockerfile.}
     odsImage="ods-$image"
     if [ "${SKIP_BUILD}" != "true" ]; then
         echo "Building image $REGISTRY/$NAMESPACE/$odsImage..."


### PR DESCRIPTION
Previously the images to be built via `build-and-push-images.sh` were determined via this line in the script itself:
```bash
IMAGES="buildah finish go-toolset gradle-toolset helm sonar start webhook-interceptor python-toolset"
```

As this is a hardcoded list it could happen (as it did with Typescript) that new images are added as a Dockerfile that are not added to this list.

With this change the script now iterates over the contents of `/build/package/` and retrieves the images to be built from this, which should not lead to missing images anymore.

Fixes #286 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
