### PR TITLE
Make task prefix customizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ listed in the changelog.
 - Provide separate binary to download all artifacts related to one version easily ([#167](https://github.com/opendevstack/ods-pipeline/issues/167))
 - Allow namespaced installation. This provides a way to give ODS pipeline a try without requiring the buy-in from a cluster admin. The OpenShift Pipelines operator is still required though. See [#263](https://github.com/opendevstack/ods-pipeline/issues/263).
 - Automated check if the Docker host has enough memory ([#283](https://github.com/opendevstack/ods-pipeline/issues/283))
+- Make task prefix customizable ([#289](https://github.com/opendevstack/ods-pipeline/issues/289))
 
 ### Changed
 

--- a/cmd/sidecar-tasks/main.go
+++ b/cmd/sidecar-tasks/main.go
@@ -50,13 +50,14 @@ func parseTasks(taskNames []string) (map[string]*tekton.ClusterTask, error) {
 func adjustTasks(tasks map[string]*tekton.ClusterTask) {
 	for name, t := range tasks {
 		fmt.Printf("Adding sidecar to task %s ...\n", name)
-		nameParts := strings.Split(t.Name, "{{")
+		cleanName := strings.Replace(t.Name, "{{default \"ods\" .Values.taskPrefix}}", "ods", 1)
+		cleanName = strings.Replace(cleanName, "{{.Values.taskSuffix}}", "", 1)
 		t.Name = strings.Replace(t.Name, "{{.Values.taskSuffix}}", "-with-sidecar{{.Values.taskSuffix}}", 1)
 		t.Spec.Description = t.Spec.Description + `
 **Sidecar variant!** Use this task if you need to run a container next to the build task.
 For example, this could be used to run a database to allow for integration tests.
 The sidecar image to must be supplied via ` + "`sidecar-image`" + `.
-Apart from the sidecar, the task is an exact copy of ` + "`" + nameParts[0] + "`" + `.`
+Apart from the sidecar, the task is an exact copy of ` + "`" + cleanName + "`" + `.`
 		t.Spec.Params = append(t.Spec.Params, tekton.ParamSpec{
 			Name:        "sidecar-image",
 			Description: "Image to use for sidecar",

--- a/deploy/central/tasks-chart/templates/task-ods-build-go-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-go-with-sidecar.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "ClusterTask" .Values.taskKind}}'
 metadata:
   creationTimestamp: null
-  name: ods-build-go-with-sidecar{{.Values.taskSuffix}}
+  name: '{{default "ods" .Values.taskPrefix}}-build-go-with-sidecar{{.Values.taskSuffix}}'
 spec:
   description: |-
     Builds Go (module) applications.

--- a/deploy/central/tasks-chart/templates/task-ods-build-go.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-go.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: '{{default "ClusterTask" .Values.taskKind}}'
 metadata:
-  name: ods-build-go{{.Values.taskSuffix}}
+  name: '{{default "ods" .Values.taskPrefix}}-build-go{{.Values.taskSuffix}}'
 spec:
   description: |
     Builds Go (module) applications.

--- a/deploy/central/tasks-chart/templates/task-ods-build-gradle-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-gradle-with-sidecar.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "ClusterTask" .Values.taskKind}}'
 metadata:
   creationTimestamp: null
-  name: ods-build-gradle-with-sidecar{{.Values.taskSuffix}}
+  name: '{{default "ods" .Values.taskPrefix}}-build-gradle-with-sidecar{{.Values.taskSuffix}}'
 spec:
   description: |-
     Builds Gradle applications.

--- a/deploy/central/tasks-chart/templates/task-ods-build-gradle.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-gradle.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: '{{default "ClusterTask" .Values.taskKind}}'
 metadata:
-  name: ods-build-gradle{{.Values.taskSuffix}}
+  name: '{{default "ods" .Values.taskPrefix}}-build-gradle{{.Values.taskSuffix}}'
 spec:
   description: |
     Builds Gradle applications.

--- a/deploy/central/tasks-chart/templates/task-ods-build-python-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-python-with-sidecar.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "ClusterTask" .Values.taskKind}}'
 metadata:
   creationTimestamp: null
-  name: ods-build-python-with-sidecar{{.Values.taskSuffix}}
+  name: '{{default "ods" .Values.taskPrefix}}-build-python-with-sidecar{{.Values.taskSuffix}}'
 spec:
   description: |-
     Builds Python applications.

--- a/deploy/central/tasks-chart/templates/task-ods-build-python.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-python.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: '{{default "ClusterTask" .Values.taskKind}}'
 metadata:
-  name: ods-build-python{{.Values.taskSuffix}}
+  name: '{{default "ods" .Values.taskPrefix}}-build-python{{.Values.taskSuffix}}'
 spec:
   description: |
     Builds Python applications.

--- a/deploy/central/tasks-chart/templates/task-ods-build-typescript-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-typescript-with-sidecar.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "ClusterTask" .Values.taskKind}}'
 metadata:
   creationTimestamp: null
-  name: ods-build-typescript-with-sidecar{{.Values.taskSuffix}}
+  name: '{{default "ods" .Values.taskPrefix}}-build-typescript-with-sidecar{{.Values.taskSuffix}}'
 spec:
   description: |-
     Builds Typescript applications.

--- a/deploy/central/tasks-chart/templates/task-ods-build-typescript.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-typescript.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: '{{default "ClusterTask" .Values.taskKind}}'
 metadata:
-  name: ods-build-typescript{{.Values.taskSuffix}}
+  name: '{{default "ods" .Values.taskPrefix}}-build-typescript{{.Values.taskSuffix}}'
 spec:
   description: |
     Builds Typescript applications.

--- a/deploy/central/tasks-chart/templates/task-ods-deploy-helm.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-deploy-helm.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: '{{default "ClusterTask" .Values.taskKind}}'
 metadata:
-  name: ods-deploy-helm{{.Values.taskSuffix}}
+  name: '{{default "ods" .Values.taskPrefix}}-deploy-helm{{.Values.taskSuffix}}'
 spec:
   description: |
     Deploy Helm charts.

--- a/deploy/central/tasks-chart/templates/task-ods-finish.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-finish.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: '{{default "ClusterTask" .Values.taskKind}}'
 metadata:
-  name: ods-finish{{.Values.taskSuffix}}
+  name: '{{default "ods" .Values.taskPrefix}}-finish{{.Values.taskSuffix}}'
 spec:
   description: |
     Finishes the pipeline run.

--- a/deploy/central/tasks-chart/templates/task-ods-package-image.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-package-image.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: '{{default "ClusterTask" .Values.taskKind}}'
 metadata:
-  name: ods-package-image{{.Values.taskSuffix}}
+  name: '{{default "ods" .Values.taskPrefix}}-package-image{{.Values.taskSuffix}}'
 spec:
   description: |
     Packages applications into container images using buildah.

--- a/deploy/central/tasks-chart/templates/task-ods-start.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-start.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: '{{default "ClusterTask" .Values.taskKind}}'
 metadata:
-  name: ods-start{{.Values.taskSuffix}}
+  name: '{{default "ods" .Values.taskPrefix}}-start{{.Values.taskSuffix}}'
 spec:
   description: |
     Starts the pipeline run.

--- a/deploy/central/tasks-chart/values.yaml
+++ b/deploy/central/tasks-chart/values.yaml
@@ -7,3 +7,12 @@ namespace: ods
 imageTag: 0.1.1
 taskSuffix: -v0-1-1
 pushRegistry: image-registry.openshift-image-registry.svc:5000
+
+
+# Optional Values
+
+# Custom task kind (defaults to "ClusterTask")
+# taskKind: "Task"
+
+# Custom task prefix (defaults to "ods")
+# taskPrefix: "foo"


### PR DESCRIPTION
While the default is still `ods`, it is now possible to use a
different prefix. That way, an installation of ODS pipeline can be
installed centrally without communicating to cluster users that it is
part of the "official" ODS core installation. For example, one could use
`experimental` as a prefix to indicate that this installation is not (yet)
blessed by the platform owners.

Closes #289

This is not directly documented as we don't want to advertise this too much. I did not find a good way to place it in the docs without making it too prominent so I only added it the `values.yaml` file.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
