### PR TITLE
fixed specifying image(s) to be build and pushed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ listed in the changelog.
 - `Directory` values in the artifact manifest (`.ods/artifacts/manifest.json`) contain an erronous leading slash. This should only be an issue if you relied on this value in a custom task. ([#269](https://github.com/opendevstack/ods-pipeline/pull/269))
 - `ods-finish` does not upload artifacts of subrepos ([#257](https://github.com/opendevstack/ods-pipeline/issues/257))
 - Waitfor-...sh scripts are not waiting for the expected 5 minutes ([#280](https://github.com/opendevstack/ods-pipeline/issues/280))
+- Specifying images to be build and pushed is not working anymore due to changes made in [#287](https://github.com/opendevstack/ods-pipeline/pull/287) ([#299](https://github.com/opendevstack/ods-pipeline/issues/299))
 
 ## [0.1.1] - 2021-10-28
 ### Fixed

--- a/scripts/build-and-push-images.sh
+++ b/scripts/build-and-push-images.sh
@@ -10,6 +10,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ODS_PIPELINE_DIR=${SCRIPT_DIR%/*}
 
 SKIP_BUILD="false"
+IMAGES=""
 http_proxy="${http_proxy:-}"
 https_proxy="${https_proxy:-}"
 
@@ -28,8 +29,7 @@ esac; shift; done
 
 cd $ODS_PIPELINE_DIR
 
-for file in build/package/Dockerfile.*; do
-    image=${file##*Dockerfile.}
+build_and_push_image() {
     odsImage="ods-$image"
     if [ "${SKIP_BUILD}" != "true" ]; then
         echo "Building image $REGISTRY/$NAMESPACE/$odsImage..."
@@ -42,4 +42,15 @@ for file in build/package/Dockerfile.*; do
     fi
     echo "Pushing image to $REGISTRY/$NAMESPACE/$odsImage ..."
     docker push "$REGISTRY/$NAMESPACE/$odsImage"
-done
+}
+
+if [ -z $IMAGES ]; then
+    for file in build/package/Dockerfile.*; do
+        image=${file##*Dockerfile.}
+        build_and_push_image
+    done
+else
+    for image in $IMAGES; do
+        build_and_push_image
+    done
+fi

--- a/scripts/build-and-push-images.sh
+++ b/scripts/build-and-push-images.sh
@@ -27,24 +27,24 @@ while [[ "$#" -gt 0 ]]; do
     *) echo "Unknown parameter passed: $1"; exit 1;;
 esac; shift; done
 
-cd $ODS_PIPELINE_DIR
+cd "$ODS_PIPELINE_DIR"
 
 build_and_push_image() {
     odsImage="ods-$image"
     if [ "${SKIP_BUILD}" != "true" ]; then
         echo "Building image $REGISTRY/$NAMESPACE/$odsImage..."
         docker build \
-            --build-arg http_proxy=$http_proxy \
-            --build-arg https_proxy=$https_proxy \
-            --build-arg HTTP_PROXY=$http_proxy \
-            --build-arg HTTPS_PROXY=$https_proxy  \
-            -f build/package/Dockerfile.$image -t $REGISTRY/$NAMESPACE/$odsImage .
+            --build-arg http_proxy="$http_proxy" \
+            --build-arg https_proxy="$https_proxy" \
+            --build-arg HTTP_PROXY="$http_proxy" \
+            --build-arg HTTPS_PROXY="$https_proxy"  \
+            -f build/package/Dockerfile."$image" -t $REGISTRY/$NAMESPACE/"$odsImage" .
     fi
     echo "Pushing image to $REGISTRY/$NAMESPACE/$odsImage ..."
     docker push "$REGISTRY/$NAMESPACE/$odsImage"
 }
 
-if [ -z $IMAGES ]; then
+if [ -z "$IMAGES" ]; then
     for file in build/package/Dockerfile.*; do
         image=${file##*Dockerfile.}
         build_and_push_image


### PR DESCRIPTION
Fixes an issue that came up due to changes made in #287 which resulted in all images being built and pushed even when running
```
./scripts/build-and-oush-images.sh --image foo
```

Fixes #299 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
