### PR TITLE
Document release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 .idea/
 test/testdata/workspaces/workspace-*
 ods.external.yaml
-/artifact-download
+artifact-download-linux-amd64
+artifact-download-darwin-amd64
+artifact-download-windows-amd64.exe

--- a/Makefile
+++ b/Makefile
@@ -159,10 +159,24 @@ clear-tmp-workspaces:
 	rm -rf test/testdata/workspaces/workspace-*
 .PHONY: clear-tmp-workspaces
 
-## Build artifact-download binary.
-build-artifact-download:
-	cd cmd/artifact-download && CGO_ENABLED=0 go build -o ../../artifact-download
+## Build artifact-download binary for each supported OS/arch.
+build-artifact-download: build-artifact-download-linux build-artifact-download-darwin build-artifact-download-windows
 .PHONY: build-artifact-download
+
+## Build artifact-download Linux binary.
+build-artifact-download-linux:
+	cd cmd/artifact-download && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -gcflags "all=-trimpath=$(CURDIR);$(shell go env GOPATH)" -o artifact-download-linux-amd64
+.PHONY: build-artifact-download-linux
+
+## Build artifact-download macOS binary.
+build-artifact-download-darwin:
+	cd cmd/artifact-download && GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -gcflags "all=-trimpath=$(CURDIR);$(shell go env GOPATH)" -o artifact-download-darwin-amd64
+.PHONY: build-artifact-download-darwin
+
+## Build artifact-download Windows binary.
+build-artifact-download-windows:
+	cd cmd/artifact-download && GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -gcflags "all=-trimpath=$(CURDIR);$(shell go env GOPATH)" -o artifact-download-windows-amd64.exe
+.PHONY: build-artifact-download-windows
 
 ### HELP
 ### Based on https://gist.github.com/prwhite/8168133#gistcomment-2278355.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The documentation provided by ODS pipeline has three audiences:
 * [Development & Running Tests](/docs/development.adoc)
 * [Artifacts](/docs/artifacts.adoc)
 * [Creating an ODS task](/docs/creating-an-ods-task.adoc)
+* [Releasing a new version](/docs/releasing.adoc)
 
 This repository also hosts the design documents that describe ODS pipeline more formally. Those design documents provide more detail and background on goals, requirements and architecture decisions and may be useful for all audiences.
 

--- a/docs/releasing.adoc
+++ b/docs/releasing.adoc
@@ -1,0 +1,31 @@
+= Releasing a new version
+
+This document describes how to release a new version of ODS pipeline.
+
+== Versioning Scheme
+
+ODS pipeline follows https://semver.org[Semantic Versioning 2.0.0]. This means breaking changes need a new major version.
+
+== Release Process
+
+=== Preparing the release
+The current version is hardcoded in a few places across the repository. All of these places must be updated immediately for a release. Until more detailed instructions are available, see the https://github.com/opendevstack/ods-pipeline/commit/1e123ca361baf918c6f4f2f3208f3285d5bc5b05[preparation commit of v0.1.1] as a reference. Note that additionally, you need to update:
+
+* the version in `cmd/artifact-download/main.go`
+* the compatibility matrix in the `README.md` (if applicable)
+
+=== Publishing the release
+Draft a new GitHub release, creating a new tag in the process (e.g. `v0.2.0`). The description should be like this:
+
+```
+< Note highlights of the release and any breaking changes >
+
+For all changes and more details, please see the [changelog](https://github.com/opendevstack/ods-pipeline/blob/master/CHANGELOG.md#< Add anchor of the released version>).
+
+To update the cluster-wide pipeline installation, refer to the [admin update instructions](https://github.com/opendevstack/ods-pipeline/blob/master/docs/admin-installation.adoc#updating).
+
+To update your project-specific pipeline installation, refer to the [user update instructions](https://github.com/opendevstack/ods-pipeline/blob/master/docs/user-installation.adoc#updating).
+```
+
+=== Attaching binaries to the release
+The `artifact-download` binary should be offered as a pre-built binary for `linux/amd64`, `darwin/amd64` and `windows/amd64`. These can be generated via `make build-artifact-download`, and then uploaded in the GitHub release creation form.


### PR DESCRIPTION
Closes #177.

We might want to detail this further in the future, but this should
suffice for the time being.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
