### PR TITLE
Configurable test timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ listed in the changelog.
 - Automated check if the Docker host has enough memory ([#283](https://github.com/opendevstack/ods-pipeline/issues/283))
 - Create SonarQube quality gate artifact ([#273](https://github.com/opendevstack/ods-pipeline/issues/273))
 - Make task prefix customizable ([#289](https://github.com/opendevstack/ods-pipeline/issues/289))
+- Add overridable test timeout to Makefile ([#284](https://github.com/opendevstack/ods-pipeline/issues/284))
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -146,12 +146,12 @@ test-pkg:
 
 ## Run testsuite of Tekton tasks.
 test-tasks:
-	go test -v -count=1 ./test/tasks/...
+	go test -v -count=1 -timeout $${ODS_TESTTIMEOUT:-30m} ./test/tasks/...
 .PHONY: test-tasks
 
 ## Run testsuite of end-to-end tasks.
 test-e2e:
-	go test -v -count=1 ./test/e2e/...
+	go test -v -count=1 $${ODS_TESTTIMEOUT:-10m} ./test/e2e/...
 .PHONY: test-e2e
 
 ## Clear temporary workspaces created in testruns.

--- a/docs/development.adoc
+++ b/docs/development.adoc
@@ -33,7 +33,9 @@ Individual task test can be executed like this:
 go test -run ^TestTaskODSBuildImage github.com/opendevstack/pipeline/test/tasks -v -count=1
 ```
 
-Be aware that depending on the tested task, some local services (e.g. Bitbucket) need to run for the test to succeed. These are all started via `make prepare-local-env`, but more fine-grained control is possible too. Unfortunately these test dependencies are not expressed explicitly yet, see tracking issue https://github.com/opendevstack/ods-pipeline/issues/99.
+Be aware that depending on the tested task, some local services (e.g. Bitbucket) need to run for the test to succeed. These are all started via `make prepare-local-env`, but more fine-grained control is possible too. Unfortunately these test dependencies are not expressed explicitly yet, see tracking issue https://github.com/opendevstack/ods-pipeline/issues/99. 
+
+Particularly the task and e2e tests might consume some time and might run into a timeout. To modify the standard timeout (by default in sync with the timeout predefined for Github actions), set the environment variable `ODS_TESTTIMEOUT` (e.g. to `45m`).
 
 Also, if you make changes to the images backing the tasks (be it by changing the `Dockerfile` or by changing the scripts/commands installed there), make sure to rebuild and push the affected images to the KinD registry for your changes to take effect. You can do this e.g. through `./scripts/build-and-push-images.sh --image finish` (the name of the image flag is the suffix of the respective Dockerfile).
 


### PR DESCRIPTION
Add overridable timeout for the potentially time consuming tests in the Makefile.

Closes #284

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
