### PR TITLE
Handle test timeout in typescript task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ listed in the changelog.
 - Hide confusing error message in Helm output ([#262](https://github.com/opendevstack/ods-pipeline/issues/262))
 - Update gcc (from 8.4 to 8.5), skopeo (from 1.3 to 1.4) and buildah (from 1.21 to 1.22) in container images ([#276](https://github.com/opendevstack/ods-pipeline/pull/276))
 - Iterating over Dockerfiles in build/package instead of using hardcoded list ([#286](https://github.com/opendevstack/ods-pipeline/issues/286))
-- Increase timeout of typescript task tests and generate a hint when testruns time out
+- Increase timeout of typescript task tests and generate a hint when testruns time out ([#310](https://github.com/opendevstack/ods-pipeline/issues/310))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ listed in the changelog.
 - Hide confusing error message in Helm output ([#262](https://github.com/opendevstack/ods-pipeline/issues/262))
 - Update gcc (from 8.4 to 8.5), skopeo (from 1.3 to 1.4) and buildah (from 1.21 to 1.22) in container images ([#276](https://github.com/opendevstack/ods-pipeline/pull/276))
 - Iterating over Dockerfiles in build/package instead of using hardcoded list ([#286](https://github.com/opendevstack/ods-pipeline/issues/286))
+- Increase timeout of typescript task tests and generate a hint when testruns time out
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ listed in the changelog.
 - Hide confusing error message in Helm output ([#262](https://github.com/opendevstack/ods-pipeline/issues/262))
 - Update gcc (from 8.4 to 8.5), skopeo (from 1.3 to 1.4) and buildah (from 1.21 to 1.22) in container images ([#276](https://github.com/opendevstack/ods-pipeline/pull/276))
 - Iterating over Dockerfiles in build/package instead of using hardcoded list ([#286](https://github.com/opendevstack/ods-pipeline/issues/286))
-- Increase timeout of typescript task tests and generate a hint when testruns time out ([#310](https://github.com/opendevstack/ods-pipeline/issues/310))
 
 ### Fixed
 

--- a/pkg/tasktesting/run.go
+++ b/pkg/tasktesting/run.go
@@ -3,6 +3,7 @@ package tasktesting
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -187,6 +188,9 @@ func WatchTaskRunUntilDone(t *testing.T, testOpts TestOpts, tr *tekton.TaskRun) 
 		case tr := <-taskRunDone:
 			cancel()
 			return tr, collectedLogsBuffer, nil
+		case <-ctx.Done():
+			cancel()
+			return nil, collectedLogsBuffer, fmt.Errorf("timeout waiting for task run to finish. Consider increasing the timeout for your testcase at hand")
 		}
 	}
 }

--- a/pkg/tasktesting/run.go
+++ b/pkg/tasktesting/run.go
@@ -145,6 +145,7 @@ func WatchTaskRunUntilDone(t *testing.T, testOpts TestOpts, tr *tekton.TaskRun) 
 	var collectedLogsBuffer bytes.Buffer
 
 	ctx, cancel := context.WithTimeout(context.TODO(), testOpts.Timeout)
+	defer cancel()
 	go waitForTaskRunDone(
 		ctx,
 		t,
@@ -167,7 +168,6 @@ func WatchTaskRunUntilDone(t *testing.T, testOpts TestOpts, tr *tekton.TaskRun) 
 		select {
 		case err := <-errs:
 			if err != nil {
-				cancel()
 				return nil, collectedLogsBuffer, err
 			}
 
@@ -186,10 +186,8 @@ func WatchTaskRunUntilDone(t *testing.T, testOpts TestOpts, tr *tekton.TaskRun) 
 			collectedLogsBuffer.Write(b)
 
 		case tr := <-taskRunDone:
-			cancel()
 			return tr, collectedLogsBuffer, nil
 		case <-ctx.Done():
-			cancel()
 			return nil, collectedLogsBuffer, fmt.Errorf("timeout waiting for task run to finish. Consider increasing the timeout for your testcase at hand")
 		}
 	}

--- a/test/tasks/ods-build-typescript_test.go
+++ b/test/tasks/ods-build-typescript_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/opendevstack/pipeline/internal/directory"
 	"github.com/opendevstack/pipeline/internal/projectpath"
@@ -18,6 +19,7 @@ func TestTaskODSBuildTypescript(t *testing.T) {
 		"ods-build-typescript",
 		map[string]tasktesting.TestCase{
 			"build typescript app": {
+				Timeout:             20 * time.Minute,
 				WorkspaceDirMapping: map[string]string{"source": "typescript-sample-app"},
 				PreRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
 					wsDir := ctxt.Workspaces["source"]
@@ -44,6 +46,7 @@ func TestTaskODSBuildTypescript(t *testing.T) {
 				},
 			},
 			"build typescript app in subdirectory": {
+				Timeout:             20 * time.Minute,
 				WorkspaceDirMapping: map[string]string{"source": "hello-world-app"},
 				PreRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
 					wsDir := ctxt.Workspaces["source"]


### PR DESCRIPTION
Typescript task tests can take a lot of time when run locally, so @henninggross and I introduced a generous timeout to handle those cases. In addition, so far, when the test run's context timed out, there was no indication that the test failure might be related to the timeout.

Closes #310

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
