### PR TITLE
Fix missing timeout flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ test-tasks:
 
 ## Run testsuite of end-to-end tasks.
 test-e2e:
-	go test -v -count=1 $${ODS_TESTTIMEOUT:-10m} ./test/e2e/...
+	go test -v -count=1 -timeout $${ODS_TESTTIMEOUT:-10m} ./test/e2e/...
 .PHONY: test-e2e
 
 ## Clear temporary workspaces created in testruns.


### PR DESCRIPTION
Fix missing timeout flag in `test-e2e` goal in makefile

Fixes #309

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
