### PR TITLE
added missing tests to test goal and provided install hints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ docs:
 .PHONY: docs
 
 ## Run complete testsuite.
-test: test-internal test-pkg test-tasks
+test: test-cmd test-internal test-pkg test-tasks test-e2e
 .PHONY: test
 
 ## Run testsuite of cmd packages.

--- a/docs/development.adoc
+++ b/docs/development.adoc
@@ -24,9 +24,11 @@ make help
 
 As mentioned above, `make test` will run all tests. You may also run only a subset of tests:
 
+* `make test-cmd` for the packages under `cmd`
 * `make test-pkg` for the packages under `pkg`
 * `make test-internal` for the packages under `internal`
 * `make test-tasks` for the Tekton tasks
+* `make test-e2e` for the end-to-end tasks
 
 Individual task test can be executed like this:
 ```

--- a/scripts/check-system.sh
+++ b/scripts/check-system.sh
@@ -5,12 +5,35 @@ set -ue
 
 ok="true"
 
-for exe in go docker jq kind kubectl helm; do
-    if ! which $exe &> /dev/null; then
-        ok="false"
-        echo "$exe is required"
-    fi
-done
+if ! which go &> /dev/null; then
+    ok="false"
+    echo "go is required. For documentation on how to install please visit https://go.dev/doc/install."
+fi
+
+if ! which docker &> /dev/null; then
+    ok="false"
+    echo "docker is required. For documentation on how to install please visit https://docs.docker.com/engine/install/."
+fi
+
+if ! which jq &> /dev/null; then
+    ok="false"
+    echo "jq is required. For documentation on how to install please visit https://stedolan.github.io/jq/download/."
+fi
+
+if ! which kind &> /dev/null; then
+    ok="false"
+    echo "kind is required. For documentation on how to install please visit https://kind.sigs.k8s.io/#installation-and-usage."
+fi
+
+if ! which kubectl &> /dev/null; then
+    ok="false"
+    echo "kubectl is required. For documentation on how to install please visit https://kubernetes.io/docs/tasks/tools/#kubectl."
+fi
+
+if ! which helm &> /dev/null; then
+    ok="false"
+    echo "helm is required. For documentation on how to install please visit https://helm.sh/docs/intro/install/."
+fi
 
 if which docker &> /dev/null; then
     docker_host_memory=$(docker info --format "{{.MemTotal}}")


### PR DESCRIPTION
- adds the missing make test to the overall test goal in the Makefile and doc
- enhances the error messages from the check-system.sh script by providing install links. @michaelsauter I had to destroy your beautiful loop here but did couldn't think of any better way to do it. 
- The error from the #290 issue:
```
# runtime/cgo
cgo: C compiler "gcc-5" not found: exec: "gcc-5": executable file not found in $PATH
FAIL    github.com/opendevstack/pipeline/cmd/artifact-download [build failed]
FAIL    github.com/opendevstack/pipeline/cmd/deploy-with-helm [build failed]
FAIL    github.com/opendevstack/pipeline/cmd/finish [build failed]
FAIL    github.com/opendevstack/pipeline/cmd/sonar [build failed]
FAIL    github.com/opendevstack/pipeline/cmd/start [build failed]
FAIL    github.com/opendevstack/pipeline/cmd/webhook-interceptor [build failed]
make: *** [Makefile:134: test-cmd] Error 2
```
did not occur anymore. I do not know why, but I'd leave it like it is until it happens somewhere again?

Fixes #290 

