### PR TITLE
Skip tests in TypeScript build if test artifacts are present already

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ listed in the changelog.
 - Create SonarQube quality gate artifact ([#273](https://github.com/opendevstack/ods-pipeline/issues/273))
 - Make task prefix customizable ([#289](https://github.com/opendevstack/ods-pipeline/issues/289))
 - Add overridable test timeout to Makefile ([#284](https://github.com/opendevstack/ods-pipeline/issues/284))
+- Skipping Tests in TypeScript build task if test artifacts are present already ([#238](https://github.com/opendevstack/ods-pipeline/issues/238))
 
 ### Changed
 

--- a/build/package/scripts/build-typescript.sh
+++ b/build/package/scripts/build-typescript.sh
@@ -66,18 +66,27 @@ echo "Copying node_modules to ${OUTPUT_DIR}/dist/node_modules ..."
 cp -r node_modules "${OUTPUT_DIR}/dist/node_modules"
 
 echo "Testing ..."
-npm run test
+if [ -f "${ROOT_DIR}/.ods/artifacts/xunit-reports/${ARTIFACT_PREFIX}report.xml" ]; then
+  echo "Test artifacts already present, skipping tests ..."
+  # Copy artifacts to working directory so that the SonarQube scanner can pick them up later.
+  cp "${ROOT_DIR}/.ods/artifacts/xunit-reports/${ARTIFACT_PREFIX}report.xml" report.xml
+  cp "${ROOT_DIR}/.ods/artifacts/code-coverage/${ARTIFACT_PREFIX}clover.xml" clover.xml
+  cp "${ROOT_DIR}/.ods/artifacts/code-coverage/${ARTIFACT_PREFIX}coverage-final.json" coverage-final.json
+  cp "${ROOT_DIR}/.ods/artifacts/code-coverage/${ARTIFACT_PREFIX}lcov.info" lcov.info
+else
+  npm run test
 
-mkdir -p "${ROOT_DIR}/.ods/artifacts/xunit-reports"
-cat build/test-results/test/report.xml
-cp build/test-results/test/report.xml "${ROOT_DIR}/.ods/artifacts/xunit-reports/${ARTIFACT_PREFIX}report.xml"
+  mkdir -p "${ROOT_DIR}/.ods/artifacts/xunit-reports"
+  cat build/test-results/test/report.xml
+  cp build/test-results/test/report.xml "${ROOT_DIR}/.ods/artifacts/xunit-reports/${ARTIFACT_PREFIX}report.xml"
 
-mkdir -p "${ROOT_DIR}/.ods/artifacts/code-coverage"
-cat build/coverage/clover.xml
-cp build/coverage/clover.xml "${ROOT_DIR}/.ods/artifacts/code-coverage/${ARTIFACT_PREFIX}clover.xml"
+  mkdir -p "${ROOT_DIR}/.ods/artifacts/code-coverage"
+  cat build/coverage/clover.xml
+  cp build/coverage/clover.xml "${ROOT_DIR}/.ods/artifacts/code-coverage/${ARTIFACT_PREFIX}clover.xml"
 
-cat build/coverage/coverage-final.json
-cp build/coverage/coverage-final.json "${ROOT_DIR}/.ods/artifacts/code-coverage/${ARTIFACT_PREFIX}coverage-final.json"
+  cat build/coverage/coverage-final.json
+  cp build/coverage/coverage-final.json "${ROOT_DIR}/.ods/artifacts/code-coverage/${ARTIFACT_PREFIX}coverage-final.json"
 
-cat build/coverage/lcov.info
-cp build/coverage/lcov.info "${ROOT_DIR}/.ods/artifacts/code-coverage/${ARTIFACT_PREFIX}lcov.info"
+  cat build/coverage/lcov.info
+  cp build/coverage/lcov.info "${ROOT_DIR}/.ods/artifacts/code-coverage/${ARTIFACT_PREFIX}lcov.info"
+fi


### PR DESCRIPTION
This functionality is implemented the same way it is done in Go (https://github.com/opendevstack/ods-pipeline/blob/master/build/package/scripts/build-go.sh#L92).

I tested it by creating a typescript workspace with the artifacts present and changing the source workspace in the TS tests to that workspace.
I am shying away from also including this test to the delivered test suite because the two TypeScript tests are already taking a lot of time which often results in timeouts (on my local machine at least).  👉  See #310 

Closes #238 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
