### PR TITLE
Fail tests if service is unreachable

### DIFF
--- a/pkg/tasktesting/check.go
+++ b/pkg/tasktesting/check.go
@@ -1,11 +1,27 @@
 package tasktesting
 
 import (
+	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/opendevstack/pipeline/internal/command"
 )
+
+type Service string
+
+const (
+	Bitbucket Service = "7990"
+	Nexus     Service = "8081"
+	SonarQube Service = "9000"
+)
+
+var serviceMapping = map[Service]string{
+	Bitbucket: "Bitbucket",
+	Nexus:     "Nexus",
+	SonarQube: "SonarQube",
+}
 
 // Safeguard against running outside KinD
 func CheckCluster(t *testing.T, outsideKindAllowed bool) {
@@ -19,5 +35,18 @@ func CheckCluster(t *testing.T, outsideKindAllowed bool) {
 		if gotContext != wantContext {
 			t.Fatalf("Not running tests outside KinD cluster ('%s') without -outside-kind! Current context: %s", wantContext, gotContext)
 		}
+	}
+}
+
+func CheckServices(t *testing.T, requiredServices []Service) {
+	t.Logf("Trying to reach the required services...")
+	for _, port := range requiredServices {
+		service := serviceMapping[port]
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%s", port))
+		if err != nil {
+			t.Fatalf("%s needs to run for this test to be executable, but it could not be reached: %s", service, err)
+		}
+		t.Logf("%s reached successfully.", service)
+		defer resp.Body.Close()
 	}
 }

--- a/pkg/tasktesting/run.go
+++ b/pkg/tasktesting/run.go
@@ -3,8 +3,6 @@ package tasktesting
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,7 +36,6 @@ type TestCase struct {
 	PreRunFunc          func(t *testing.T, ctxt *TaskRunContext)
 	PostRunFunc         func(t *testing.T, ctxt *TaskRunContext)
 	Timeout             time.Duration
-	RequiredServices    []string
 }
 
 type TaskRunContext struct {
@@ -56,27 +53,6 @@ func Run(t *testing.T, tc TestCase, testOpts TestOpts) {
 	// Set default timeout for running the test
 	if testOpts.Timeout == 0 {
 		testOpts.Timeout = 120 * time.Second
-	}
-
-	if tc.RequiredServices != nil {
-		serviceToPortMapping := map[string]string{
-			"Bitbucket": "7990",
-			"Nexus":     "8081",
-			"SonarQube": "9000",
-		}
-		t.Logf("Trying to reach the required services...")
-		for _, service := range tc.RequiredServices {
-			if port, ok := serviceToPortMapping[service]; ok {
-				resp, err := http.Get(fmt.Sprintf("http://localhost:%s", port))
-				if err != nil {
-					t.Fatalf("%s needs to run for this test to be executable, but it could not be reached: %s", service, err)
-				}
-				t.Logf("%s reached successfully.", service)
-				defer resp.Body.Close()
-			} else {
-				t.Logf("Unknown Service specified: %s", service)
-			}
-		}
 	}
 
 	taskWorkspaces := map[string]string{}

--- a/pkg/tasktesting/run.go
+++ b/pkg/tasktesting/run.go
@@ -3,6 +3,8 @@ package tasktesting
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,6 +38,7 @@ type TestCase struct {
 	PreRunFunc          func(t *testing.T, ctxt *TaskRunContext)
 	PostRunFunc         func(t *testing.T, ctxt *TaskRunContext)
 	Timeout             time.Duration
+	RequiredServices    []string
 }
 
 type TaskRunContext struct {
@@ -53,6 +56,27 @@ func Run(t *testing.T, tc TestCase, testOpts TestOpts) {
 	// Set default timeout for running the test
 	if testOpts.Timeout == 0 {
 		testOpts.Timeout = 120 * time.Second
+	}
+
+	if tc.RequiredServices != nil {
+		serviceToPortMapping := map[string]string{
+			"Bitbucket": "7990",
+			"Nexus":     "8081",
+			"SonarQube": "9000",
+		}
+		t.Logf("Trying to reach the required services...")
+		for _, service := range tc.RequiredServices {
+			if port, ok := serviceToPortMapping[service]; ok {
+				resp, err := http.Get(fmt.Sprintf("http://localhost:%s", port))
+				if err != nil {
+					t.Fatalf("%s needs to run for this test to be executable, but it could not be reached: %s", service, err)
+				}
+				t.Logf("%s reached successfully.", service)
+				defer resp.Body.Close()
+			} else {
+				t.Logf("Unknown Service specified: %s", service)
+			}
+		}
 	}
 
 	taskWorkspaces := map[string]string{}

--- a/test/tasks/common_test.go
+++ b/test/tasks/common_test.go
@@ -112,8 +112,11 @@ func getFileContentLean(filename string) (string, error) {
 	return contentStr, nil
 }
 
-func runTaskTestCases(t *testing.T, taskName string, testCases map[string]tasktesting.TestCase) {
+func runTaskTestCases(t *testing.T, taskName string, requiredServices []tasktesting.Service, testCases map[string]tasktesting.TestCase) {
 	tasktesting.CheckCluster(t, *outsideKindFlag)
+	if len(requiredServices) != 0 {
+		tasktesting.CheckServices(t, requiredServices)
+	}
 
 	c, ns := tasktesting.Setup(t,
 		tasktesting.SetupOpts{

--- a/test/tasks/ods-build-go_test.go
+++ b/test/tasks/ods-build-go_test.go
@@ -18,6 +18,11 @@ import (
 func TestTaskODSBuildGo(t *testing.T) {
 	runTaskTestCases(t,
 		"ods-build-go",
+		[]tasktesting.Service{
+			tasktesting.Bitbucket,
+			tasktesting.Nexus,
+			tasktesting.SonarQube,
+		},
 		map[string]tasktesting.TestCase{
 			"build go app": {
 				WorkspaceDirMapping: map[string]string{"source": "go-sample-app"},

--- a/test/tasks/ods-build-gradle_test.go
+++ b/test/tasks/ods-build-gradle_test.go
@@ -23,7 +23,8 @@ func TestTaskODSBuildGradle(t *testing.T) {
 						"sonar-quality-gate": "true",
 					}
 				},
-				WantRunSuccess: true,
+				RequiredServices: []string{"Bitbucket", "Nexus", "SonarQube"},
+				WantRunSuccess:   true,
 				PostRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
 					wsDir := ctxt.Workspaces["source"]
 

--- a/test/tasks/ods-build-gradle_test.go
+++ b/test/tasks/ods-build-gradle_test.go
@@ -13,6 +13,11 @@ import (
 func TestTaskODSBuildGradle(t *testing.T) {
 	runTaskTestCases(t,
 		"ods-build-gradle",
+		[]tasktesting.Service{
+			tasktesting.Bitbucket,
+			tasktesting.Nexus,
+			tasktesting.SonarQube,
+		},
 		map[string]tasktesting.TestCase{
 			"task should build gradle app": {
 				WorkspaceDirMapping: map[string]string{"source": "gradle-sample-app"},
@@ -23,8 +28,7 @@ func TestTaskODSBuildGradle(t *testing.T) {
 						"sonar-quality-gate": "true",
 					}
 				},
-				RequiredServices: []string{"Bitbucket", "Nexus", "SonarQube"},
-				WantRunSuccess:   true,
+				WantRunSuccess: true,
 				PostRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
 					wsDir := ctxt.Workspaces["source"]
 

--- a/test/tasks/ods-build-python_test.go
+++ b/test/tasks/ods-build-python_test.go
@@ -18,6 +18,11 @@ import (
 func TestTaskODSBuildPython(t *testing.T) {
 	runTaskTestCases(t,
 		"ods-build-python",
+		[]tasktesting.Service{
+			tasktesting.Bitbucket,
+			tasktesting.Nexus,
+			tasktesting.SonarQube,
+		},
 		map[string]tasktesting.TestCase{
 			"build python fastapi app": {
 				WorkspaceDirMapping: map[string]string{"source": "python-fastapi-sample-app"},

--- a/test/tasks/ods-build-typescript_test.go
+++ b/test/tasks/ods-build-typescript_test.go
@@ -16,6 +16,11 @@ import (
 func TestTaskODSBuildTypescript(t *testing.T) {
 	runTaskTestCases(t,
 		"ods-build-typescript",
+		[]tasktesting.Service{
+			tasktesting.Bitbucket,
+			tasktesting.Nexus,
+			tasktesting.SonarQube,
+		},
 		map[string]tasktesting.TestCase{
 			"build typescript app": {
 				WorkspaceDirMapping: map[string]string{"source": "typescript-sample-app"},

--- a/test/tasks/ods-deploy-helm_external_test.go
+++ b/test/tasks/ods-deploy-helm_external_test.go
@@ -50,6 +50,7 @@ func TestTaskODSDeployHelmExternal(t *testing.T) {
 	var imageStream string
 	runTaskTestCases(t,
 		"ods-deploy-helm",
+		[]tasktesting.Service{},
 		map[string]tasktesting.TestCase{
 			"external deployment": {
 				Timeout:             10 * time.Minute,

--- a/test/tasks/ods-deploy-helm_test.go
+++ b/test/tasks/ods-deploy-helm_test.go
@@ -26,6 +26,7 @@ func TestTaskODSDeployHelm(t *testing.T) {
 	var separateReleaseNamespace string
 	runTaskTestCases(t,
 		"ods-deploy-helm",
+		[]tasktesting.Service{},
 		map[string]tasktesting.TestCase{
 			"should skip when no environment selected": {
 				WorkspaceDirMapping: map[string]string{"source": "helm-sample-app"},

--- a/test/tasks/ods-finish_test.go
+++ b/test/tasks/ods-finish_test.go
@@ -18,6 +18,10 @@ import (
 func TestTaskODSFinish(t *testing.T) {
 	runTaskTestCases(t,
 		"ods-finish",
+		[]tasktesting.Service{
+			tasktesting.Bitbucket,
+			tasktesting.Nexus,
+		},
 		map[string]tasktesting.TestCase{
 			"set bitbucket build status to failed": {
 				WorkspaceDirMapping: map[string]string{"source": "hello-world-app-with-artifacts"},

--- a/test/tasks/ods-package-image_test.go
+++ b/test/tasks/ods-package-image_test.go
@@ -14,6 +14,7 @@ import (
 func TestTaskODSPackageImage(t *testing.T) {
 	runTaskTestCases(t,
 		"ods-package-image",
+		[]tasktesting.Service{},
 		map[string]tasktesting.TestCase{
 			"task should build image": {
 				WorkspaceDirMapping: map[string]string{"source": "hello-world-app"},

--- a/test/tasks/ods-start_test.go
+++ b/test/tasks/ods-start_test.go
@@ -20,6 +20,10 @@ func TestTaskODSStart(t *testing.T) {
 	var subrepoContext *pipelinectxt.ODSContext
 	runTaskTestCases(t,
 		"ods-start",
+		[]tasktesting.Service{
+			tasktesting.Bitbucket,
+			tasktesting.Nexus,
+		},
 		map[string]tasktesting.TestCase{
 			"clones repo": {
 				WorkspaceDirMapping: map[string]string{"source": "hello-world-app"},


### PR DESCRIPTION
This is my try to address #99

For now I have only implemented this in the Gradle test case because I wanted to get your opinion on this implementation first.

To specify which services need to run in order for the test case to be executable one needs to add this to the respective test case:
```go
map[string]tasktesting.TestCase{
  "task foo": {
    ...
    RequiredServices: []string{"Bitbucket", "Nexus", "SonarQube"},
    ...
}
```

Closes #99 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
