### PR TITLE
Fix Helm invocation

### DIFF
--- a/deploy/cd-namespace/install.sh
+++ b/deploy/cd-namespace/install.sh
@@ -61,17 +61,17 @@ else
     fi
 fi
 
-DIFF_UPGRADE_ARGS="diff upgrade"
-UPGRADE_ARGS="upgrade"
+DIFF_UPGRADE_ARGS=(diff upgrade)
+UPGRADE_ARGS=(upgrade)
 if helm plugin list | grep secrets &> /dev/null; then
-    DIFF_UPGRADE_ARGS="secrets diff upgrade"
-    UPGRADE_ARGS="secrets upgrade"
+    DIFF_UPGRADE_ARGS=(secrets diff upgrade)
+    UPGRADE_ARGS=(secrets upgrade)
 fi
 
 echo "Installing Helm release ${RELEASE_NAME} ..."
 if [ "${DIFF}" == "true" ]; then
     if helm -n "${NAMESPACE}" \
-            "${DIFF_UPGRADE_ARGS}" --install --detailed-exitcode \
+            "${DIFF_UPGRADE_ARGS[@]}" --install --detailed-exitcode \
             "${VALUES_ARGS[@]}" \
             ${RELEASE_NAME} ${CHART_DIR}; then
         echo "Helm release already up-to-date."
@@ -80,7 +80,7 @@ if [ "${DIFF}" == "true" ]; then
             echo "(skipping in dry-run)"
         else
             helm -n "${NAMESPACE}" \
-                "${UPGRADE_ARGS}" --install \
+                "${UPGRADE_ARGS[@]}" --install \
                 "${VALUES_ARGS[@]}" \
                 ${RELEASE_NAME} ${CHART_DIR}
         fi
@@ -90,7 +90,7 @@ else
         echo "(skipping in dry-run)"
     else
         helm -n "${NAMESPACE}" \
-            "${UPGRADE_ARGS}" --install \
+            "${UPGRADE_ARGS[@]}" --install \
             "${VALUES_ARGS[@]}" \
             ${RELEASE_NAME} ${CHART_DIR}
     fi

--- a/deploy/central/install.sh
+++ b/deploy/central/install.sh
@@ -72,11 +72,11 @@ if [ "${VERBOSE}" == "true" ]; then
     set -x
 fi
 
-DIFF_UPGRADE_ARGS=("diff upgrade")
-UPGRADE_ARGS=("upgrade")
+DIFF_UPGRADE_ARGS=(diff upgrade)
+UPGRADE_ARGS=(upgrade)
 if helm plugin list | grep secrets &> /dev/null; then
-    DIFF_UPGRADE_ARGS=("secrets diff upgrade")
-    UPGRADE_ARGS=("secrets upgrade")
+    DIFF_UPGRADE_ARGS=(secrets diff upgrade)
+    UPGRADE_ARGS=(secrets upgrade)
 fi
 
 echo "Installing Helm release ${RELEASE_NAME} ..."


### PR DESCRIPTION
The quotes determine what makes up one entry in the array. So e.g.
"secrets upgrade" is seen as one entry, not as two. This leads to:

```
Error: unknown command "secrets upgrade" for "helm"
```

The regression was introduced in #322. ShellCheck is nice, but rule
https://github.com/koalaman/shellcheck/wiki/SC2086 in particular might
cause more problems than it solves ... ?!

FYI @henrjk @henninggross 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
