### PR TITLE
Only handle webhook events related to branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ listed in the changelog.
 - `ods-finish` does not upload artifacts of subrepos ([#257](https://github.com/opendevstack/ods-pipeline/issues/257))
 - Waitfor-...sh scripts are not waiting for the expected 5 minutes ([#280](https://github.com/opendevstack/ods-pipeline/issues/280))
 - Specifying images to be build and pushed is not working anymore due to changes made in [#287](https://github.com/opendevstack/ods-pipeline/pull/287) ([#299](https://github.com/opendevstack/ods-pipeline/issues/299))
+- Tagging in ods-start causes second pipeline run ([#331](https://github.com/opendevstack/ods-pipeline/issues/331))
 
 ## [0.1.1] - 2021-10-28
 ### Fixed

--- a/test/testdata/fixtures/interceptor/payload-tag.json
+++ b/test/testdata/fixtures/interceptor/payload-tag.json
@@ -1,0 +1,74 @@
+{
+    "eventKey": "repo:refs_changed",
+    "date": "2021-01-15T13:29:05+0000",
+    "actor": {
+        "name": "max.mustermann@acme.org",
+        "emailAddress": "max.mustermann@acme.org",
+        "id": 4653,
+        "displayName": "Mustermann,Max ACME",
+        "active": true,
+        "slug": "max.mustermann_acme.org",
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "https://bitbucket.acme.org/users/max.mustermann_acme.org"
+                }
+            ]
+        }
+    },
+    "repository": {
+        "slug": "ods-pipeline",
+        "id": 8733,
+        "name": "ods-pipeline",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+            "key": "FOO",
+            "id": 6603,
+            "name": "Max Mustermann Playground",
+            "public": false,
+            "type": "NORMAL",
+            "links": {
+                "self": [
+                    {
+                        "href": "https://bitbucket.acme.org/projects/FOO"
+                    }
+                ]
+            }
+        },
+        "public": false,
+        "links": {
+            "clone": [
+                {
+                    "href": "https://bitbucket.acme.org/scm/foo/ods-pipeline.git",
+                    "name": "http"
+                },
+                {
+                    "href": "ssh://git@bitbucket.acme.org:7999/foo/ods-pipeline.git",
+                    "name": "ssh"
+                }
+            ],
+            "self": [
+                {
+                    "href": "https://bitbucket.acme.org/projects/FOO/repos/ods-pipeline/browse"
+                }
+            ]
+        }
+    },
+    "changes": [
+        {
+            "ref": {
+                "id": "refs/tags/v2.0.0",
+                "displayId": "v2.0.0",
+                "type": "TAG"
+            },
+            "refId": "refs/heads/master",
+            "fromHash": "dc85ccd8bb912006162e0d1d9f48e1f2d7210c9c",
+            "toHash": "0e183aa3bc3c6deb8f40b93fb2fc4354533cf62f",
+            "type": "UPDATE"
+        }
+    ]
+}

--- a/test/testdata/fixtures/interceptor/payload-unknown-event.json
+++ b/test/testdata/fixtures/interceptor/payload-unknown-event.json
@@ -1,0 +1,74 @@
+{
+    "eventKey": "repo:ref_changed",
+    "date": "2021-01-15T13:29:05+0000",
+    "actor": {
+        "name": "max.mustermann@acme.org",
+        "emailAddress": "max.mustermann@acme.org",
+        "id": 4653,
+        "displayName": "Mustermann,Max ACME",
+        "active": true,
+        "slug": "max.mustermann_acme.org",
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "https://bitbucket.acme.org/users/max.mustermann_acme.org"
+                }
+            ]
+        }
+    },
+    "repository": {
+        "slug": "ods-pipeline",
+        "id": 8733,
+        "name": "ods-pipeline",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+            "key": "FOO",
+            "id": 6603,
+            "name": "Max Mustermann Playground",
+            "public": false,
+            "type": "NORMAL",
+            "links": {
+                "self": [
+                    {
+                        "href": "https://bitbucket.acme.org/projects/FOO"
+                    }
+                ]
+            }
+        },
+        "public": false,
+        "links": {
+            "clone": [
+                {
+                    "href": "https://bitbucket.acme.org/scm/foo/ods-pipeline.git",
+                    "name": "http"
+                },
+                {
+                    "href": "ssh://git@bitbucket.acme.org:7999/foo/ods-pipeline.git",
+                    "name": "ssh"
+                }
+            ],
+            "self": [
+                {
+                    "href": "https://bitbucket.acme.org/projects/FOO/repos/ods-pipeline/browse"
+                }
+            ]
+        }
+    },
+    "changes": [
+        {
+            "ref": {
+                "id": "refs/heads/master",
+                "displayId": "master",
+                "type": "BRANCH"
+            },
+            "refId": "refs/heads/master",
+            "fromHash": "dc85ccd8bb912006162e0d1d9f48e1f2d7210c9c",
+            "toHash": "0e183aa3bc3c6deb8f40b93fb2fc4354533cf62f",
+            "type": "UPDATE"
+        }
+    ]
+}


### PR DESCRIPTION
We do not know what to do with triggers from tags right now so we better
refuse to handle it for now. Otherwise we trigger another pipeline run
when we apply Git tags in ods-start.

Fixes #331.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
