### PR TITLE
Upgrade to JDK 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ listed in the changelog.
 - Update gcc (from 8.4 to 8.5), skopeo (from 1.3 to 1.4) and buildah (from 1.21 to 1.22) in container images ([#276](https://github.com/opendevstack/ods-pipeline/pull/276))
 - Iterating over Dockerfiles in `build/package` instead of using hardcoded list ([#286](https://github.com/opendevstack/ods-pipeline/issues/286) and [#287](https://github.com/opendevstack/ods-pipeline/pull/287))
 - Upgrade Python toolset to v3.9, with migration from Flask to FastAPI sample app ([#312](https://github.com/opendevstack/ods-pipeline/issues/312))
+- Upgrade Java toolset to JDK 17 ([#294](https://github.com/opendevstack/ods-pipeline/issues/294))
 
 ### Fixed
 

--- a/build/package/Dockerfile.gradle-toolset
+++ b/build/package/Dockerfile.gradle-toolset
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.10
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.10
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/deploy/central/images-chart/templates/bc-ods-gradle-toolset.yaml
+++ b/deploy/central/images-chart/templates/bc-ods-gradle-toolset.yaml
@@ -17,7 +17,7 @@ spec:
       dockerfilePath: build/package/Dockerfile.gradle-toolset
       from:
         kind: DockerImage
-        name: 'registry.redhat.io/ubi8/openjdk-11:1.10'
+        name: 'registry.redhat.io/ubi8/openjdk-17:1.10'
       pullSecret:
         name: registry.redhat.io
   postCommit: {}

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -120,7 +120,7 @@ Input parameters:
 
 | SDS-TASK-5
 | `ods-gradle-toolset` contaner image
-| Container image for building Gradle modules. Based on `ubi8/openjdk-11` (SDS-EXT-11), includes SDS-EXT-12, SDS-SHARED-3, SDS-TASK-6 and SDS-TASK-26.
+| Container image for building Gradle modules. Based on `ubi8/openjdk-17` (SDS-EXT-11), includes SDS-EXT-12, SDS-SHARED-3, SDS-TASK-6 and SDS-TASK-26.
 
 | SDS-TASK-6
 | `build-gradle.sh` shell script
@@ -433,15 +433,15 @@ For all repositories in scope, the artifacts in the corresponding groups in Nexu
 
 | SDS-EXT-10
 | OpenJDK Headless
-| 11
-| Reference implementation of version 11 of the Java SE Platform.
-| https://openjdk.java.net/projects/jdk/11/
+| 17
+| Reference implementation of version 17 of the Java SE Platform.
+| https://openjdk.java.net/projects/jdk/17/
 
 | SDS-EXT-11
-| Red Hat OpenJDK 11 Image
+| Red Hat OpenJDK 17 Image
 | 1.10
-| OpenJDK 11 container is a base platform for building and running plain Java 11 applications, e.g. fat-jar and flat classpath.
-| https://catalog.redhat.com/software/containers/ubi8/openjdk-11/5dd6a4b45a13461646f677f4
+| OpenJDK 17 container is a base platform for building and running plain Java 17 applications, e.g. fat-jar and flat classpath.
+| https://catalog.redhat.com/software/containers/ubi8/openjdk-17/618bdbf34ae3739687568813
 
 | SDS-EXT-12
 | Gradle
@@ -534,6 +534,11 @@ The following table provides the history of the document.
 [cols="1,1,1,3"]
 |===
 | Version | Date | Author | Change
+
+| 0.6
+| 2021-12-15
+| Andreas Kübler
+| Updated JDK version.
 
 | 0.5
 | 2021-12-10

--- a/test/testdata/workspaces/gradle-sample-app/docker/Dockerfile
+++ b/test/testdata/workspaces/gradle-sample-app/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk-alpine
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.10
 
 COPY app.jar app.jar
 

--- a/test/testdata/workspaces/gradle-sample-app/docker/Dockerfile
+++ b/test/testdata/workspaces/gradle-sample-app/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM eclipse-temurin:17-jdk-alpine
 
 COPY app.jar app.jar
 


### PR DESCRIPTION
Upgrade graldle image and test to JDK 17. Adoptopendjk is retired, so use its successsor eclipse-temurin in the test cases. Sonarqube image couldn't be upgrade since Sonarqube does only support Java 11 so far.

Closes 294

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
