### PR TITLE
Set image.tag and fullnameOverride values via CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ listed in the changelog.
 - Iterating over Dockerfiles in `build/package` instead of using hardcoded list ([#286](https://github.com/opendevstack/ods-pipeline/issues/286) and [#287](https://github.com/opendevstack/ods-pipeline/pull/287))
 - Upgrade Python toolset to v3.9, with migration from Flask to FastAPI sample app ([#312](https://github.com/opendevstack/ods-pipeline/issues/312))
 - Upgrade Java toolset to JDK 17 ([#294](https://github.com/opendevstack/ods-pipeline/issues/294))
+- Set Helm value `image.tag` instead of `gitCommitSha` ([#342](https://github.com/opendevstack/ods-pipeline/pull/342))
 
 ### Fixed
 
@@ -38,6 +39,8 @@ listed in the changelog.
 - `ods-finish` does not upload artifacts of subrepos ([#257](https://github.com/opendevstack/ods-pipeline/issues/257))
 - Waitfor-...sh scripts are not waiting for the expected 5 minutes ([#280](https://github.com/opendevstack/ods-pipeline/issues/280))
 - Tagging in ods-start causes second pipeline run ([#331](https://github.com/opendevstack/ods-pipeline/issues/331))
+- Helm resource names differ between component and umbrella repository ([#340](https://github.com/opendevstack/ods-pipeline/issues/340))
+
 
 ## [0.1.1] - 2021-10-28
 ### Fixed

--- a/deploy/central/tasks-chart/templates/task-ods-deploy-helm.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-deploy-helm.yaml
@@ -9,14 +9,17 @@ spec:
     This tasks will install / upgrade a Helm chart into your Kubernetes /
     OpenShift cluster using Helm.
 
-    Helm has the plugins `helm-diff` and `helm-secrets` installed. A diff is performed
-    before an upgrade is attempted. `helm-secrets` can be used to encrypt sensitive
-    values in the underlying Git repository. Secrets are decrypted on the fly if the secret
-    identified by the `age-key-secret` parameter exists, and contains an age secret key
-    which public key was used as one of the recipients to encrypt.
+    Helm has the plugins `helm-diff` and `helm-secrets` installed. A diff is
+    performed before an upgrade is attempted. `helm-secrets` can be used to
+    encrypt sensitive values in the underlying Git repository using
+    https://age-encryption.org[age]. Secrets are decrypted on the fly if the
+    secret identified by the `age-key-secret` parameter exists and contains an
+    age secret key which corresponding public key was used as one of the
+    recipients to encrypt.
 
-    Based on the target environment, some values files are added automatically to the
-    invocation of the `helm` command if they are present in the chart directory:
+    Based on the target environment, some values files are added automatically
+    to the invocation of the `helm` command if they are present in the chart
+    directory:
 
     - `values.yaml`: the values file (automatically considered by Helm).
     - `secrets.yaml`: a secrets file.
@@ -25,21 +28,30 @@ spec:
     - `values.<ENVIRONMENT>.yaml`: a values file named after the name of the target environment.
     - `secrets.<ENVIRONMENT>.yaml`: a secrets file named after the name of the target environment.
 
-    Further, the task adds a `values.generated.yaml` file. This values file
-    contains only one value, `gitCommitSha`, which contains the Git commit SHA being built. It is
-    provided by the task as this value cannot be known by value file authors in advance. Use this
-    value to set e.g. the image tags in `Deployment` resources, like this: `{{.Values.gitCommitSha}}`.
+    Further, the task automatically sets the `image.tag` value on the CLI which
+    equals the Git commit SHA being built. This value can be used in your Helm
+    templates to refer to images built via `ods-package-image`.
 
-    Before the Helm chart is applied, it is packaged, setting the `appVersion` to the Git commit SHA
-    and the `version` to the externally provided version, if any. If `version` is not given, the value
-    in `Chart.yaml` is used as-is.
+    Before the Helm chart is applied, it is packaged, setting the `appVersion`
+    to the Git commit SHA and the `version` to the externally provided version,
+    if any. If `version` is not given, the value in `Chart.yaml` is used as-is.
 
-    If the pipeline runs for a repository defining subrepos in its `ods.y(a)ml` file, then any charts in
-    those subrepos are packaged as well, and added as dependencies to the top-most chart under `charts/`.
-    Note that values and secrets files are only collected from the repository for which the pipeline runs.
-    This means that if you use an umbrella repository to promote an application from a `dev` stage to `qa`
-    and `prod`, the umbrella repository needs to define the stage/environment specific values for
-    the subcomponents  for `qa`/`prod` instead of having those files in the subrepo.
+    If the pipeline runs for a repository defining subrepos in its `ods.y(a)ml`
+    file, then any charts in those subrepos are packaged as well, and added as
+    dependencies to the top-most chart under `charts/`. Note that values and
+    secrets files are only collected from the repository for which the pipeline
+    runs. Therefore, if you use an umbrella repository to promote an
+    application from a `dev` stage to `qa` and `prod`, the umbrella repository
+    needs to define the stage/environment specific values for the subcomponents
+    for `qa`/`prod` instead of having those files in the subrepo.
+
+    In order to produce correct `image.tag` values for subcomponents, the task
+    automatically sets `<subcomponent>.image.tag` equal to the Git commit SHA of
+    the subcomponent. Further, if no release name is explicitly configured, the
+    task also sets `<subcomponent>.fullnameOverride` equal to the respective
+    subcomponent to avoid resources being prefixed with the umbrella repository
+    component name (assuming your resources are named using the `chart.fullname`
+    helper).
   params:
     - name: chart-dir
       description: Helm chart directory that will be deployed

--- a/docs/tasks/ods-deploy-helm.adoc
+++ b/docs/tasks/ods-deploy-helm.adoc
@@ -7,14 +7,17 @@ Deploy Helm charts.
 This tasks will install / upgrade a Helm chart into your Kubernetes /
 OpenShift cluster using Helm.
 
-Helm has the plugins `helm-diff` and `helm-secrets` installed. A diff is performed
-before an upgrade is attempted. `helm-secrets` can be used to encrypt sensitive
-values in the underlying Git repository. Secrets are decrypted on the fly if the secret
-identified by the `age-key-secret` parameter exists, and contains an age secret key
-which public key was used as one of the recipients to encrypt.
+Helm has the plugins `helm-diff` and `helm-secrets` installed. A diff is
+performed before an upgrade is attempted. `helm-secrets` can be used to
+encrypt sensitive values in the underlying Git repository using
+https://age-encryption.org[age]. Secrets are decrypted on the fly if the
+secret identified by the `age-key-secret` parameter exists and contains an
+age secret key which corresponding public key was used as one of the
+recipients to encrypt.
 
-Based on the target environment, some values files are added automatically to the
-invocation of the `helm` command if they are present in the chart directory:
+Based on the target environment, some values files are added automatically
+to the invocation of the `helm` command if they are present in the chart
+directory:
 
 - `values.yaml`: the values file (automatically considered by Helm).
 - `secrets.yaml`: a secrets file.
@@ -23,21 +26,30 @@ invocation of the `helm` command if they are present in the chart directory:
 - `values.<ENVIRONMENT>.yaml`: a values file named after the name of the target environment.
 - `secrets.<ENVIRONMENT>.yaml`: a secrets file named after the name of the target environment.
 
-Further, the task adds a `values.generated.yaml` file. This values file
-contains only one value, `gitCommitSha`, which contains the Git commit SHA being built. It is
-provided by the task as this value cannot be known by value file authors in advance. Use this
-value to set e.g. the image tags in `Deployment` resources, like this: ``.
+Further, the task automatically sets the `image.tag` value on the CLI which
+equals the Git commit SHA being built. This value can be used in your Helm
+templates to refer to images built via `ods-package-image`.
 
-Before the Helm chart is applied, it is packaged, setting the `appVersion` to the Git commit SHA
-and the `version` to the externally provided version, if any. If `version` is not given, the value
-in `Chart.yaml` is used as-is.
+Before the Helm chart is applied, it is packaged, setting the `appVersion`
+to the Git commit SHA and the `version` to the externally provided version,
+if any. If `version` is not given, the value in `Chart.yaml` is used as-is.
 
-If the pipeline runs for a repository defining subrepos in its `ods.y(a)ml` file, then any charts in
-those subrepos are packaged as well, and added as dependencies to the top-most chart under `charts/`.
-Note that values and secrets files are only collected from the repository for which the pipeline runs.
-This means that if you use an umbrella repository to promote an application from a `dev` stage to `qa`
-and `prod`, the umbrella repository needs to define the stage/environment specific values for
-the subcomponents  for `qa`/`prod` instead of having those files in the subrepo.
+If the pipeline runs for a repository defining subrepos in its `ods.y(a)ml`
+file, then any charts in those subrepos are packaged as well, and added as
+dependencies to the top-most chart under `charts/`. Note that values and
+secrets files are only collected from the repository for which the pipeline
+runs. Therefore, if you use an umbrella repository to promote an
+application from a `dev` stage to `qa` and `prod`, the umbrella repository
+needs to define the stage/environment specific values for the subcomponents
+for `qa`/`prod` instead of having those files in the subrepo.
+
+In order to produce correct `image.tag` values for subcomponents, the task
+automatically sets `<subcomponent>.image.tag` equal to the Git commit SHA of
+the subcomponent. Further, if no release name is explicitly configured, the
+task also sets `<subcomponent>.fullnameOverride` equal to the respective
+subcomponent to avoid resources being prefixed with the umbrella repository
+component name (assuming your resources are named using the `chart.fullname`
+helper).
 
 
 == Parameters

--- a/test/tasks/ods-deploy-helm_test.go
+++ b/test/tasks/ods-deploy-helm_test.go
@@ -129,7 +129,7 @@ func TestTaskODSDeployHelm(t *testing.T) {
 						t.Fatal(err)
 					}
 					// Subchart
-					subChartResourceName := fmt.Sprintf("%s-%s", ctxt.ODS.Component, "helm-sample-database")
+					subChartResourceName := "helm-sample-database" // fixed name due to fullnameOverride
 					_, err = checkService(ctxt.Clients.KubernetesClientSet, ctxt.Namespace, subChartResourceName)
 					if err != nil {
 						t.Fatal(err)

--- a/test/testdata/workspaces/helm-app-with-dependencies/.ods/repos/database/chart/templates/deployment.yaml
+++ b/test/testdata/workspaces/helm-app-with-dependencies/.ods/repos/database/chart/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: {{.Chart.Name}}
           securityContext: {}
-          image: "{{.Values.image.registry}}/{{.Values.image.namespace | default .Release.Namespace}}/{{.Values.image.repository | default .Chart.Name}}:{{.Values.image.tag | default .Chart.AppVersion}}"
+          image: "{{.Values.image.registry}}/{{.Values.image.namespace | default .Release.Namespace}}/{{.Values.image.repository | default .Chart.Name}}"
           imagePullPolicy: {{.Values.image.pullPolicy}}
           env:
           - name: USERNAME

--- a/test/testdata/workspaces/helm-app-with-dependencies/.ods/repos/database/chart/values.yaml
+++ b/test/testdata/workspaces/helm-app-with-dependencies/.ods/repos/database/chart/values.yaml
@@ -11,8 +11,6 @@ image:
   # Overrides the image repository whose default is the chart name.
   repository: hello-world
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
 
 nameOverride: ""
 fullnameOverride: ""

--- a/test/testdata/workspaces/helm-app-with-dependencies/chart/templates/deployment.yaml
+++ b/test/testdata/workspaces/helm-app-with-dependencies/chart/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: {{.Chart.Name}}
           securityContext: {}
-          image: "{{.Values.image.registry}}/{{.Values.image.namespace | default .Release.Namespace}}/{{.Values.image.repository | default .Chart.Name}}:{{.Values.image.tag | default .Chart.AppVersion}}"
+          image: "{{.Values.image.registry}}/{{.Values.image.namespace | default .Release.Namespace}}/{{.Values.image.repository | default .Chart.Name}}"
           imagePullPolicy: {{.Values.image.pullPolicy}}
           ports:
             - name: http

--- a/test/testdata/workspaces/helm-app-with-dependencies/chart/values.yaml
+++ b/test/testdata/workspaces/helm-app-with-dependencies/chart/values.yaml
@@ -11,8 +11,6 @@ image:
   # Overrides the image repository whose default is the chart name.
   repository: hello-world
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
 
 nameOverride: ""
 fullnameOverride: ""

--- a/test/testdata/workspaces/helm-sample-app/chart/templates/deployment.yaml
+++ b/test/testdata/workspaces/helm-sample-app/chart/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: {{.Chart.Name}}
           securityContext: {}
-          image: "{{.Values.image.registry}}/{{.Values.image.namespace | default .Release.Namespace}}/{{.Values.image.repository | default .Chart.Name}}:{{.Values.image.tag | default .Chart.AppVersion}}"
+          image: "{{.Values.image.registry}}/{{.Values.image.namespace | default .Release.Namespace}}/{{.Values.image.repository | default .Chart.Name}}"
           imagePullPolicy: {{.Values.image.pullPolicy}}
           ports:
             - name: http

--- a/test/testdata/workspaces/helm-sample-app/chart/values.yaml
+++ b/test/testdata/workspaces/helm-sample-app/chart/values.yaml
@@ -11,8 +11,6 @@ image:
   # Overrides the image repository whose default is the chart name.
   repository: hello-world
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Replaces setting gitCommitSha to control the image tag and adds
fullnameOverride to avoid resource prefixes for umbrella repos.

Closes #340.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
