### PR TITLE
Set CI=true in build tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ listed in the changelog.
 - Provided make target for ShellCheck and added ShellCheck to GitHub actions ([#240](https://github.com/opendevstack/ods-pipeline/issues/240))
 - Supply default `sonar-project.properties` when none is present, configuring SonarQube out-of-the-box ([#296](https://github.com/opendevstack/ods-pipeline/issues/296))
 - Linting stage in TypeScript build task ([#325](https://github.com/opendevstack/ods-pipeline/issues/325))
+- Set `CI=true` in build tasks ([#336](https://github.com/opendevstack/ods-pipeline/issues/336))
 
 ### Changed
 

--- a/deploy/central/tasks-chart/templates/task-ods-build-go-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-go-with-sidecar.yaml
@@ -86,6 +86,8 @@ spec:
   - env:
     - name: HOME
       value: /tekton/home
+    - name: CI
+      value: "true"
     - name: DEBUG
       valueFrom:
         configMapKeyRef:

--- a/deploy/central/tasks-chart/templates/task-ods-build-go.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-go.yaml
@@ -72,6 +72,8 @@ spec:
       env:
         - name: HOME
           value: '/tekton/home'
+        - name: CI
+          value: "true"
         - name: DEBUG
           valueFrom:
             configMapKeyRef:

--- a/deploy/central/tasks-chart/templates/task-ods-build-gradle-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-gradle-with-sidecar.yaml
@@ -137,6 +137,8 @@ spec:
           name: ods-pipeline
     - name: HOME
       value: /tekton/home
+    - name: CI
+      value: "true"
     image: '{{.Values.registry}}/{{.Values.namespace}}/ods-gradle-toolset:{{.Values.imageTag}}'
     name: build-gradle-binary
     resources: {}

--- a/deploy/central/tasks-chart/templates/task-ods-build-gradle.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-gradle.yaml
@@ -127,6 +127,8 @@ spec:
               name: ods-pipeline
         - name: HOME
           value: '/tekton/home'
+        - name: CI
+          value: "true"
       resources: {}
       script: |
         # build-gradle is build/package/scripts/build-gradle.sh.

--- a/deploy/central/tasks-chart/templates/task-ods-build-python-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-python-with-sidecar.yaml
@@ -63,6 +63,8 @@ spec:
   - env:
     - name: HOME
       value: /tekton/home
+    - name: CI
+      value: "true"
     - name: NEXUS_URL
       valueFrom:
         configMapKeyRef:

--- a/deploy/central/tasks-chart/templates/task-ods-build-python.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-python.yaml
@@ -51,6 +51,8 @@ spec:
       env:
         - name: HOME
           value: '/tekton/home'
+        - name: CI
+          value: "true"
         - name: NEXUS_URL
           valueFrom:
             configMapKeyRef:

--- a/deploy/central/tasks-chart/templates/task-ods-build-typescript-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-typescript-with-sidecar.yaml
@@ -76,6 +76,8 @@ spec:
   - env:
     - name: HOME
       value: /tekton/home
+    - name: CI
+      value: "true"
     - name: NEXUS_URL
       valueFrom:
         configMapKeyRef:

--- a/deploy/central/tasks-chart/templates/task-ods-build-typescript.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-typescript.yaml
@@ -65,6 +65,8 @@ spec:
       env:
         - name: HOME
           value: '/tekton/home'
+        - name: CI
+          value: "true"
         - name: NEXUS_URL
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
Closes #336.

Follow-up for documentation is at #344.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
