### PR TITLE
Use ubi8/go-toolset as consistent builder image and as image for the ods-build-go task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ listed in the changelog.
 - Upgrade Java toolset to JDK 17 ([#294](https://github.com/opendevstack/ods-pipeline/issues/294))
 - Set Helm value `image.tag` instead of `gitCommitSha` ([#342](https://github.com/opendevstack/ods-pipeline/pull/342))
 - Provide TypeScript toolset with Node.js 16 ([#337](https://github.com/opendevstack/ods-pipeline/issues/337))
+- Use `ubi8/go-toolset` as consistent builder image and as image for the `ods-build-go` task ([#295](https://github.com/opendevstack/ods-pipeline/issues/295))
 
 ### Fixed
 

--- a/build/package/Dockerfile.buildah
+++ b/build/package/Dockerfile.buildah
@@ -1,27 +1,16 @@
-FROM registry.access.redhat.com/ubi8 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12 AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-ENV GO_VERSION 1.16.3
-RUN yum install -y git && rm -rf /var/cache /var/log/dnf* /var/log/yum.*
-RUN cd /tmp && \
-    curl -LO https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go$GO_VERSION.linux-amd64.tar.gz && \
-    rm -f *.tar.gz && \
-    cd - && \
-    mkdir /go
-ENV PATH $PATH:/usr/local/go/bin
-ENV GOBIN /usr/local/bin
-RUN chmod g+w /go
+USER root
 
 # Add Go binaries
-RUN mkdir -p /etc/go
-COPY go.* /etc/go/
-COPY cmd /etc/go/cmd
-COPY internal /etc/go/internal
-COPY pkg /etc/go/pkg
-RUN cd /etc/go/cmd/build-push-image && CGO_ENABLED=0 go build -o /usr/local/bin/ods-build-push-image
+COPY go.* .
+COPY cmd cmd
+COPY internal internal
+COPY pkg pkg
+RUN cd cmd/build-push-image && CGO_ENABLED=0 go build -o /usr/local/bin/ods-build-push-image
 
+# Final image
 # Copied from https://catalog.redhat.com/software/containers/detail/5dca3d76dd19c71643b226d5?container-tabs=dockerfile&tag=8.4&push_date=1621383358000.
 FROM registry.access.redhat.com/ubi8:8.4
 

--- a/build/package/Dockerfile.finish
+++ b/build/package/Dockerfile.finish
@@ -1,28 +1,16 @@
-FROM registry.access.redhat.com/ubi8 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12 AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-ENV GO_VERSION 1.16.3
-RUN yum install -y git && rm -rf /var/cache /var/log/dnf* /var/log/yum.*
-RUN cd /tmp && \
-    curl -LO https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go$GO_VERSION.linux-amd64.tar.gz && \
-    rm -f *.tar.gz && \
-    cd - && \
-    mkdir /go
-ENV PATH $PATH:/usr/local/go/bin
-ENV GOBIN /usr/local/bin
-RUN chmod g+w /go
+USER root
 
 # Add Go binaries
-RUN mkdir -p /etc/go
-COPY go.* /etc/go/
-COPY cmd /etc/go/cmd
-COPY internal /etc/go/internal
-COPY pkg /etc/go/pkg
-RUN cd /etc/go/cmd/finish && CGO_ENABLED=0 go build -o /usr/local/bin/ods-finish
+COPY go.* .
+COPY cmd cmd
+COPY internal internal
+COPY pkg pkg
+RUN cd cmd/finish && CGO_ENABLED=0 go build -o /usr/local/bin/ods-finish
 
+# Final image
 # ubi-micro cannot be used as it misses the ca-certificates package.
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 COPY --from=builder /usr/local/bin/ods-finish /usr/local/bin/ods-finish
-WORKDIR /go

--- a/build/package/Dockerfile.go-toolset
+++ b/build/package/Dockerfile.go-toolset
@@ -1,30 +1,15 @@
-FROM registry.access.redhat.com/ubi8:8.4
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+USER root
 
-ENV GO_VERSION=1.16.3 \
-    GOLANGCI_LINT_VERSION=v1.41.1 \
+ENV GOLANGCI_LINT_VERSION=v1.41.1 \
     GO_JUNIT_REPORT_VERSION=v0.9.1 \
-    GIT_VERSION=2.27 \
-    GCC_VERSION=8.5
-
-RUN yum install -y gcc-${GCC_VERSION}* gcc-c++-${GCC_VERSION}* git-${GIT_VERSION}*
-
-RUN cd /tmp && \
-    curl -LO https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go$GO_VERSION.linux-amd64.tar.gz && \
-    rm -f *.tar.gz && \
-    cd - && \
-    mkdir /go
-
-ENV PATH $PATH:/usr/local/go/bin
-ENV GOBIN /usr/local/bin
+    GOBIN=/usr/local/bin
 
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$GOLANGCI_LINT_VERSION/install.sh | sh -s -- -b /usr/local/bin $GOLANGCI_LINT_VERSION
 
 RUN go get github.com/jstemmer/go-junit-report@$GO_JUNIT_REPORT_VERSION
-
-RUN chmod g+w /go
 
 # Add scripts
 COPY build/package/scripts/build-go.sh /usr/local/bin/build-go
@@ -35,4 +20,4 @@ RUN chmod +x /usr/local/bin/build-go && \
 # Add sonar-project.properties
 COPY build/package/sonar-project.properties.d/go.properties /usr/local/default-sonar-project.properties
 
-WORKDIR /go
+USER default

--- a/build/package/Dockerfile.helm
+++ b/build/package/Dockerfile.helm
@@ -1,23 +1,12 @@
-FROM registry.access.redhat.com/ubi8 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12 AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+USER root
 
-ENV GO_VERSION=1.16.3 \
-    HELM_VERSION=3.5.2 \
+ENV HELM_VERSION=3.5.2 \
     SOPS_VERSION=3.7.1 \
-    AGE_VERSION=1.0.0
-
-RUN cd /tmp && \
-    curl -LO https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go$GO_VERSION.linux-amd64.tar.gz && \
-    rm -f *.tar.gz && \
-    cd - && \
-    mkdir /go
-
-ENV PATH=$PATH:/usr/local/go/bin
-ENV GOBIN=/usr/local/bin
-
-RUN chmod g+w /go
+    AGE_VERSION=1.0.0 \
+    GOBIN=/usr/local/bin
 
 # Install Helm.
 RUN mkdir -p /tmp/helm \
@@ -27,29 +16,27 @@ RUN mkdir -p /tmp/helm \
     && mv /tmp/helm/linux-amd64/helm /usr/local/bin/helm \
     && chmod a+x /usr/local/bin/helm \
     && helm version \
-    && helm env \
-    && rm -rf /tmp/helm
+    && helm env
 
-# Add Go binaries
-RUN mkdir -p /etc/go
-COPY go.* /etc/go/
-COPY cmd /etc/go/cmd
-COPY internal /etc/go/internal
-COPY pkg /etc/go/pkg
-RUN cd /etc/go/cmd/deploy-with-helm && CGO_ENABLED=0 go build -o /usr/local/bin/deploy-with-helm
+# Add Go binaries.
+COPY go.* .
+COPY cmd cmd
+COPY internal internal
+COPY pkg pkg
+RUN cd cmd/deploy-with-helm && CGO_ENABLED=0 go build -o /usr/local/bin/deploy-with-helm
 
-# Add sops
+# Install sops.
 RUN mkdir -p /tmp/sops \
     && cd /tmp/sops \
     && curl -LO https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-${SOPS_VERSION}-1.x86_64.rpm \
     && yum install -y sops-${SOPS_VERSION}-1.x86_64.rpm \
-    && sops --version \
-    && rm -rf /tmp/sops
+    && sops --version
 
-# Add age
+# Install age.
 RUN go install filippo.io/age/cmd/...@v${AGE_VERSION} \
     && age --version
 
+# Final image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ENV HELM_PLUGIN_DIFF_VERSION=3.1.3 \

--- a/build/package/Dockerfile.sonar
+++ b/build/package/Dockerfile.sonar
@@ -1,38 +1,19 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12 AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+USER root
 
 ARG sonarEdition=community
 
 ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     CNES_REPORT_VERSION=3.2.2 \
-    GO_VERSION=1.16 \
-    GIT_VERSION=2.27 \
     SONAR_EDITION=$sonarEdition
-
-USER root
-
-RUN microdnf install -y git-${GIT_VERSION}*
-
-RUN cd /tmp && \
-    curl -LO https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go$GO_VERSION.linux-amd64.tar.gz && \
-    rm -f *.tar.gz && \
-    cd - && \
-    mkdir /go
-
-ENV PATH $PATH:/usr/local/go/bin
-ENV GOBIN /usr/local/bin
-
-RUN chmod g+w /go
 
 # Install Sonar Scanner.
 RUN cd /tmp \
     && curl -LO https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/${SONAR_SCANNER_VERSION}/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
     && unzip sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
-    && mv sonar-scanner-${SONAR_SCANNER_VERSION} /usr/local/sonar-scanner-cli \
-    && rm -rf sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
-    && /usr/local/sonar-scanner-cli/bin/sonar-scanner --version
+    && mv sonar-scanner-${SONAR_SCANNER_VERSION} /usr/local/sonar-scanner-cli
 
 # Install CNES report.
 RUN cd /tmp \
@@ -41,14 +22,14 @@ RUN cd /tmp \
     && mv cnesreport.jar /usr/local/cnes/cnesreport.jar \
     && chmod +x /usr/local/cnes/cnesreport.jar
 
-# Add Go binaries
-RUN mkdir -p /etc/go
-COPY go.* /etc/go/
-COPY cmd /etc/go/cmd
-COPY internal /etc/go/internal
-COPY pkg /etc/go/pkg
-RUN cd /etc/go/cmd/sonar && CGO_ENABLED=0 go build -o /usr/local/bin/sonar
+# Add Go binaries.
+COPY go.* .
+COPY cmd cmd
+COPY internal internal
+COPY pkg pkg
+RUN cd cmd/sonar && CGO_ENABLED=0 go build -o /usr/local/bin/sonar
 
+# Final image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 RUN microdnf install --nodocs java-11-openjdk-headless which && microdnf clean all
@@ -58,5 +39,3 @@ COPY --from=builder /usr/local/sonar-scanner-cli /usr/local/sonar-scanner-cli
 COPY --from=builder /usr/local/cnes/cnesreport.jar /usr/local/cnes/cnesreport.jar
 
 ENV PATH=/usr/local/sonar-scanner-cli/bin:$PATH
-
-WORKDIR /go

--- a/build/package/Dockerfile.start
+++ b/build/package/Dockerfile.start
@@ -1,32 +1,17 @@
-FROM registry.access.redhat.com/ubi8 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12 AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+USER root
 
-ENV GO_VERSION=1.16.3 \
-    TEKTON_VERSION=0.24.0 \
+ENV TEKTON_VERSION=0.24.0 \
     TEKTONCD_PATH=/opt/app-root/src/go/src/github.com/tektoncd \
     BINARY=git-init.orig \
     KO_APP=/ko-app
-
-USER root
-
-RUN cd /tmp && \
-    curl -LO https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go$GO_VERSION.linux-amd64.tar.gz && \
-    rm -f *.tar.gz && \
-    cd - && \
-    mkdir /go
-
-ENV PATH $PATH:/usr/local/go/bin
-ENV GOBIN /usr/local/bin
-
-RUN chmod g+w /go
 
 RUN mkdir -p $TEKTONCD_PATH && \
     cd /tmp && \
     curl -LO https://github.com/tektoncd/pipeline/archive/refs/tags/v$TEKTON_VERSION.tar.gz && \
     tar -C $TEKTONCD_PATH -xzf v$TEKTON_VERSION.tar.gz && \
-    rm -f *.tar.gz && \
     ln -s $TEKTONCD_PATH/pipeline-$TEKTON_VERSION $TEKTONCD_PATH/pipeline && \
     cd -
 
@@ -43,6 +28,7 @@ COPY internal /etc/go/internal
 COPY pkg /etc/go/pkg
 RUN cd /etc/go/cmd/start && CGO_ENABLED=0 go build -o /usr/local/bin/ods-start
 
+# Final image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ENV GIT_VERSION=2.27 \

--- a/build/package/Dockerfile.webhook-interceptor
+++ b/build/package/Dockerfile.webhook-interceptor
@@ -1,12 +1,16 @@
-FROM golang:1.16-alpine AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12 AS builder
 
-RUN mkdir -p /etc/go
-COPY go.* /etc/go/
-COPY cmd /etc/go/cmd
-COPY internal /etc/go/internal
-COPY pkg /etc/go/pkg
-RUN cd /etc/go/cmd/webhook-interceptor && CGO_ENABLED=0 go build -o /usr/local/bin/webhook-interceptor
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+USER root
 
+# Add Go binaries
+COPY go.* .
+COPY cmd cmd
+COPY internal internal
+COPY pkg pkg
+RUN cd cmd/webhook-interceptor && CGO_ENABLED=0 go build -o /usr/local/bin/webhook-interceptor
+
+# Final image
 # ubi-micro cannot be used as it misses the ca-certificates package.
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 

--- a/deploy/central/images-chart/templates/bc-ods-go-toolset.yaml
+++ b/deploy/central/images-chart/templates/bc-ods-go-toolset.yaml
@@ -17,7 +17,7 @@ spec:
       dockerfilePath: build/package/Dockerfile.go-toolset
       from:
         kind: DockerImage
-        name: 'registry.redhat.io/ubi8:8.4'
+        name: 'registry.redhat.io/ubi8/go-toolset:1.16.12'
       pullSecret:
         name: registry.redhat.io
   postCommit: {}

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -32,7 +32,7 @@ As described in the architecture, the system is split into two main containers: 
 |===
 | SDS-SHARED-1
 | `ods-sonar` container image
-| Container image for SQ scanning. Based on `ubi8/ubi-minimal` (SDS-EXT-2), includes software to analyze source code statically (SDS-SHARED-2, SDS-EXT-7, SDS-EXT-8 and SDS-EXT-9).
+| Container image for SQ scanning. Based on `ubi8/ubi-minimal` (SDS-EXT-2), includes software to analyze source code statically (SDS-SHARED-2, SDS-EXT-7 and SDS-EXT-8).
 
 | SDS-SHARED-2
 | `sonar` binary
@@ -77,7 +77,7 @@ Input parameters:
 
 | SDS-TASK-2
 | `ods-go-toolset` contaner image
-| Container image for building Go applications. Based on `ubi8` (SDS-EXT-1), includes SDS-EXT-3, SDS-EXT-4,EXT- SDS-EXT-5, SDS-EXT-6, SDS-EXT-9, SDS-SHARED-3, SDS-TASK-3 and SDS-TASK-25.
+| Container image for building Go applications. Based on `ubi8/go-toolset` (SDS-EXT-25), includes SDS-EXT-4,EXT- SDS-EXT-5, SDS-SHARED-3, SDS-TASK-3 and SDS-TASK-25.
 
 | SDS-TASK-3
 | `build-go.sh` shell script
@@ -530,6 +530,12 @@ For all repositories in scope, the artifacts in the corresponding groups in Nexu
 | File encryption tool, format and Go library with small explicit keys.
 | https://github.com/FiloSottile/age
 
+| SDS-EXT-25
+| Go Toolset for UBI 8
+| 1.16.12
+| go-toolset available as a container is a base platform for building and running various Go applications and frameworks. It is maintained by Red Hat and updated regularly.
+| https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1
+
 |===
 
 == Appendix
@@ -543,6 +549,11 @@ The following table provides the history of the document.
 [cols="1,1,1,3"]
 |===
 | Version | Date | Author | Change
+
+| 0.9
+| 2021-12-21
+| Michael Sauter
+| Add Go UBI base image.
 
 | 0.8
 | 2021-12-20


### PR DESCRIPTION
Use `ubi8/go-toolset` as consistent builder image and as image for the `ods-build-go` task.

Closes #295.

Also switches the `ods-sonar` base image to `ubi8/openjdk-11-runtime:1.10`. This removes the need to install the runtime via `microdnf`, allowing the build to be faster because the image pull is parallelized.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
