### PR TITLE
Generate lint report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@ listed in the changelog.
 - Make task prefix customizable ([#289](https://github.com/opendevstack/ods-pipeline/issues/289))
 - Add overridable test timeout to Makefile ([#284](https://github.com/opendevstack/ods-pipeline/issues/284))
 - Skipping Tests in TypeScript build task if test artifacts are present already ([#238](https://github.com/opendevstack/ods-pipeline/issues/238))
-- Provided make target for ShellCheck and added ShellCheck to GitHub actions ([#240](https://github.com/opendevstack/ods-pipeline/issues/240))
+- Provide make target for ShellCheck and added ShellCheck to GitHub actions ([#240](https://github.com/opendevstack/ods-pipeline/issues/240))
 - Supply default `sonar-project.properties` when none is present, configuring SonarQube out-of-the-box ([#296](https://github.com/opendevstack/ods-pipeline/issues/296))
-- Linting stage in TypeScript build task ([#325](https://github.com/opendevstack/ods-pipeline/issues/325))
+- Linting step in TypeScript build task ([#325](https://github.com/opendevstack/ods-pipeline/issues/325))
 - Set `CI=true` in build tasks ([#336](https://github.com/opendevstack/ods-pipeline/issues/336))
+- Generate report for successful linting step in Go build task ([#215](https://github.com/opendevstack/ods-pipeline/issues/215))
 
 ### Changed
 

--- a/deploy/central/tasks-chart/templates/task-ods-build-go-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-go-with-sidecar.yaml
@@ -20,7 +20,8 @@ spec:
       link:https://golangci-lint.run/usage/configuration/[configuration documentation].
     - Tests are executed. A potential `vendor` directory is excluded. Test
       results are converted into xUnit format, and placed together with coverage
-      report into `.ods/artifacts`.
+      report into `.ods/artifacts`. If test artifacts are already present for
+      the current Git commit SHA, testing is skipped.
     - Application binary (named `app`) is built and placed into the directory
       specified by `output-dir`.
 

--- a/deploy/central/tasks-chart/templates/task-ods-build-go-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-go-with-sidecar.yaml
@@ -8,23 +8,23 @@ spec:
   description: |-
     Builds Go (module) applications.
 
-    The following steps are executed:
-
-    - check proper formatting against gofmt
-    - linting using golangci-lint
-    - build (using `go-os` and `go-arch` parameters)
-    - test execution
-
-    Tests exclude the vendor directory. Test results are converted into xUnit format.
-
-    Both xUnit report and coverage report are placed into .ods/artifacts.
-
-    The built binary is named `app` and placed into the directory specified by `output-dir`.
-
     The exact build recipe can be found at
     link:https://github.com/opendevstack/ods-pipeline/blob/master/build/package/scripts/build-go.sh[build/package/scripts/build-go.sh].
 
-    After tests ran successfully, the application source code is scanned by SonarQube.
+    The following provides an overview of the performed steps:
+
+    - Source files are checked to be formatted with `gofmt`.
+    - `golanci-lint` is run, generating a report which is placed into
+      `.ods/artifacts/lint-reports`. The linter can be configured via a
+      config file as described in the
+      link:https://golangci-lint.run/usage/configuration/[configuration documentation].
+    - Tests are executed. A potential `vendor` directory is excluded. Test
+      results are converted into xUnit format, and placed together with coverage
+      report into `.ods/artifacts`.
+    - Application binary (named `app`) is built and placed into the directory
+      specified by `output-dir`.
+
+    Finally, the application source code is scanned by SonarQube.
     Default SonarQube project properties are provided unless `sonar-project.properties`
     is present.
     When `sonar-quality-gate` is set to `true`, the task will fail if the quality gate

--- a/deploy/central/tasks-chart/templates/task-ods-build-go.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-go.yaml
@@ -18,7 +18,8 @@ spec:
       link:https://golangci-lint.run/usage/configuration/[configuration documentation].
     - Tests are executed. A potential `vendor` directory is excluded. Test
       results are converted into xUnit format, and placed together with coverage
-      report into `.ods/artifacts`.
+      report into `.ods/artifacts`. If test artifacts are already present for
+      the current Git commit SHA, testing is skipped.
     - Application binary (named `app`) is built and placed into the directory
       specified by `output-dir`.
 

--- a/deploy/central/tasks-chart/templates/task-ods-build-go.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-go.yaml
@@ -6,23 +6,23 @@ spec:
   description: |
     Builds Go (module) applications.
 
-    The following steps are executed:
-
-    - check proper formatting against gofmt
-    - linting using golangci-lint
-    - build (using `go-os` and `go-arch` parameters)
-    - test execution
-
-    Tests exclude the vendor directory. Test results are converted into xUnit format.
-
-    Both xUnit report and coverage report are placed into .ods/artifacts.
-
-    The built binary is named `app` and placed into the directory specified by `output-dir`.
-
     The exact build recipe can be found at
     link:https://github.com/opendevstack/ods-pipeline/blob/master/build/package/scripts/build-go.sh[build/package/scripts/build-go.sh].
 
-    After tests ran successfully, the application source code is scanned by SonarQube.
+    The following provides an overview of the performed steps:
+
+    - Source files are checked to be formatted with `gofmt`.
+    - `golanci-lint` is run, generating a report which is placed into
+      `.ods/artifacts/lint-reports`. The linter can be configured via a
+      config file as described in the
+      link:https://golangci-lint.run/usage/configuration/[configuration documentation].
+    - Tests are executed. A potential `vendor` directory is excluded. Test
+      results are converted into xUnit format, and placed together with coverage
+      report into `.ods/artifacts`.
+    - Application binary (named `app`) is built and placed into the directory
+      specified by `output-dir`.
+
+    Finally, the application source code is scanned by SonarQube.
     Default SonarQube project properties are provided unless `sonar-project.properties`
     is present.
     When `sonar-quality-gate` is set to `true`, the task will fail if the quality gate

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -83,7 +83,7 @@ Input parameters:
 | `build-go.sh` shell script
 a| Runs `gofmt` (SDS-EXT-3) to check all Go files are formatted.
 
-Runs `golangci-lint` (SDS-EXT-4) to check if there are any lint errors.
+Runs `golangci-lint` (SDS-EXT-4) to check if there are any lint errors. A report is placed into `.ods/artifacts/lint-reports`.
 
 If the `pre-test-script` is set, it executes the given script before running tests.
 

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -550,6 +550,11 @@ The following table provides the history of the document.
 |===
 | Version | Date | Author | Change
 
+| 0.10
+| 2021-12-22
+| Michael Sauter
+| Add Go lint report artifact.
+
 | 0.9
 | 2021-12-21
 | Michael Sauter

--- a/docs/tasks/ods-build-go-with-sidecar.adoc
+++ b/docs/tasks/ods-build-go-with-sidecar.adoc
@@ -16,7 +16,8 @@ The following provides an overview of the performed steps:
   link:https://golangci-lint.run/usage/configuration/[configuration documentation].
 - Tests are executed. A potential `vendor` directory is excluded. Test
   results are converted into xUnit format, and placed together with coverage
-  report into `.ods/artifacts`.
+  report into `.ods/artifacts`. If test artifacts are already present for
+  the current Git commit SHA, testing is skipped.
 - Application binary (named `app`) is built and placed into the directory
   specified by `output-dir`.
 

--- a/docs/tasks/ods-build-go-with-sidecar.adoc
+++ b/docs/tasks/ods-build-go-with-sidecar.adoc
@@ -4,23 +4,23 @@
 
 Builds Go (module) applications.
 
-The following steps are executed:
-
-- check proper formatting against gofmt
-- linting using golangci-lint
-- build (using `go-os` and `go-arch` parameters)
-- test execution
-
-Tests exclude the vendor directory. Test results are converted into xUnit format.
-
-Both xUnit report and coverage report are placed into .ods/artifacts.
-
-The built binary is named `app` and placed into the directory specified by `output-dir`.
-
 The exact build recipe can be found at
 link:https://github.com/opendevstack/ods-pipeline/blob/master/build/package/scripts/build-go.sh[build/package/scripts/build-go.sh].
 
-After tests ran successfully, the application source code is scanned by SonarQube.
+The following provides an overview of the performed steps:
+
+- Source files are checked to be formatted with `gofmt`.
+- `golanci-lint` is run, generating a report which is placed into
+  `.ods/artifacts/lint-reports`. The linter can be configured via a
+  config file as described in the
+  link:https://golangci-lint.run/usage/configuration/[configuration documentation].
+- Tests are executed. A potential `vendor` directory is excluded. Test
+  results are converted into xUnit format, and placed together with coverage
+  report into `.ods/artifacts`.
+- Application binary (named `app`) is built and placed into the directory
+  specified by `output-dir`.
+
+Finally, the application source code is scanned by SonarQube.
 Default SonarQube project properties are provided unless `sonar-project.properties`
 is present.
 When `sonar-quality-gate` is set to `true`, the task will fail if the quality gate

--- a/docs/tasks/ods-build-go.adoc
+++ b/docs/tasks/ods-build-go.adoc
@@ -16,7 +16,8 @@ The following provides an overview of the performed steps:
   link:https://golangci-lint.run/usage/configuration/[configuration documentation].
 - Tests are executed. A potential `vendor` directory is excluded. Test
   results are converted into xUnit format, and placed together with coverage
-  report into `.ods/artifacts`.
+  report into `.ods/artifacts`. If test artifacts are already present for
+  the current Git commit SHA, testing is skipped.
 - Application binary (named `app`) is built and placed into the directory
   specified by `output-dir`.
 

--- a/docs/tasks/ods-build-go.adoc
+++ b/docs/tasks/ods-build-go.adoc
@@ -4,23 +4,23 @@
 
 Builds Go (module) applications.
 
-The following steps are executed:
-
-- check proper formatting against gofmt
-- linting using golangci-lint
-- build (using `go-os` and `go-arch` parameters)
-- test execution
-
-Tests exclude the vendor directory. Test results are converted into xUnit format.
-
-Both xUnit report and coverage report are placed into .ods/artifacts.
-
-The built binary is named `app` and placed into the directory specified by `output-dir`.
-
 The exact build recipe can be found at
 link:https://github.com/opendevstack/ods-pipeline/blob/master/build/package/scripts/build-go.sh[build/package/scripts/build-go.sh].
 
-After tests ran successfully, the application source code is scanned by SonarQube.
+The following provides an overview of the performed steps:
+
+- Source files are checked to be formatted with `gofmt`.
+- `golanci-lint` is run, generating a report which is placed into
+  `.ods/artifacts/lint-reports`. The linter can be configured via a
+  config file as described in the
+  link:https://golangci-lint.run/usage/configuration/[configuration documentation].
+- Tests are executed. A potential `vendor` directory is excluded. Test
+  results are converted into xUnit format, and placed together with coverage
+  report into `.ods/artifacts`.
+- Application binary (named `app`) is built and placed into the directory
+  specified by `output-dir`.
+
+Finally, the application source code is scanned by SonarQube.
 Default SonarQube project properties are provided unless `sonar-project.properties`
 is present.
 When `sonar-quality-gate` is set to `true`, the task will fail if the quality gate

--- a/test/tasks/ods-build-go_test.go
+++ b/test/tasks/ods-build-go_test.go
@@ -43,6 +43,7 @@ func TestTaskODSBuildGo(t *testing.T) {
 					wantFiles := []string{
 						"docker/Dockerfile",
 						"docker/app",
+						filepath.Join(pipelinectxt.LintReportsPath, "report.txt"),
 						filepath.Join(pipelinectxt.XUnitReportsPath, "report.xml"),
 						filepath.Join(pipelinectxt.CodeCoveragesPath, "coverage.out"),
 						filepath.Join(pipelinectxt.SonarAnalysisPath, "analysis-report.md"),
@@ -106,6 +107,7 @@ func TestTaskODSBuildGo(t *testing.T) {
 					wantFiles := []string{
 						fmt.Sprintf("%s/docker/Dockerfile", subdir),
 						binary,
+						filepath.Join(pipelinectxt.LintReportsPath, fmt.Sprintf("%s-report.txt", subdir)),
 						filepath.Join(pipelinectxt.XUnitReportsPath, fmt.Sprintf("%s-report.xml", subdir)),
 						filepath.Join(pipelinectxt.CodeCoveragesPath, fmt.Sprintf("%s-coverage.out", subdir)),
 						filepath.Join(pipelinectxt.SonarAnalysisPath, fmt.Sprintf("%s-analysis-report.md", subdir)),


### PR DESCRIPTION
Closes #215.

Implementation mirrors #325.

The change includes updates to the task documentation. It also ensures
a pre-test script is only executed when tests are executed.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
