### PR TITLE
Install SOPS via go install

### DIFF
--- a/build/package/Dockerfile.helm
+++ b/build/package/Dockerfile.helm
@@ -26,10 +26,7 @@ COPY pkg pkg
 RUN cd cmd/deploy-with-helm && CGO_ENABLED=0 go build -o /usr/local/bin/deploy-with-helm
 
 # Install sops.
-RUN mkdir -p /tmp/sops \
-    && cd /tmp/sops \
-    && curl -LO https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-${SOPS_VERSION}-1.x86_64.rpm \
-    && yum install -y sops-${SOPS_VERSION}-1.x86_64.rpm \
+RUN go install go.mozilla.org/sops/v3/cmd/sops@v${SOPS_VERSION} \
     && sops --version
 
 # Install age.


### PR DESCRIPTION
This avoids the download of an architecture specific package
(`x86_64.rpm`), which should help with #360.

Tasks: 
- [ ] Updated design documents in `docs/design` directory or not applicable
- [ ] Updated user-facing documentation in `docs` directory or not applicable
- [ ] Ran tests (e.g. `make test`) or not applicable
- [ ] Updated changelog or not applicable
