### PR TITLE
Instruct Helm to keep image streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ listed in the changelog.
 
 - Apply labels to pipelines allowing easier identification for cleanup ([#358](https://github.com/opendevstack/ods-pipeline/issues/358))
 
+### Changed
+
+- Prevent existing image streams from being cleaned up if they are renamed in future versions ([#366](https://github.com/opendevstack/ods-pipeline/issues/366))
+
 ## [0.2.0] - 2021-12-22
 ### Added
 

--- a/deploy/central/images-chart/templates/is-ods-buildah.yaml
+++ b/deploy/central/images-chart/templates/is-ods-buildah.yaml
@@ -2,3 +2,5 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: ods-buildah
+  annotations:
+    "helm.sh/resource-policy": keep

--- a/deploy/central/images-chart/templates/is-ods-finish.yaml
+++ b/deploy/central/images-chart/templates/is-ods-finish.yaml
@@ -2,3 +2,5 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: ods-finish
+  annotations:
+    "helm.sh/resource-policy": keep

--- a/deploy/central/images-chart/templates/is-ods-go-toolset.yaml
+++ b/deploy/central/images-chart/templates/is-ods-go-toolset.yaml
@@ -2,3 +2,5 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: ods-go-toolset
+  annotations:
+    "helm.sh/resource-policy": keep

--- a/deploy/central/images-chart/templates/is-ods-gradle-toolset.yaml
+++ b/deploy/central/images-chart/templates/is-ods-gradle-toolset.yaml
@@ -2,3 +2,5 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: ods-gradle-toolset
+  annotations:
+    "helm.sh/resource-policy": keep

--- a/deploy/central/images-chart/templates/is-ods-helm.yaml
+++ b/deploy/central/images-chart/templates/is-ods-helm.yaml
@@ -2,3 +2,5 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: ods-helm
+  annotations:
+    "helm.sh/resource-policy": keep

--- a/deploy/central/images-chart/templates/is-ods-node16-typescript-toolset.yaml
+++ b/deploy/central/images-chart/templates/is-ods-node16-typescript-toolset.yaml
@@ -2,3 +2,5 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: ods-node16-typescript-toolset
+  annotations:
+    "helm.sh/resource-policy": keep

--- a/deploy/central/images-chart/templates/is-ods-python-toolset.yaml
+++ b/deploy/central/images-chart/templates/is-ods-python-toolset.yaml
@@ -2,3 +2,5 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: ods-python-toolset
+  annotations:
+    "helm.sh/resource-policy": keep

--- a/deploy/central/images-chart/templates/is-ods-sonar.yaml
+++ b/deploy/central/images-chart/templates/is-ods-sonar.yaml
@@ -2,3 +2,5 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: ods-sonar
+  annotations:
+    "helm.sh/resource-policy": keep

--- a/deploy/central/images-chart/templates/is-ods-start.yaml
+++ b/deploy/central/images-chart/templates/is-ods-start.yaml
@@ -2,3 +2,5 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: ods-start
+  annotations:
+    "helm.sh/resource-policy": keep

--- a/deploy/central/images-chart/templates/is-ods-webhook-interceptor.yaml
+++ b/deploy/central/images-chart/templates/is-ods-webhook-interceptor.yaml
@@ -2,3 +2,5 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: ods-webhook-interceptor
+  annotations:
+    "helm.sh/resource-policy": keep


### PR DESCRIPTION
Closes #366.

Motivated by the rename of ods-typescript-toolset to
ods-node16-typescript-toolset in 0.2.0 which caused cleanup of the old
ods-typescript-toolset images.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
