### PR TITLE
use nexus image for arm64

### DIFF
--- a/scripts/nexus/Dockerfile.arm64
+++ b/scripts/nexus/Dockerfile.arm64
@@ -1,0 +1,6 @@
+FROM klo2k/nexus3:3.30.1-01
+
+USER root
+RUN echo "storage.diskCache.diskFreeSpaceLimit=2048" >> /opt/sonatype/nexus/etc/karaf/system.properties && \
+    echo "nexus.scripts.allowCreation=true" >> /opt/sonatype/nexus/etc/nexus-default.properties
+USER nexus

--- a/scripts/run-nexus.sh
+++ b/scripts/run-nexus.sh
@@ -29,7 +29,11 @@ esac; shift; done
 echo "Run container using image tag ${NEXUS_IMAGE_TAG}"
 docker rm -f ${CONTAINER_NAME} || true
 cd "${SCRIPT_DIR}"/nexus
-docker build -t ${IMAGE_NAME} .
+if [ "$(uname -m)" == "arm64" ]; then
+    docker build -t ${IMAGE_NAME} -f Dockerfile.arm64 .
+else 
+    docker build -t ${IMAGE_NAME} .
+fi 
 cd - &> /dev/null
 docker run -d -p "${HOST_PORT}:8081" --net kind --name ${CONTAINER_NAME} ${IMAGE_NAME}
 


### PR DESCRIPTION
Uses image as proposed in https://github.com/opendevstack/ods-pipeline/issues/362#issuecomment-1004594095 when uname reports an arm64 machine.

Closes #362

Tasks: 
- [NA] Updated design documents in `docs/design` directory or not applicable
- [NA] Updated user-facing documentation in `docs` directory or not applicable
- [NA] Ran tests (e.g. `make test`) or not applicable
- [?] Updated changelog or not applicable
Propose to add this when related issues mentioned on #360 are fixed.
