### PR TITLE
Update helm-diff to 3.3.2

### DIFF
--- a/build/package/Dockerfile.helm
+++ b/build/package/Dockerfile.helm
@@ -36,7 +36,7 @@ RUN go install filippo.io/age/cmd/...@v${AGE_VERSION} \
 # Final image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
-ENV HELM_PLUGIN_DIFF_VERSION=3.1.3 \
+ENV HELM_PLUGIN_DIFF_VERSION=3.3.2 \
     HELM_PLUGIN_SECRETS_VERSION=3.10.0 \
     HELM_PLUGINS=/usr/local/helm/plugins \
     SKOPEO_VERSION=1.4 \

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -502,7 +502,7 @@ For all repositories in scope, the artifacts in the corresponding groups in Nexu
 
 | SDS-EXT-20
 | Helm Diff plugin
-| 3.1
+| 3.3
 | Shows a diff explaining what a helm upgrade would change.
 | https://github.com/databus23/helm-diff
 
@@ -549,6 +549,11 @@ The following table provides the history of the document.
 [cols="1,1,1,3"]
 |===
 | Version | Date | Author | Change
+
+| 0.11
+| 2022-01-10
+| Michael Sauter
+| Update helm-diff.
 
 | 0.10
 | 2021-12-22


### PR DESCRIPTION
helm-diff should now work on arm64. This should fix
https://github.com/opendevstack/ods-pipeline/issues/360#issuecomment-1004632923.

@henrjk Can you try and confirm?

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
