### PR TITLE
Expose Nexus environment variables to Gradle task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ listed in the changelog.
 
 ### Fixed
 - Cannot enable debug mode in some tasks ([#377](https://github.com/opendevstack/ods-pipeline/issues/377))
+- Gradle task does not expose Nexus env variables ([#373](https://github.com/opendevstack/ods-pipeline/issues/373))
 
 ## [0.2.0] - 2021-12-22
 ### Added

--- a/deploy/central/tasks-chart/templates/task-ods-build-gradle-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-gradle-with-sidecar.yaml
@@ -24,7 +24,7 @@ spec:
     - `ODS_OUTPUT_DIR`: this environment variable points to the folder
     that this build expects generated application artifacts to be copied to.
     The gradle script should read it and copy there the generated artifacts.
-    - `NEXUS_*` env vars: `NEXUS_HOST`, `NEXUS_USER` and `NEXUS_PASSWORD`
+    - `NEXUS_*` env vars: `NEXUS_URL`, `NEXUS_USERNAME` and `NEXUS_PASSWORD`
     are available and should be read by the gradle script.
 
     To enable the gradle script to copy the generated application artifacts script follow these steps:
@@ -142,6 +142,21 @@ spec:
       value: /tekton/home
     - name: CI
       value: "true"
+    - name: NEXUS_URL
+      valueFrom:
+        configMapKeyRef:
+          key: url
+          name: ods-nexus
+    - name: NEXUS_USERNAME
+      valueFrom:
+        secretKeyRef:
+          key: username
+          name: ods-nexus-auth
+    - name: NEXUS_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          key: password
+          name: ods-nexus-auth
     image: '{{.Values.registry}}/{{.Values.namespace}}/ods-gradle-toolset:{{.Values.imageTag}}'
     name: build-gradle-binary
     resources: {}

--- a/deploy/central/tasks-chart/templates/task-ods-build-gradle.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-gradle.yaml
@@ -22,7 +22,7 @@ spec:
     - `ODS_OUTPUT_DIR`: this environment variable points to the folder
     that this build expects generated application artifacts to be copied to.
     The gradle script should read it and copy there the generated artifacts.
-    - `NEXUS_*` env vars: `NEXUS_HOST`, `NEXUS_USER` and `NEXUS_PASSWORD`
+    - `NEXUS_*` env vars: `NEXUS_URL`, `NEXUS_USERNAME` and `NEXUS_PASSWORD`
     are available and should be read by the gradle script.
 
     To enable the gradle script to copy the generated application artifacts script follow these steps:
@@ -132,6 +132,21 @@ spec:
           value: '/tekton/home'
         - name: CI
           value: "true"
+        - name: NEXUS_URL
+          valueFrom:
+            configMapKeyRef:
+              key: url
+              name: ods-nexus
+        - name: NEXUS_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: ods-nexus-auth
+        - name: NEXUS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: ods-nexus-auth
       resources: {}
       script: |
         # build-gradle is build/package/scripts/build-gradle.sh.

--- a/docs/tasks/ods-build-gradle-with-sidecar.adoc
+++ b/docs/tasks/ods-build-gradle-with-sidecar.adoc
@@ -20,7 +20,7 @@ Available environment variables:
 - `ODS_OUTPUT_DIR`: this environment variable points to the folder
 that this build expects generated application artifacts to be copied to.
 The gradle script should read it and copy there the generated artifacts.
-- `NEXUS_*` env vars: `NEXUS_HOST`, `NEXUS_USER` and `NEXUS_PASSWORD`
+- `NEXUS_*` env vars: `NEXUS_URL`, `NEXUS_USERNAME` and `NEXUS_PASSWORD`
 are available and should be read by the gradle script.
 
 To enable the gradle script to copy the generated application artifacts script follow these steps:

--- a/docs/tasks/ods-build-gradle.adoc
+++ b/docs/tasks/ods-build-gradle.adoc
@@ -20,7 +20,7 @@ Available environment variables:
 - `ODS_OUTPUT_DIR`: this environment variable points to the folder
 that this build expects generated application artifacts to be copied to.
 The gradle script should read it and copy there the generated artifacts.
-- `NEXUS_*` env vars: `NEXUS_HOST`, `NEXUS_USER` and `NEXUS_PASSWORD`
+- `NEXUS_*` env vars: `NEXUS_URL`, `NEXUS_USERNAME` and `NEXUS_PASSWORD`
 are available and should be read by the gradle script.
 
 To enable the gradle script to copy the generated application artifacts script follow these steps:


### PR DESCRIPTION
Fixes #373.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
