### PR TITLE
use helm for targetplatform

### DIFF
--- a/build/package/Dockerfile.helm
+++ b/build/package/Dockerfile.helm
@@ -1,5 +1,7 @@
 FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12 AS builder
 
+ARG TARGETARCH
+
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
 
@@ -11,9 +13,9 @@ ENV HELM_VERSION=3.5.2 \
 # Install Helm.
 RUN mkdir -p /tmp/helm \
     && cd /tmp \
-    && curl -LO https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
-    && tar -zxvf helm-v${HELM_VERSION}-linux-amd64.tar.gz -C /tmp/helm \
-    && mv /tmp/helm/linux-amd64/helm /usr/local/bin/helm \
+    && curl -LO https://get.helm.sh/helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz \
+    && tar -zxvf helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz -C /tmp/helm \
+    && mv /tmp/helm/linux-${TARGETARCH}/helm /usr/local/bin/helm \
     && chmod a+x /usr/local/bin/helm \
     && helm version \
     && helm env


### PR DESCRIPTION
This enables using arm64 for example on M1 macs.

Fixing what is mentioned in comment https://github.com/opendevstack/ods-pipeline/issues/360#issuecomment-1004632923 so that the helm image is now expected to work.

Issue #360 was inadvertently closed (I believe) and should be reopened until the typescript issue is fixed. 

Tasks: 
- [NA] Updated design documents in `docs/design` directory or not applicable
- [NA] Updated user-facing documentation in `docs` directory or not applicable
- [NA ] Ran tests (e.g. `make test`) or not applicable
- [Na ] Updated changelog or not applicable
