### PR TITLE
Allow to customize flags passed to helm (diff) upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ listed in the changelog.
 
 - Apply labels to pipelines allowing easier identification for cleanup ([#358](https://github.com/opendevstack/ods-pipeline/issues/358))
 - Configurable workspace PVC size ([#368](https://github.com/opendevstack/ods-pipeline/issues/368))
+- Customizable Helm flags ([#388](https://github.com/opendevstack/ods-pipeline/issues/388))
 
 ### Changed
 

--- a/deploy/central/tasks-chart/templates/task-ods-deploy-helm.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-deploy-helm.yaml
@@ -66,6 +66,14 @@ spec:
       description: The Helm release name. If empty, the release name is simply the name of the chart.
       type: string
       default: ''
+    - name: diff-flags
+      description: Flags to pass to `helm diff upgrade`. Note that `--detailed-exitcode` and `--no-color` are automatically set and cannot be removed. Changes should be aligned with `upgrade-flags` as needed.
+      type: string
+      default: '--install'
+    - name: upgrade-flags
+      description: Flags to pass to `helm upgrade`. Changes should be aligned with `diff-flags` as needed.
+      type: string
+      default: '--install --wait'
     - name: age-key-secret
       description: |
         Name of the secret containing the age key to use for helm-secrets.
@@ -90,6 +98,8 @@ spec:
         deploy-with-helm \
           -chart-dir=$(params.chart-dir) \
           -release-name=$(params.release-name) \
+          -diff-flags="$(params.diff-flags)" \
+          -upgrade-flags="$(params.upgrade-flags)" \
           -age-key-secret=$(params.age-key-secret)
       workingDir: $(workspaces.source.path)
   workspaces:

--- a/docs/tasks/ods-deploy-helm.adoc
+++ b/docs/tasks/ods-deploy-helm.adoc
@@ -73,6 +73,16 @@ the box.
 | The Helm release name. If empty, the release name is simply the name of the chart.
 
 
+| diff-flags
+| --install
+| Flags to pass to `helm diff upgrade`. Note that `--detailed-exitcode` and `--no-color` are automatically set and cannot be removed. Changes should be aligned with `upgrade-flags` as needed.
+
+
+| upgrade-flags
+| --install --wait
+| Flags to pass to `helm upgrade`. Changes should be aligned with `diff-flags` as needed.
+
+
 | age-key-secret
 | helm-secrets-age-key
 | Name of the secret containing the age key to use for helm-secrets.


### PR DESCRIPTION
Closes #388.

I think explicit tests for this are not required as we implicitly test that passing flags (both one and two flags) works. In general, `deploy-with-helm` would benefit from refactoring, extracting all the Helm logic into a client that can then be replaced with a mock for testing ... but not for this PR.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
