### PR TITLE
use NEXUS_* envs when testing with the gradle-sample-app

### DIFF
--- a/build/package/scripts/build-gradle.sh
+++ b/build/package/scripts/build-gradle.sh
@@ -40,6 +40,9 @@ if [ "${DEBUG}" == "true" ]; then
 fi
 
 export GRADLE_USER_HOME=/home/gradle/.gradle
+
+echo "Using NEXUS_URL=$NEXUS_URL"
+
 echo "Exported env var 'GRADLE_USER_HOME' with value '${GRADLE_USER_HOME}'"
 echo
 cd "${WORKING_DIR}"

--- a/test/tasks/ods-build-gradle_test.go
+++ b/test/tasks/ods-build-gradle_test.go
@@ -42,11 +42,16 @@ func TestTaskODSBuildGradle(t *testing.T) {
 						filepath.Join(pipelinectxt.SonarAnalysisPath, "quality-gate.json"),
 					)
 
-					wantLogMsg := "No sonar-project.properties present, using default:"
-					if !strings.Contains(string(ctxt.CollectedLogs), wantLogMsg) {
-						t.Fatalf("Want:\n%s\n\nGot:\n%s", wantLogMsg, string(ctxt.CollectedLogs))
-					}
+					logContains("No sonar-project.properties present, using default:", ctxt.CollectedLogs, t)
+					logContains("Using NEXUS_URL=http://ods-test-nexus.kind:8081", ctxt.CollectedLogs, t)
 				},
 			},
 		})
+}
+
+func logContains(wantLogMsg string, collectedLogs []byte, t *testing.T) {
+	logString := string(collectedLogs)
+	if !strings.Contains(logString, wantLogMsg) {
+		t.Fatalf("Want:\n%s\n\nGot:\n%s", wantLogMsg, logString)
+	}
 }

--- a/test/testdata/workspaces/gradle-sample-app/build.gradle
+++ b/test/testdata/workspaces/gradle-sample-app/build.gradle
@@ -8,6 +8,9 @@
 buildscript {
     ext {
         odsOutputDir = System.getenv('ODS_OUTPUT_DIR')
+        nexus_url = System.getenv('NEXUS_URL')
+        nexus_user = System.getenv('NEXUS_USERNAME')
+        nexus_pw = System.getenv('NEXUS_PASSWORD')
     }
 }
 
@@ -19,7 +22,41 @@ plugins {
 
 repositories {
     // Use Maven Central for resolving dependencies.
-    mavenCentral()
+    maven() {
+        url "${nexus_url}/repository/jcenter/"
+        credentials {
+            username = "${nexus_user}"
+            password = "${nexus_pw}"
+        }
+        /*
+         this setting is only added bcs. nexus in test runs under http, don't use this as a blueprint for your
+         */
+        allowInsecureProtocol = true
+    }
+
+    maven() {
+        url "${nexus_url}/repository/maven-public/"
+        credentials {
+            username = "${nexus_user}"
+            password = "${nexus_pw}"
+        }
+        /*
+         this setting is only added bcs. nexus in test runs under http, don't use this as a blueprint for your
+         */
+        allowInsecureProtocol = true
+    }
+
+    maven() {
+        url "${nexus_url}/repository/atlassian_public/"
+        credentials {
+            username = "${nexus_user}"
+            password = "${nexus_pw}"
+        }
+        /*
+        this setting is only added bcs. nexus in test runs under http, don't use this as a blueprint for your
+        */
+        allowInsecureProtocol = true
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Adds the missing link to use the NEXUS_* envs when using the gradle-sample-app to verify gradle build task works with the nexus repositories instead of the public maven repos.

Closes #373 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
