### PR TITLE
build-and-push-images use linux/amd64 for typescript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,16 @@ install-tekton-pipelines: ## Install Tekton pipelines in KinD cluster.
 .PHONY: install-tekton-pipelines
 
 build-and-push-images: ## Build and push images to local registry.
-		cd scripts && ./build-and-push-images.sh
+		cd scripts && ./build-and-push-images.sh --image start
+		cd scripts && ./build-and-push-images.sh --image finish
+		cd scripts && ./build-and-push-images.sh --image buildah
+		cd scripts && ./build-and-push-images.sh --image sonar
+		cd scripts && ./build-and-push-images.sh --image webhook-interceptor
+		cd scripts && ./build-and-push-images.sh --image go-toolset
+		cd scripts && ./build-and-push-images.sh --image gradle-toolset
+		cd scripts && ./build-and-push-images.sh --image python-toolset
+		cd scripts && ./build-and-push-images.sh --image helm
+		cd scripts && ./build-and-push-images.sh --image node16-typescript-toolset --platform linux/amd64
 .PHONY: build-and-push-images
 
 install-ods-tasks-kind: ## KinD only! Apply ODS ClusterTask manifests in KinD

--- a/scripts/build-and-push-images.sh
+++ b/scripts/build-and-push-images.sh
@@ -27,8 +27,8 @@ while [[ "$#" -gt 0 ]]; do
     -i|--image) IMAGES="$2"; shift;;
     -i=*|--image=*) IMAGES="${1#*=}";;
 
-    -i|--platform) PLATFORM="$2"; shift;;
-    -i=*|--platform=*) PLATFORM="${1#*=}";;
+    -p|--platform) PLATFORM="$2"; shift;;
+    -p=*|--platform=*) PLATFORM="${1#*=}";;
 
     *) echo "Unknown parameter passed: $1"; exit 1;;
 esac; shift; done
@@ -39,6 +39,7 @@ build_and_push_image() {
     odsImage="ods-$image"
     if [ "${SKIP_BUILD}" != "true" ]; then
         echo "Building image $REGISTRY/$NAMESPACE/$odsImage..."
+        # shellcheck disable=SC2086
         docker build $platform_arg \
             --build-arg http_proxy="$http_proxy" \
             --build-arg https_proxy="$https_proxy" \
@@ -50,9 +51,9 @@ build_and_push_image() {
     docker push "$REGISTRY/$NAMESPACE/$odsImage"
 }
 
-platform_arg=""
-if [ ! -z "$PLATFORM" ]; then
-    platform_arg="--platform $PLATFORM"
+platform_arg=
+if [ -n "$PLATFORM" ]; then
+    platform_arg="--platform=${PLATFORM}"
 fi
 
 if [ -z "$IMAGES" ]; then

--- a/scripts/build-and-push-images.sh
+++ b/scripts/build-and-push-images.sh
@@ -14,6 +14,9 @@ IMAGES=""
 http_proxy="${http_proxy:-}"
 https_proxy="${https_proxy:-}"
 
+PLATFORM=""
+# eg. --platform linux/amd64
+
 while [[ "$#" -gt 0 ]]; do
     case $1 in
 
@@ -24,6 +27,9 @@ while [[ "$#" -gt 0 ]]; do
     -i|--image) IMAGES="$2"; shift;;
     -i=*|--image=*) IMAGES="${1#*=}";;
 
+    -i|--platform) PLATFORM="$2"; shift;;
+    -i=*|--platform=*) PLATFORM="${1#*=}";;
+
     *) echo "Unknown parameter passed: $1"; exit 1;;
 esac; shift; done
 
@@ -33,7 +39,7 @@ build_and_push_image() {
     odsImage="ods-$image"
     if [ "${SKIP_BUILD}" != "true" ]; then
         echo "Building image $REGISTRY/$NAMESPACE/$odsImage..."
-        docker build \
+        docker build $platform_arg \
             --build-arg http_proxy="$http_proxy" \
             --build-arg https_proxy="$https_proxy" \
             --build-arg HTTP_PROXY="$http_proxy" \
@@ -43,6 +49,11 @@ build_and_push_image() {
     echo "Pushing image to $REGISTRY/$NAMESPACE/$odsImage ..."
     docker push "$REGISTRY/$NAMESPACE/$odsImage"
 }
+
+platform_arg=""
+if [ ! -z "$PLATFORM" ]; then
+    platform_arg="--platform $PLATFORM"
+fi
 
 if [ -z "$IMAGES" ]; then
     for file in build/package/Dockerfile.*; do


### PR DESCRIPTION
Support building images on an M1. 

The typescript image currently uses chrome for cypress.
Until there is a use case which allows verification of using chromium stay with chrome so force platform linux/amd64 for the image. 

Fixes #360

Tasks: 
- [NA] Updated design documents in `docs/design` directory or not applicable
- [NA] Updated user-facing documentation in `docs` directory or not applicable
- [NA] Ran tests (e.g. `make test`) or not applicable
- [NA] Updated changelog or not applicable
