### PR TITLE
Document generated artifacts per task

### DIFF
--- a/cmd/sidecar-tasks/main.go
+++ b/cmd/sidecar-tasks/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/opendevstack/pipeline/internal/docs"
 	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
@@ -29,15 +30,15 @@ func main() {
 	}
 }
 
-func parseTasks(taskNames []string) (map[string]*tekton.ClusterTask, error) {
-	tasks := map[string]*tekton.ClusterTask{}
+func parseTasks(taskNames []string) (map[string]*docs.ODSClusterTask, error) {
+	tasks := map[string]*docs.ODSClusterTask{}
 	for _, task := range taskNames {
 		fmt.Printf("Parsing task %s ...\n", task)
 		b, err := ioutil.ReadFile(fmt.Sprintf("deploy/central/tasks-chart/templates/task-%s.yaml", task))
 		if err != nil {
 			return nil, err
 		}
-		var t tekton.ClusterTask
+		var t docs.ODSClusterTask
 		err = yaml.Unmarshal(b, &t)
 		if err != nil {
 			return nil, err
@@ -47,7 +48,7 @@ func parseTasks(taskNames []string) (map[string]*tekton.ClusterTask, error) {
 	return tasks, nil
 }
 
-func adjustTasks(tasks map[string]*tekton.ClusterTask) {
+func adjustTasks(tasks map[string]*docs.ODSClusterTask) {
 	for name, t := range tasks {
 		fmt.Printf("Adding sidecar to task %s ...\n", name)
 		cleanName := strings.Replace(t.Name, "{{default \"ods\" .Values.taskPrefix}}", "ods", 1)
@@ -74,7 +75,7 @@ Apart from the sidecar, the task is an exact copy of ` + "`" + cleanName + "`" +
 	}
 }
 
-func writeTasks(tasks map[string]*tekton.ClusterTask) error {
+func writeTasks(tasks map[string]*docs.ODSClusterTask) error {
 	for name, t := range tasks {
 		fmt.Printf("Writing sidecar task %s ...\n", name)
 		out, err := yaml.Marshal(t)

--- a/deploy/central/tasks-chart/templates/task-ods-build-typescript-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-typescript-with-sidecar.yaml
@@ -5,6 +5,28 @@ metadata:
   creationTimestamp: null
   name: '{{default "ods" .Values.taskPrefix}}-build-typescript-with-sidecar{{.Values.taskSuffix}}'
 spec:
+  artifacts:
+  - format: XML
+    name: Clover coverage report
+    path: ./code-coverage/clover.xml
+  - format: JSON
+    name: Jest coverage report
+    path: ./code-coverage/coverage-final.json
+  - format: LCOV format
+    name: LCOV coverage report
+    path: ./code-coverage/lcov.info
+  - format: Text
+    name: Lint report
+    path: ./lint-reports/report.txt
+  - format: Markdown
+    name: SonarQube analysis report
+    path: ./sonarqube-analysis/analysis-report.md
+  - format: CSV
+    name: SonarQube issues report
+    path: ./sonarqube-analysis/issues-report.csv
+  - format: XML
+    name: Unit test report
+    path: ./xunit-reports/report.xml
   description: |-
     Builds Typescript applications.
 

--- a/deploy/central/tasks-chart/templates/task-ods-build-typescript.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-typescript.yaml
@@ -3,6 +3,28 @@ kind: '{{default "ClusterTask" .Values.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-build-typescript{{.Values.taskSuffix}}'
 spec:
+  artifacts:
+    - name: Clover coverage report
+      format: XML
+      path: './code-coverage/clover.xml'
+    - name: Jest coverage report
+      format: JSON
+      path: './code-coverage/coverage-final.json'
+    - name: LCOV coverage report
+      format: LCOV format
+      path: './code-coverage/lcov.info'
+    - name: Lint report
+      format: Text
+      path: './lint-reports/report.txt'
+    - name: SonarQube analysis report
+      format: Markdown
+      path: './sonarqube-analysis/analysis-report.md'
+    - name: SonarQube issues report
+      format: CSV
+      path: './sonarqube-analysis/issues-report.csv'
+    - name: Unit test report
+      format: XML
+      path: './xunit-reports/report.xml'
   description: |
     Builds Typescript applications.
 

--- a/docs/tasks/ods-build-go-with-sidecar.adoc
+++ b/docs/tasks/ods-build-go-with-sidecar.adoc
@@ -90,6 +90,10 @@ without leading `./` and trailing `/`.
 
 |===
 
+== Artifacts
+
+N/A
+
 == Results
 
 N/A

--- a/docs/tasks/ods-build-go.adoc
+++ b/docs/tasks/ods-build-go.adoc
@@ -81,6 +81,10 @@ without leading `./` and trailing `/`.
 
 |===
 
+== Artifacts
+
+N/A
+
 == Results
 
 N/A

--- a/docs/tasks/ods-build-gradle-with-sidecar.adoc
+++ b/docs/tasks/ods-build-gradle-with-sidecar.adoc
@@ -133,6 +133,10 @@ without leading `./` and trailing `/`.
 
 |===
 
+== Artifacts
+
+N/A
+
 == Results
 
 N/A

--- a/docs/tasks/ods-build-gradle.adoc
+++ b/docs/tasks/ods-build-gradle.adoc
@@ -124,6 +124,10 @@ without leading `./` and trailing `/`.
 
 |===
 
+== Artifacts
+
+N/A
+
 == Results
 
 N/A

--- a/docs/tasks/ods-build-python-with-sidecar.adoc
+++ b/docs/tasks/ods-build-python-with-sidecar.adoc
@@ -67,6 +67,10 @@ without leading `./` and trailing `/`.
 
 |===
 
+== Artifacts
+
+N/A
+
 == Results
 
 N/A

--- a/docs/tasks/ods-build-python.adoc
+++ b/docs/tasks/ods-build-python.adoc
@@ -58,6 +58,10 @@ without leading `./` and trailing `/`.
 
 |===
 
+== Artifacts
+
+N/A
+
 == Results
 
 N/A

--- a/docs/tasks/ods-build-typescript-with-sidecar.adoc
+++ b/docs/tasks/ods-build-typescript-with-sidecar.adoc
@@ -84,6 +84,41 @@ without leading `./` and trailing `/`.
 
 |===
 
+== Artifacts
+
+[cols="1,1,1"]
+|===
+| Name | File Format | Path (relative to `.ods/artifacts/`)
+
+| Clover coverage report
+| XML
+| ./code-coverage/clover.xml
+
+| Jest coverage report
+| JSON
+| ./code-coverage/coverage-final.json
+
+| LCOV coverage report
+| LCOV format
+| ./code-coverage/lcov.info
+
+| Lint report
+| Text
+| ./lint-reports/report.txt
+
+| SonarQube analysis report
+| Markdown
+| ./sonarqube-analysis/analysis-report.md
+
+| SonarQube issues report
+| CSV
+| ./sonarqube-analysis/issues-report.csv
+
+| Unit test report
+| XML
+| ./xunit-reports/report.xml
+|===
+
 == Results
 
 N/A

--- a/docs/tasks/ods-build-typescript.adoc
+++ b/docs/tasks/ods-build-typescript.adoc
@@ -75,6 +75,41 @@ without leading `./` and trailing `/`.
 
 |===
 
+== Artifacts
+
+[cols="1,1,1"]
+|===
+| Name | File Format | Path (relative to `.ods/artifacts/`)
+
+| Clover coverage report
+| XML
+| ./code-coverage/clover.xml
+
+| Jest coverage report
+| JSON
+| ./code-coverage/coverage-final.json
+
+| LCOV coverage report
+| LCOV format
+| ./code-coverage/lcov.info
+
+| Lint report
+| Text
+| ./lint-reports/report.txt
+
+| SonarQube analysis report
+| Markdown
+| ./sonarqube-analysis/analysis-report.md
+
+| SonarQube issues report
+| CSV
+| ./sonarqube-analysis/issues-report.csv
+
+| Unit test report
+| XML
+| ./xunit-reports/report.xml
+|===
+
 == Results
 
 N/A

--- a/docs/tasks/ods-deploy-helm.adoc
+++ b/docs/tasks/ods-deploy-helm.adoc
@@ -91,6 +91,10 @@ If the secret exists, it is expected to have a field named `key.txt` with the ag
 
 |===
 
+== Artifacts
+
+N/A
+
 == Results
 
 N/A

--- a/docs/tasks/ods-finish.adoc
+++ b/docs/tasks/ods-finish.adoc
@@ -28,6 +28,10 @@ by the webhook interceptor and cannot be customized by users at this point.
 
 |===
 
+== Artifacts
+
+N/A
+
 == Results
 
 N/A

--- a/docs/tasks/ods-package-image.adoc
+++ b/docs/tasks/ods-package-image.adoc
@@ -83,6 +83,10 @@ built branch, a code insight report is attached to the Git commit.
 
 |===
 
+== Artifacts
+
+N/A
+
 == Results
 
 [cols="1,3"]

--- a/docs/tasks/ods-start.adoc
+++ b/docs/tasks/ods-start.adoc
@@ -121,6 +121,10 @@ by the webhook interceptor and cannot be customized by users at this point.*
 
 |===
 
+== Artifacts
+
+N/A
+
 == Results
 
 [cols="1,3"]

--- a/docs/tasks/template.adoc.tmpl
+++ b/docs/tasks/template.adoc.tmpl
@@ -15,6 +15,22 @@
 {{ end}}
 |===
 
+== Artifacts
+{{ if .Artifacts }}
+[cols="1,1,1"]
+|===
+| Name | File Format | Path (relative to `.ods/artifacts/`)
+{{- range .Artifacts}}
+
+| {{.Name}}
+| {{.Format}}
+| {{.Path}}
+{{- end}}
+|===
+{{- else}}
+N/A
+{{- end}}
+
 == Results
 {{ if .Results}}
 [cols="1,3"]


### PR DESCRIPTION
This PR is WIP to get first feedback on the implementation before going through all task charts to add the generated artifacts for each.

To be able to retrieve the `artifacts` that one documents in `task-ods-build-foo.yaml` I needed to create a new type called `ODSClusterTask` that extends the `ClusterTask` type coming from `tekton` by adding an `Artifacts` field.
The `Artifact` type looks like this:
```go
type Artifact struct {
  Name   string `json:"name"`
  Format string `json:"format"`
  Path   string `json:"path"`
}
```

With that one is able to document the artifacts each task produces by adding this to the task chart:
```yaml
spec:
  artifacts:
  - name: Sample report
    format: JSON
    path: './sample-folder/sample-report.json'
```

To be able to see how the docs would look like in the end I have gone through the TypeScript task chart first to document all generated artifacts for it.

Closes #389 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
