### PR TITLE
Change gradle run defaults and add possibility to configure GRADLE_OPTS via task params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ listed in the changelog.
 - Apply labels to pipelines allowing easier identification for cleanup ([#358](https://github.com/opendevstack/ods-pipeline/issues/358))
 - Configurable workspace PVC size ([#368](https://github.com/opendevstack/ods-pipeline/issues/368))
 - Customizable Helm flags ([#388](https://github.com/opendevstack/ods-pipeline/issues/388))
+- Run gradle in non daemon mode by default and enabling stacktraces ([#386](https://github.com/opendevstack/ods-pipeline/issues/386)) 
+- Enable setting `GRADLE_OPTS` via task parameters ([#387](https://github.com/opendevstack/ods-pipeline/issues/387))
 
 ### Changed
 

--- a/build/package/scripts/build-gradle.sh
+++ b/build/package/scripts/build-gradle.sh
@@ -22,8 +22,8 @@ while [[ "$#" -gt 0 ]]; do
     --gradle-additional-tasks) GRADLE_ADDITIONAL_TASKS="$2"; shift;;
     --gradle-additional-tasks=*) GRADLE_ADDITIONAL_TASKS="${1#*=}";;
 
-    # Gradle project properties ref: https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties
-    # Gradle options ref: https://docs.gradle.org/current/userguide/command_line_interface.html
+    # Gradle project properties ref: https://docs.gradle.org/7.3.3/userguide/build_environment.html#sec:gradle_configuration_properties
+    # Gradle options ref: https://docs.gradle.org/7.3.3/userguide/command_line_interface.html
     --gradle-options) GRADLE_OPTIONS="$2"; shift;;
     --gradle-options=*) GRADLE_OPTIONS="${1#*=}";;
 
@@ -42,6 +42,7 @@ fi
 export GRADLE_USER_HOME=/home/gradle/.gradle
 
 echo "Using NEXUS_URL=$NEXUS_URL"
+echo "Using GRADLE_OPTS=$GRADLE_OPTS"
 
 echo "Exported env var 'GRADLE_USER_HOME' with value '${GRADLE_USER_HOME}'"
 echo

--- a/deploy/central/tasks-chart/templates/task-ods-build-gradle-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-gradle-with-sidecar.yaml
@@ -104,9 +104,19 @@ spec:
       tasks called are `clean` and `build`).
     name: gradle-additional-tasks
     type: string
-  - default: ""
-    description: 'Options to be passed to the gradle build. (See ref: https://docs.gradle.org/current/userguide/command_line_interface.html#sec:command_line_debugging)'
+  - default: --no-daemon --stacktrace
+    description: 'Options to be passed to the gradle build. (See ref: https://docs.gradle.org/7.3.3/userguide/command_line_interface.html#sec:command_line_debugging)'
     name: gradle-options
+    type: string
+  - default: -Dorg.gradle.jvmargs=-Xmx512M
+    description: 'Will be exposed to the build via `GRADLE_OPTS` environment variable.
+      Specifies JVM arguments to use when starting the Gradle client VM. The client
+      VM only handles command line input/output, so it is rare that one would need
+      to change its VM options. You can still use this to change the settings for
+      the Gradle daemon which runs the actual build by setting the according Gradle
+      properties by `-D`. If you want to set the JVM arguments for the actual build
+      you would do this via `-Dorg.gradle.jvmargs=-Xmx1024M` (See ref: https://docs.gradle.org/7.3.3/userguide/build_environment.html#sec:gradle_configuration_properties).'
+    name: gradle-opts-env
     type: string
   - default: docker
     description: Path to the directory into which the resulting Java application jar
@@ -142,6 +152,8 @@ spec:
       value: /tekton/home
     - name: CI
       value: "true"
+    - name: GRADLE_OPTS
+      value: $(params.gradle-opts-env)
     - name: NEXUS_URL
       valueFrom:
         configMapKeyRef:
@@ -165,8 +177,8 @@ spec:
       build-gradle \
         --working-dir=$(params.working-dir) \
         --output-dir=$(params.output-dir) \
-        --gradle-additional-tasks=$(params.gradle-additional-tasks) \
-        --gradle-options=$(params.gradle-options)
+        --gradle-additional-tasks="$(params.gradle-additional-tasks)" \
+        --gradle-options="$(params.gradle-options)"
     workingDir: $(workspaces.source.path)
   - env:
     - name: HOME

--- a/deploy/central/tasks-chart/templates/task-ods-build-gradle.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-gradle.yaml
@@ -101,9 +101,18 @@ spec:
     - name: gradle-options
       description: >-
         Options to be passed to the gradle build.
-        (See ref: https://docs.gradle.org/current/userguide/command_line_interface.html#sec:command_line_debugging)
+        (See ref: https://docs.gradle.org/7.3.3/userguide/command_line_interface.html#sec:command_line_debugging)
       type: string
-      default: ""
+      default: "--no-daemon --stacktrace"
+    - name: gradle-opts-env
+      description: >-
+        Will be exposed to the build via `GRADLE_OPTS` environment variable.
+        Specifies JVM arguments to use when starting the Gradle client VM. The client VM only handles command line input/output, so it is rare that one would need to change its VM options.
+        You can still use this to change the settings for the Gradle daemon which runs the actual build by setting the according Gradle properties by `-D`.
+        If you want to set the JVM arguments for the actual build you would do this via `-Dorg.gradle.jvmargs=-Xmx1024M`
+        (See ref: https://docs.gradle.org/7.3.3/userguide/build_environment.html#sec:gradle_configuration_properties).
+      type: string
+      default: "-Dorg.gradle.jvmargs=-Xmx512M"
     - name: output-dir
       description: >-
         Path to the directory into which the resulting Java application jar should be copied, relative to `working-dir`.
@@ -132,6 +141,8 @@ spec:
           value: '/tekton/home'
         - name: CI
           value: "true"
+        - name: GRADLE_OPTS
+          value: "$(params.gradle-opts-env)"
         - name: NEXUS_URL
           valueFrom:
             configMapKeyRef:
@@ -153,8 +164,8 @@ spec:
         build-gradle \
           --working-dir=$(params.working-dir) \
           --output-dir=$(params.output-dir) \
-          --gradle-additional-tasks=$(params.gradle-additional-tasks) \
-          --gradle-options=$(params.gradle-options)
+          --gradle-additional-tasks="$(params.gradle-additional-tasks)" \
+          --gradle-options="$(params.gradle-options)"
       workingDir: $(workspaces.source.path)
     - name: scan-with-sonar
       # Image is built from build/package/Dockerfile.sonar.

--- a/docs/tasks/ods-build-gradle-with-sidecar.adoc
+++ b/docs/tasks/ods-build-gradle-with-sidecar.adoc
@@ -108,8 +108,13 @@ without leading `./` and trailing `/`.
 
 
 | gradle-options
-| 
-| Options to be passed to the gradle build. (See ref: https://docs.gradle.org/current/userguide/command_line_interface.html#sec:command_line_debugging)
+| --no-daemon --stacktrace
+| Options to be passed to the gradle build. (See ref: https://docs.gradle.org/7.3.3/userguide/command_line_interface.html#sec:command_line_debugging)
+
+
+| gradle-opts-env
+| -Dorg.gradle.jvmargs=-Xmx512M
+| Will be exposed to the build via `GRADLE_OPTS` environment variable. Specifies JVM arguments to use when starting the Gradle client VM. The client VM only handles command line input/output, so it is rare that one would need to change its VM options. You can still use this to change the settings for the Gradle daemon which runs the actual build by setting the according Gradle properties by `-D`. If you want to set the JVM arguments for the actual build you would do this via `-Dorg.gradle.jvmargs=-Xmx1024M` (See ref: https://docs.gradle.org/7.3.3/userguide/build_environment.html#sec:gradle_configuration_properties).
 
 
 | output-dir

--- a/docs/tasks/ods-build-gradle.adoc
+++ b/docs/tasks/ods-build-gradle.adoc
@@ -104,8 +104,13 @@ without leading `./` and trailing `/`.
 
 
 | gradle-options
-| 
-| Options to be passed to the gradle build. (See ref: https://docs.gradle.org/current/userguide/command_line_interface.html#sec:command_line_debugging)
+| --no-daemon --stacktrace
+| Options to be passed to the gradle build. (See ref: https://docs.gradle.org/7.3.3/userguide/command_line_interface.html#sec:command_line_debugging)
+
+
+| gradle-opts-env
+| -Dorg.gradle.jvmargs=-Xmx512M
+| Will be exposed to the build via `GRADLE_OPTS` environment variable. Specifies JVM arguments to use when starting the Gradle client VM. The client VM only handles command line input/output, so it is rare that one would need to change its VM options. You can still use this to change the settings for the Gradle daemon which runs the actual build by setting the according Gradle properties by `-D`. If you want to set the JVM arguments for the actual build you would do this via `-Dorg.gradle.jvmargs=-Xmx1024M` (See ref: https://docs.gradle.org/7.3.3/userguide/build_environment.html#sec:gradle_configuration_properties).
 
 
 | output-dir

--- a/test/tasks/ods-build-gradle_test.go
+++ b/test/tasks/ods-build-gradle_test.go
@@ -14,7 +14,6 @@ func TestTaskODSBuildGradle(t *testing.T) {
 	runTaskTestCases(t,
 		"ods-build-gradle",
 		[]tasktesting.Service{
-			tasktesting.Bitbucket,
 			tasktesting.Nexus,
 			tasktesting.SonarQube,
 		},
@@ -42,17 +41,26 @@ func TestTaskODSBuildGradle(t *testing.T) {
 						filepath.Join(pipelinectxt.SonarAnalysisPath, "quality-gate.json"),
 					)
 
-					logContains("No sonar-project.properties present, using default:", ctxt.CollectedLogs, t)
-					logContains("Using NEXUS_URL=http://ods-test-nexus.kind:8081", ctxt.CollectedLogs, t)
-					logContains("Gradle 7.3.3", ctxt.CollectedLogs, t)
+					logContains(ctxt.CollectedLogs, t,
+						"--gradle-options=--no-daemon --stacktrace",
+						"No sonar-project.properties present, using default:",
+						"Using NEXUS_URL=http://ods-test-nexus.kind:8081",
+						"Gradle 7.3.3",
+						"Using GRADLE_OPTS=-Dorg.gradle.jvmargs=-Xmx512M",
+						"To honour the JVM settings for this build a single-use Daemon process will be forked.",
+					)
 				},
 			},
 		})
 }
 
-func logContains(wantLogMsg string, collectedLogs []byte, t *testing.T) {
+func logContains(collectedLogs []byte, t *testing.T, wantLogMsgs ...string) {
 	logString := string(collectedLogs)
-	if !strings.Contains(logString, wantLogMsg) {
-		t.Fatalf("Want:\n%s\n\nGot:\n%s", wantLogMsg, logString)
+
+	for _, msg := range wantLogMsgs {
+		if !strings.Contains(logString, msg) {
+			t.Fatalf("Want:\n%s\n\nGot:\n%s", msg, logString)
+		}
 	}
+
 }

--- a/test/testdata/workspaces/gradle-sample-app/build.gradle
+++ b/test/testdata/workspaces/gradle-sample-app/build.gradle
@@ -3,7 +3,7 @@
  *
  * This generated file contains a sample Java application project to get you started.
  * For more details take a look at the 'Building Java & JVM projects' chapter in the Gradle
- * User Manual available at https://docs.gradle.org/7.2/userguide/building_java_projects.html
+ * User Manual available at https://docs.gradle.org/7.3.3/userguide/building_java_projects.html
  */
 buildscript {
     ext {

--- a/test/testdata/workspaces/gradle-sample-app/settings.gradle
+++ b/test/testdata/workspaces/gradle-sample-app/settings.gradle
@@ -4,7 +4,7 @@
  * The settings file is used to specify which projects to include in your build.
  *
  * Detailed information about configuring a multi-project build in Gradle can be found
- * in the user manual at https://docs.gradle.org/7.2/userguide/multi_project_builds.html
+ * in the user manual at https://docs.gradle.org/7.3.3/userguide/multi_project_builds.html
  */
 
 rootProject.name = 'gradle-sample-app'


### PR DESCRIPTION
Closes #386, #387  

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
