### PR TITLE
Export ARTIFACTS_DIR environment variable to be visible to the gradle…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ listed in the changelog.
 - Customizable Helm flags ([#388](https://github.com/opendevstack/ods-pipeline/issues/388))
 - Run gradle in non daemon mode by default and enabling stacktraces ([#386](https://github.com/opendevstack/ods-pipeline/issues/386)) 
 - Enable setting `GRADLE_OPTS` via task parameters ([#387](https://github.com/opendevstack/ods-pipeline/issues/387))
+- Export `ARTIFACTS_DIR` environment variable to be visible to the gradle build ([#408](https://github.com/opendevstack/ods-pipeline/issues/408))
 
 ### Changed
 

--- a/build/package/scripts/build-gradle.sh
+++ b/build/package/scripts/build-gradle.sh
@@ -4,7 +4,7 @@ set -eu
 OUTPUT_DIR="docker"
 WORKING_DIR="."
 ROOT_DIR=$(pwd)
-ARTIFACTS_DIR=$ROOT_DIR/.ods/artifacts
+export ARTIFACTS_DIR=$ROOT_DIR/.ods/artifacts
 ARTIFACT_PREFIX=
 DEBUG="${DEBUG:-false}"
 GRADLE_ADDITIONAL_TASKS=
@@ -43,6 +43,7 @@ export GRADLE_USER_HOME=/home/gradle/.gradle
 
 echo "Using NEXUS_URL=$NEXUS_URL"
 echo "Using GRADLE_OPTS=$GRADLE_OPTS"
+echo "Using ARTIFACTS_DIR=$ARTIFACTS_DIR"
 
 echo "Exported env var 'GRADLE_USER_HOME' with value '${GRADLE_USER_HOME}'"
 echo

--- a/test/tasks/ods-build-gradle_test.go
+++ b/test/tasks/ods-build-gradle_test.go
@@ -48,6 +48,7 @@ func TestTaskODSBuildGradle(t *testing.T) {
 						"Gradle 7.3.3",
 						"Using GRADLE_OPTS=-Dorg.gradle.jvmargs=-Xmx512M",
 						"To honour the JVM settings for this build a single-use Daemon process will be forked.",
+						"Using ARTIFACTS_DIR=/workspace/source/.ods/artifacts",
 					)
 				},
 			},


### PR DESCRIPTION
Export `ARTIFACTS_DIR` environment variable to be visible to the gradle build.

Closes #408 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
