### PR TITLE
Handle NotFound error specifically

### DIFF
--- a/internal/interceptor/server.go
+++ b/internal/interceptor/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/opendevstack/pipeline/pkg/config"
 	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -381,6 +382,9 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 func (s *Server) createPVCIfRequired(ctxt context.Context, pData PipelineData) error {
 	_, err := s.KubernetesClient.GetPersistentVolumeClaim(ctxt, pData.PVC, metav1.GetOptions{})
 	if err != nil {
+		if !kerrors.IsNotFound(err) {
+			return fmt.Errorf("could not determine if %s already exists: %w", pData.PVC, err)
+		}
 		vm := corev1.PersistentVolumeFilesystem
 		pvc := &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/kubernetes/test_client.go
+++ b/internal/kubernetes/test_client.go
@@ -3,10 +3,11 @@ package kubernetes
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kschema "k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // TestClient returns mocked resources.
@@ -25,7 +26,10 @@ func (c *TestClient) GetPersistentVolumeClaim(ctxt context.Context, name string,
 			return p, nil
 		}
 	}
-	return nil, fmt.Errorf("pipeline %s not found", name)
+	return nil, kerrors.NewNotFound(kschema.GroupResource{
+		Group:    "core",
+		Resource: "PersistentVolumeClaim",
+	}, name)
 }
 
 func (c *TestClient) CreatePersistentVolumeClaim(ctxt context.Context, pipeline *corev1.PersistentVolumeClaim, options metav1.CreateOptions) (*corev1.PersistentVolumeClaim, error) {


### PR DESCRIPTION
Otherwise all errors would lead to a creation attempt. While that
shouldn't break anything as creation would likely fail then, it is
better to immediately fail when we encounter an error that is not due to
the resource not being found.

Follow-up from #413.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
