### PR TITLE
Update skopeo (1.4 to 1.5) and buildah (1.22 to 1.23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ listed in the changelog.
 - Update gradle version to 7.3.3 to address log4j vulnerability and improved JDK 17 support. ([#395](https://github.com/opendevstack/ods-pipeline/issues/395))
 - Create and use one PVC per repository ([#160](https://github.com/opendevstack/ods-pipeline/issues/160))
 - Leaner NodeJS 16 Typescript image task, removed cypress and its dependencies ([#426](https://github.com/opendevstack/ods-pipeline/issues/426))
+- Update skopeo (from 1.4 to 1.5) and buildah (from 1.22 to 1.23) ([#430](https://github.com/opendevstack/ods-pipeline/issues/430))
 
 ### Fixed
 - Cannot enable debug mode in some tasks ([#377](https://github.com/opendevstack/ods-pipeline/issues/377))

--- a/build/package/Dockerfile.buildah
+++ b/build/package/Dockerfile.buildah
@@ -16,8 +16,8 @@ FROM registry.access.redhat.com/ubi8:8.4
 
 ARG aquasecScannerUrl
 
-ENV BUILDAH_VERSION=1.22 \
-    SKOPEO_VERSION=1.4
+ENV BUILDAH_VERSION=1.23 \
+    SKOPEO_VERSION=1.5
 
 COPY --from=builder /usr/local/bin/ods-build-push-image /usr/local/bin/ods-build-push-image
 

--- a/build/package/Dockerfile.helm
+++ b/build/package/Dockerfile.helm
@@ -41,7 +41,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 ENV HELM_PLUGIN_DIFF_VERSION=3.3.2 \
     HELM_PLUGIN_SECRETS_VERSION=3.10.0 \
     HELM_PLUGINS=/usr/local/helm/plugins \
-    SKOPEO_VERSION=1.4 \
+    SKOPEO_VERSION=1.5 \
     TAR_VERSION=1.30 \
     GIT_VERSION=2.27
 

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -488,13 +488,13 @@ For all repositories in scope, the artifacts in the corresponding groups in Nexu
 
 | SDS-EXT-17
 | Skopeo
-| 1.4
+| 1.5
 | Tool for moving container images between different types of container storages.
 | https://github.com/containers/skopeo
 
 | SDS-EXT-18
 | Buildah
-| 1.22
+| 1.23
 | Tool that facilitates building OCI images.
 | https://github.com/containers/buildah
 


### PR DESCRIPTION
Fixes #430 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
