### PR TITLE
Configure SONAR_EDITION via ConfigMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ listed in the changelog.
 
 ### Changed
 
+- Use configmap `ods-sonar` to configure SonarQube edition ([#410](https://github.com/opendevstack/ods-pipeline/issues/410))
 - Prevent existing image streams from being cleaned up if they are renamed in future versions ([#366](https://github.com/opendevstack/ods-pipeline/issues/366))
 - Add `build-dir` and `copy-node-modules` parameters to TypeScript build task to make it more suitable for FE builds ([#356](https://github.com/opendevstack/ods-pipeline/issues/356))
 - Update gradle version to 7.3.3 to address log4j vulnerability and improved JDK 17 support. ([#395](https://github.com/opendevstack/ods-pipeline/issues/395))

--- a/build/package/Dockerfile.sonar
+++ b/build/package/Dockerfile.sonar
@@ -29,8 +29,7 @@ RUN cd cmd/sonar && CGO_ENABLED=0 go build -o /usr/local/bin/sonar
 # Final image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
-ARG sonarEdition=community
-ENV SONAR_EDITION=$sonarEdition
+ENV SONAR_EDITION="community"
 
 RUN microdnf install --nodocs java-11-openjdk-headless which && microdnf clean all
 

--- a/deploy/cd-namespace/chart/templates/configmap-sonar.yaml
+++ b/deploy/cd-namespace/chart/templates/configmap-sonar.yaml
@@ -6,3 +6,4 @@ metadata:
     {{- include "chart.labels" . | nindent 4}}
 data:
   url: '{{.Values.sonarUrl}}'
+  edition: '{{.Values.sonarEdition | default "community" }}'

--- a/deploy/cd-namespace/chart/values.yaml
+++ b/deploy/cd-namespace/chart/values.yaml
@@ -25,6 +25,8 @@ nexusPermanentRepository: 'ods-permanent-artifacts'
 sonarUrl: ''
 # SonarQube username. Example: developer.
 sonarUsername: ''
+# SonarQube edition. Valid options: 'community', 'developer', 'enterprise' or 'datacenter'
+sonarEdition: 'community'
 
 # Aqua
 # Aqua URL (including scheme). Example: https://aqua.example.com.

--- a/deploy/central/images-chart/templates/bc-ods-sonar.yaml
+++ b/deploy/central/images-chart/templates/bc-ods-sonar.yaml
@@ -18,9 +18,6 @@ spec:
       from:
         kind: DockerImage
         name: 'registry.redhat.io/ubi8/ubi-minimal:8.4'
-      buildArgs:
-        - name: sonarEdition
-          value: '{{.Values.sonarEdition}}'
       pullSecret:
         name: registry.redhat.io
   postCommit: {}

--- a/deploy/central/images-chart/values.yaml
+++ b/deploy/central/images-chart/values.yaml
@@ -7,7 +7,3 @@ taskSuffix: -v0-2-0
 # Git
 odsPipelineGitRepoUri: https://github.com/opendevstack/ods-pipeline
 odsPipelineGitRepoRef: v0.2.0
-
-# Sonar
-# Edition of SonarQube server. One of "community", "developer", "enterprise" or "datacenter".
-sonarEdition: 'community'

--- a/deploy/central/tasks-chart/templates/task-ods-build-go-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-go-with-sidecar.yaml
@@ -131,6 +131,11 @@ spec:
         configMapKeyRef:
           key: url
           name: ods-sonar
+    - name: SONAR_EDITION
+      valueFrom:
+        configMapKeyRef:
+          key: edition
+          name: ods-sonar
     - name: SONAR_AUTH_TOKEN
       valueFrom:
         secretKeyRef:

--- a/deploy/central/tasks-chart/templates/task-ods-build-go.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-go.yaml
@@ -118,6 +118,11 @@ spec:
             configMapKeyRef:
               key: url
               name: ods-sonar
+        - name: SONAR_EDITION
+          valueFrom:
+            configMapKeyRef:
+              key: edition
+              name: ods-sonar
         - name: SONAR_AUTH_TOKEN
           valueFrom:
             secretKeyRef:

--- a/deploy/central/tasks-chart/templates/task-ods-build-gradle-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-gradle-with-sidecar.yaml
@@ -198,6 +198,11 @@ spec:
         configMapKeyRef:
           key: url
           name: ods-sonar
+    - name: SONAR_EDITION
+      valueFrom:
+        configMapKeyRef:
+          key: edition
+          name: ods-sonar
     - name: SONAR_AUTH_TOKEN
       valueFrom:
         secretKeyRef:

--- a/deploy/central/tasks-chart/templates/task-ods-build-gradle.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-gradle.yaml
@@ -187,6 +187,11 @@ spec:
             configMapKeyRef:
               key: url
               name: ods-sonar
+        - name: SONAR_EDITION
+          valueFrom:
+            configMapKeyRef:
+              key: edition
+              name: ods-sonar
         - name: SONAR_AUTH_TOKEN
           valueFrom:
             secretKeyRef:

--- a/deploy/central/tasks-chart/templates/task-ods-build-python-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-python-with-sidecar.yaml
@@ -121,6 +121,11 @@ spec:
         configMapKeyRef:
           key: url
           name: ods-sonar
+    - name: SONAR_EDITION
+      valueFrom:
+        configMapKeyRef:
+          key: edition
+          name: ods-sonar
     - name: SONAR_AUTH_TOKEN
       valueFrom:
         secretKeyRef:

--- a/deploy/central/tasks-chart/templates/task-ods-build-python.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-python.yaml
@@ -110,6 +110,11 @@ spec:
             configMapKeyRef:
               key: url
               name: ods-sonar
+        - name: SONAR_EDITION
+          valueFrom:
+            configMapKeyRef:
+              key: edition
+              name: ods-sonar
         - name: SONAR_AUTH_TOKEN
           valueFrom:
             secretKeyRef:

--- a/deploy/central/tasks-chart/templates/task-ods-build-typescript-with-sidecar.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-typescript-with-sidecar.yaml
@@ -154,6 +154,11 @@ spec:
         configMapKeyRef:
           key: url
           name: ods-sonar
+    - name: SONAR_EDITION
+      valueFrom:
+        configMapKeyRef:
+          key: edition
+          name: ods-sonar
     - name: SONAR_AUTH_TOKEN
       valueFrom:
         secretKeyRef:

--- a/deploy/central/tasks-chart/templates/task-ods-build-typescript.yaml
+++ b/deploy/central/tasks-chart/templates/task-ods-build-typescript.yaml
@@ -146,6 +146,11 @@ spec:
             configMapKeyRef:
               key: url
               name: ods-sonar
+        - name: SONAR_EDITION
+          valueFrom:
+            configMapKeyRef:
+              key: edition
+              name: ods-sonar
         - name: SONAR_AUTH_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Don't bake `SONAR_EDITION` into `ods-sonar` image but make it configurable via ConfigMap `ods-sonar`.

Closes #410 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
