### PR TITLE
webhook interceptor with ods.yaml filename in e2e test

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -107,7 +107,15 @@ branchToEnvironmentMapping:
 environments:
   - name: dev
     stage: dev
-pipeline: {}`
+pipeline:
+  tasks:
+    - name: package-image
+      taskRef:
+        kind: ClusterTask
+        name: ods-package-image
+      workspaces:
+        - name: source
+          workspace: shared-workspace`
 
 	err = ioutil.WriteFile(filepath.Join(wsDir, filename), []byte(fileContent), 0644)
 	if err != nil {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -98,26 +98,16 @@ func TestWebhookInterceptor(t *testing.T) {
 	}
 
 	// Push a commit, which should trigger a webhook, which in turn should start a pipeline run.
-	filename := "ods.yml"
+	filename := "ods.yaml"
 	fileContent := `
-	version: 2022.2.0
-
-	branchToEnvironmentMapping:
-		- branch: master
-		  environment: dev
-
-	environments:
-		- name: dev
-		  stage: dev
-	pipeline:
-		tasks:
-		  - name: package-image
-			taskRef:
-			kind: ClusterTask
-			name: ods-package-image
-			workspaces:
-			- name: source
-			  workspace: shared-workspace`
+version: 2022.2.0
+branchToEnvironmentMapping:
+  - branch: master
+    environment: dev
+environments:
+  - name: dev
+    stage: dev
+pipeline: {}`
 
 	err = ioutil.WriteFile(filepath.Join(wsDir, filename), []byte(fileContent), 0644)
 	if err != nil {
@@ -135,7 +125,7 @@ func TestWebhookInterceptor(t *testing.T) {
 	t.Log("Sleeping for 10s to make it work - unsure why needed ...")
 	time.Sleep(10 * time.Second)
 	t.Log("Pushing file to Bitbucket ...")
-	tasktesting.PushFileToBitbucketOrFatal(t, c.KubernetesClientSet, ns, wsDir, "master", "ods.yml")
+	tasktesting.PushFileToBitbucketOrFatal(t, c.KubernetesClientSet, ns, wsDir, "master", "ods.yaml")
 	triggerTimeout := time.Minute
 	t.Logf("Waiting %s for pipeline run to be triggered ...", triggerTimeout)
 	pr, err := waitForPipelineRunToBeTriggered(c.TektonClientSet, ns, triggerTimeout)


### PR DESCRIPTION
Fixes #441 

I have detected that if we add specific tasks in the pipeline definition then the webhook request from bitbucket gets a 500 server error response making the whole pipeline never start, and we get a "context deadline exceeded" error when waiting for the pipeline run to be triggered.

Hence I think we have another bug within the test.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
