### PR TITLE
Remove WriteHeader call

### DIFF
--- a/internal/manager/server.go
+++ b/internal/manager/server.go
@@ -447,8 +447,6 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 		log.Println(requestID, fmt.Sprintf("cannot write body: %s", err))
 		return
 	}
-
-	w.WriteHeader(http.StatusOK)
 }
 
 // createPipelineRun creates a PipelineRun resource


### PR DESCRIPTION
According to the docs, "the first call to Write will trigger an implicit WriteHeader(http.StatusOK). Thus explicit calls to WriteHeader are mainly used to send error codes".

Removing the call avoids to run into "http: superfluous
response.WriteHeader call" as seen e.g. in https://github.com/opendevstack/ods-pipeline/runs/5234208813?check_suite_focus=true.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
