### PR TITLE
separate gradle build into test and build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ listed in the changelog.
 - Prune pipelines and pipeline runs ([#153](https://github.com/opendevstack/ods-pipeline/issues/153)). Note that any pipeline runs created with 0.2.0 or earlier will not be cleaned up and need to be dealt with manually.
 - Log artifact URL after upload ([#384](https://github.com/opendevstack/ods-pipeline/issues/384))
 - Remove Tekton Triggers, moving the required functionality it provided into the new ODS pipeline manager ([#438](https://github.com/opendevstack/ods-pipeline/issues/438))
+- Implement skipping tests for Gradle ([239](https://github.com/opendevstack/ods-pipeline/issues/239))
 
 ### Fixed
 - Cannot enable debug mode in some tasks ([#377](https://github.com/opendevstack/ods-pipeline/issues/377))

--- a/build/package/scripts/build-gradle.sh
+++ b/build/package/scripts/build-gradle.sh
@@ -69,10 +69,10 @@ echo "Building ..."
 UNIT_TEST_ARTIFACTS_DIR="${ARTIFACTS_DIR}/xunit-reports"
 CODE_COVERAGE_ARTIFACTS_DIR="${ARTIFACTS_DIR}/code-coverage"
 
-if [ -f "${UNIT_TEST_ARTIFACTS_DIR}/${ARTIFACT_PREFIX}report.xml" ] && [ -f "${CODE_COVERAGE_ARTIFACTS_DIR}/${ARTIFACT_PREFIX}coverage.xml" ]; then
+if [ "$(ls "${UNIT_TEST_ARTIFACTS_DIR}" 2>/dev/null)" ] && [ -f "${CODE_COVERAGE_ARTIFACTS_DIR}/${ARTIFACT_PREFIX}coverage.xml" ]; then
   echo "Test artifacts already present, skipping tests ..."
   # Copy artifacts to working directory so that the SonarQube scanner can pick them up later.
-  cp "${UNIT_TEST_ARTIFACTS_DIR}/${ARTIFACT_PREFIX}report.xml" report.xml
+  cp "${UNIT_TEST_ARTIFACTS_DIR}" .
   cp "${CODE_COVERAGE_ARTIFACTS_DIR}/${ARTIFACT_PREFIX}coverage.xml" coverage.xml
 
   # shellcheck disable=SC2086
@@ -85,7 +85,7 @@ else
   UNIT_TEST_RESULT_DIR="${BUILD_DIR}/test-results/test"
   if [ -d "${UNIT_TEST_RESULT_DIR}" ]; then
       mkdir -p "${UNIT_TEST_ARTIFACTS_DIR}"
-      cp "${UNIT_TEST_RESULT_DIR}/"*.xml "${UNIT_TEST_ARTIFACTS_DIR}/${ARTIFACT_PREFIX}"
+      cp "${UNIT_TEST_RESULT_DIR}/"*.xml "${UNIT_TEST_ARTIFACTS_DIR}"
   else
     echo "Build failed: no unit test results found in ${UNIT_TEST_RESULT_DIR}"
     exit 1

--- a/build/package/scripts/build-gradle.sh
+++ b/build/package/scripts/build-gradle.sh
@@ -65,17 +65,21 @@ export ODS_OUTPUT_DIR=${OUTPUT_DIR}
 echo "Exported env var 'ODS_OUTPUT_DIR' with value '${OUTPUT_DIR}'"
 echo
 
-echo "Testing ..."
+echo "Building ..."
 UNIT_TEST_ARTIFACTS_DIR="${ARTIFACTS_DIR}/xunit-reports"
 CODE_COVERAGE_ARTIFACTS_DIR="${ARTIFACTS_DIR}/code-coverage"
 
-if [ -f "${UNIT_TEST_ARTIFACTS_DIR}/${ARTIFACT_PREFIX}report.xml" ]; then
+if [ -f "${UNIT_TEST_ARTIFACTS_DIR}/${ARTIFACT_PREFIX}report.xml" ] && [ -f "${CODE_COVERAGE_ARTIFACTS_DIR}/${ARTIFACT_PREFIX}coverage.xml" ]; then
   echo "Test artifacts already present, skipping tests ..."
   # Copy artifacts to working directory so that the SonarQube scanner can pick them up later.
   cp "${UNIT_TEST_ARTIFACTS_DIR}/${ARTIFACT_PREFIX}report.xml" report.xml
   cp "${CODE_COVERAGE_ARTIFACTS_DIR}/${ARTIFACT_PREFIX}coverage.xml" coverage.xml
+
+  # shellcheck disable=SC2086
+  ./gradlew clean build -x test ${GRADLE_ADDITIONAL_TASKS} ${GRADLE_OPTIONS}
 else
-  ./gradlew clean test
+  # shellcheck disable=SC2086
+  ./gradlew clean build ${GRADLE_ADDITIONAL_TASKS} ${GRADLE_OPTIONS}
 
   echo "Verifying unit test report was generated  ..."
   UNIT_TEST_RESULT_DIR="${BUILD_DIR}/test-results/test"
@@ -97,11 +101,6 @@ else
     exit 1
   fi
 fi
-
-echo
-echo "Building ..."
-# shellcheck disable=SC2086
-./gradlew clean build -x test ${GRADLE_ADDITIONAL_TASKS} ${GRADLE_OPTIONS}
 echo
 
 supply-sonar-project-properties-default

--- a/build/package/scripts/build-gradle.sh
+++ b/build/package/scripts/build-gradle.sh
@@ -64,7 +64,6 @@ export ODS_OUTPUT_DIR=${OUTPUT_DIR}
 echo "Exported env var 'ODS_OUTPUT_DIR' with value '${OUTPUT_DIR}'"
 echo
 
-
 echo "Testing ..."
 if [ -f "${ROOT_DIR}/.ods/artifacts/xunit-reports/${ARTIFACT_PREFIX}report.xml" ]; then
   echo "Test artifacts already present, skipping tests ..."
@@ -99,6 +98,7 @@ else
   exit 1
 fi
 
+echo
 echo "Building ..."
 # shellcheck disable=SC2086
 ./gradlew clean build -x test ${GRADLE_ADDITIONAL_TASKS} ${GRADLE_OPTIONS}

--- a/build/package/scripts/build-gradle.sh
+++ b/build/package/scripts/build-gradle.sh
@@ -63,10 +63,17 @@ echo
 export ODS_OUTPUT_DIR=${OUTPUT_DIR}
 echo "Exported env var 'ODS_OUTPUT_DIR' with value '${OUTPUT_DIR}'"
 echo
-echo "Building (Compile and Test) ..."
-# shellcheck disable=SC2086
-./gradlew clean build ${GRADLE_ADDITIONAL_TASKS} ${GRADLE_OPTIONS}
-echo
+
+
+echo "Testing ..."
+if [ -f "${ROOT_DIR}/.ods/artifacts/xunit-reports/${ARTIFACT_PREFIX}report.xml" ]; then
+  echo "Test artifacts already present, skipping tests ..."
+  # Copy artifacts to working directory so that the SonarQube scanner can pick them up later.
+  cp "${ROOT_DIR}/.ods/artifacts/xunit-reports/${ARTIFACT_PREFIX}report.xml" report.xml
+  cp "${ROOT_DIR}/.ods/artifacts/code-coverage/${ARTIFACT_PREFIX}coverage.out" coverage.out
+else
+  ./gradlew clean test
+fi
 
 echo "Verifying unit test report was generated  ..."
 BUILD_DIR="build"
@@ -91,5 +98,10 @@ else
   echo "Build failed: no unit test coverage report was found in ${COVERAGE_RESULT_DIR}"
   exit 1
 fi
+
+echo "Building ..."
+# shellcheck disable=SC2086
+./gradlew clean build -x test ${GRADLE_ADDITIONAL_TASKS} ${GRADLE_OPTIONS}
+echo
 
 supply-sonar-project-properties-default


### PR DESCRIPTION
Closes #239 

This basically runs `gradle build -x test` (skip tests) if unit- AND coverage xml files are present, otherwise runs the build (with tests) like before.

**Note:** I could not test the 'tests are existing' case because my laptop is not powerful enough to run tests locally and on github this artifact dir `.ods/artifacts` does not seem to survive two runs.