### PR TITLE
Add xargs in helm image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ listed in the changelog.
 - Gradle task does not expose Nexus env variables ([#373](https://github.com/opendevstack/ods-pipeline/issues/373))
 - Gradle build fails when it contains more than one test class ([#414](https://github.com/opendevstack/ods-pipeline/issues/414))
 - Gradle proxy settings are set during prepare-local-env ([#291](https://github.com/opendevstack/ods-pipeline/issues/291))
+- Add `xargs` to helm image as `helm-secrets` depends on it ([#465](https://github.com/opendevstack/ods-pipeline/issues/465))
 
 ## [0.2.0] - 2021-12-22
 ### Added

--- a/build/package/Dockerfile.helm
+++ b/build/package/Dockerfile.helm
@@ -45,7 +45,9 @@ ENV HELM_PLUGIN_DIFF_VERSION=3.3.2 \
     TAR_VERSION=1.30 \
     GIT_VERSION=2.27
 
-RUN microdnf install skopeo-${SKOPEO_VERSION}* git-${GIT_VERSION}* tar-${TAR_VERSION}* && microdnf clean all
+# helm-secrets depends on xargs (from GNU findutils) in it's signal handlers,
+# c.f. https://github.com/jkroepke/helm-secrets/blob/main/scripts/commands/helm.sh#L34-L36
+RUN microdnf install skopeo-${SKOPEO_VERSION}* git-${GIT_VERSION}* tar-${TAR_VERSION}* findutils && microdnf clean all
 
 COPY --from=builder /usr/local/bin/deploy-with-helm /usr/local/bin/deploy-with-helm
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm

--- a/build/package/Dockerfile.helm
+++ b/build/package/Dockerfile.helm
@@ -43,11 +43,12 @@ ENV HELM_PLUGIN_DIFF_VERSION=3.3.2 \
     HELM_PLUGINS=/usr/local/helm/plugins \
     SKOPEO_VERSION=1.5 \
     TAR_VERSION=1.30 \
-    GIT_VERSION=2.27
+    GIT_VERSION=2.27 \
+    FINDUTILS_VERSION=4.6.0
 
 # helm-secrets depends on xargs (from GNU findutils) in it's signal handlers,
 # c.f. https://github.com/jkroepke/helm-secrets/blob/main/scripts/commands/helm.sh#L34-L36
-RUN microdnf install skopeo-${SKOPEO_VERSION}* git-${GIT_VERSION}* tar-${TAR_VERSION}* findutils && microdnf clean all
+RUN microdnf install skopeo-${SKOPEO_VERSION}* git-${GIT_VERSION}* tar-${TAR_VERSION}* findutils-${FINDUTILS_VERSION} && microdnf clean all
 
 COPY --from=builder /usr/local/bin/deploy-with-helm /usr/local/bin/deploy-with-helm
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm

--- a/build/package/Dockerfile.helm
+++ b/build/package/Dockerfile.helm
@@ -44,11 +44,11 @@ ENV HELM_PLUGIN_DIFF_VERSION=3.3.2 \
     SKOPEO_VERSION=1.5 \
     TAR_VERSION=1.30 \
     GIT_VERSION=2.27 \
-    FINDUTILS_VERSION=4.6.0
+    FINDUTILS_VERSION=4.6
 
 # helm-secrets depends on xargs (from GNU findutils) in it's signal handlers,
 # c.f. https://github.com/jkroepke/helm-secrets/blob/main/scripts/commands/helm.sh#L34-L36
-RUN microdnf install skopeo-${SKOPEO_VERSION}* git-${GIT_VERSION}* tar-${TAR_VERSION}* findutils-${FINDUTILS_VERSION} && microdnf clean all
+RUN microdnf install skopeo-${SKOPEO_VERSION}* git-${GIT_VERSION}* tar-${TAR_VERSION}* findutils-${FINDUTILS_VERSION}* && microdnf clean all
 
 COPY --from=builder /usr/local/bin/deploy-with-helm /usr/local/bin/deploy-with-helm
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -562,7 +562,7 @@ For all repositories in scope, the artifacts in the corresponding groups in Nexu
 
 | SDS-EXT-29
 | GNU findutils
-| 4.6.0
+| 4.6
 | Basic directory searching utilities, included due to the dependency of `helm-secrets` on `xargs`
 | https://www.gnu.org/software/findutils/
 

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -560,6 +560,12 @@ For all repositories in scope, the artifacts in the corresponding groups in Nexu
 | Python 3.9 available as container is a base platform for building and running various Python applications and frameworks. It is maintained by Red Hat and updated regularly.
 | https://catalog.redhat.com/software/containers/ubi8/python-39/6065b24eb92fbda3a4c65d8f
 
+| SDS-EXT-29
+| GNU findutils
+| 4.6.0
+| Basic directory searching utilities, included due to the dependency of `helm-secrets` on `xargs`
+| https://www.gnu.org/software/findutils/
+
 |===
 
 == Appendix

--- a/test/tasks/ods-deploy-helm_test.go
+++ b/test/tasks/ods-deploy-helm_test.go
@@ -99,7 +99,7 @@ func TestTaskODSDeployHelm(t *testing.T) {
 					if strings.Contains(string(ctxt.CollectedLogs), doNotWantLogMsg) {
 						t.Fatalf("Do not want:\n%s\n\nGot:\n%s", doNotWantLogMsg, string(ctxt.CollectedLogs))
 					}
-					wantLogMsg := "plugin \"diff\" identified at least one change"
+					wantLogMsg := "identified at least one change"
 					if !strings.Contains(string(ctxt.CollectedLogs), wantLogMsg) {
 						t.Fatalf("Want:\n%s\n\nGot:\n%s", wantLogMsg, string(ctxt.CollectedLogs))
 					}


### PR DESCRIPTION
`helm-secrets` depends on `xargs` (from GNU findutils) in its signal handlers. In rare circumstances (e.g. when helm unexpectedly fails), this will generate a `command not found` error and prevent the signal handler from cleaning up.

Fixes #465

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
