### PR TITLE
remove logging of test reports for typescript and python build tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ listed in the changelog.
 - Remove Tekton Triggers, moving the required functionality it provided into the new ODS pipeline manager ([#438](https://github.com/opendevstack/ods-pipeline/issues/438))
 - Use UBI8 provided Python 3.9 toolset image ([#457](https://github.com/opendevstack/ods-pipeline/issues/457))
 - Change installation mode from centralized to local/namespaced ([#404](https://github.com/opendevstack/ods-pipeline/pull/404))
+- Removed logging of test reports for TypeScript and Python build tasks ([#470](https://github.com/opendevstack/ods-pipeline/issues/470))
 
 ### Fixed
 - Cannot enable debug mode in some tasks ([#377](https://github.com/opendevstack/ods-pipeline/issues/377))

--- a/build/package/scripts/build-python.sh
+++ b/build/package/scripts/build-python.sh
@@ -82,10 +82,8 @@ rm report.xml coverage.xml &>/dev/null || true
 PYTHONPATH=src python -m pytest --junitxml=report.xml -o junit_family=xunit2 --cov-report term-missing --cov-report xml:coverage.xml --cov=src -o testpaths=tests
 
 mkdir -p "${ROOT_DIR}/.ods/artifacts/xunit-reports"
-cat report.xml
 cp report.xml "${ROOT_DIR}/.ods/artifacts/xunit-reports/${ARTIFACT_PREFIX}report.xml"
 mkdir -p "${ROOT_DIR}/.ods/artifacts/code-coverage"
-cat coverage.xml
 cp coverage.xml "${ROOT_DIR}/.ods/artifacts/code-coverage/${ARTIFACT_PREFIX}coverage.xml"
 
 echo "Copying src and requirements.txt to ${OUTPUT_DIR}/app ..."

--- a/build/package/scripts/build-typescript.sh
+++ b/build/package/scripts/build-typescript.sh
@@ -138,17 +138,13 @@ else
   npm run test
 
   mkdir -p "${ROOT_DIR}/.ods/artifacts/xunit-reports"
-  cat build/test-results/test/report.xml
   cp build/test-results/test/report.xml "${ROOT_DIR}/.ods/artifacts/xunit-reports/${ARTIFACT_PREFIX}report.xml"
 
   mkdir -p "${ROOT_DIR}/.ods/artifacts/code-coverage"
-  cat build/coverage/clover.xml
   cp build/coverage/clover.xml "${ROOT_DIR}/.ods/artifacts/code-coverage/${ARTIFACT_PREFIX}clover.xml"
 
-  cat build/coverage/coverage-final.json
   cp build/coverage/coverage-final.json "${ROOT_DIR}/.ods/artifacts/code-coverage/${ARTIFACT_PREFIX}coverage-final.json"
 
-  cat build/coverage/lcov.info
   cp build/coverage/lcov.info "${ROOT_DIR}/.ods/artifacts/code-coverage/${ARTIFACT_PREFIX}lcov.info"
 fi
 


### PR DESCRIPTION
Closes #470 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
