### PR TITLE
Fix illegal characters in gitRef label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ listed in the changelog.
 - Gradle task does not expose Nexus env variables ([#373](https://github.com/opendevstack/ods-pipeline/issues/373))
 - Gradle build fails when it contains more than one test class ([#414](https://github.com/opendevstack/ods-pipeline/issues/414))
 - Gradle proxy settings are set during prepare-local-env ([#291](https://github.com/opendevstack/ods-pipeline/issues/291))
+- Pipeline creation fails when branch names contain slashes ([#466](https://github.com/opendevstack/ods-pipeline/issues/466))
 
 ## [0.2.0] - 2021-12-22
 ### Added

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -108,7 +108,7 @@ func TestE2E(t *testing.T) {
 	fileContent := `
 version: 2022.2.0
 branchToEnvironmentMapping:
-  - branch: master
+  - branch: "*"
     environment: dev
 environments:
   - name: dev
@@ -135,7 +135,7 @@ pipeline:
 		t.Fatal(err)
 	}
 	t.Log("Pushing file to Bitbucket ...")
-	tasktesting.PushFileToBitbucketOrFatal(t, c.KubernetesClientSet, ns, wsDir, "master", "ods.yaml")
+	tasktesting.PushFileToBitbucketOrFatal(t, c.KubernetesClientSet, ns, wsDir, "master:feature/test-branch", "ods.yaml")
 	triggerTimeout := time.Minute
 	t.Logf("Waiting %s for pipeline run to be triggered ...", triggerTimeout)
 	pr, err := waitForPipelineRunToBeTriggered(c.TektonClientSet, ns, triggerTimeout)


### PR DESCRIPTION
Pipelines for branches that contained e.g. slashes couldn't be created due to kubernetes' label value validity rules.

Fixes #466

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
