### PR TITLE
Configure pipeline manager's taskSuffix & taskKind via deployment

### DIFF
--- a/build/package/Dockerfile.pipeline-manager
+++ b/build/package/Dockerfile.pipeline-manager
@@ -14,11 +14,6 @@ RUN cd cmd/pipeline-manager && CGO_ENABLED=0 go build -o /usr/local/bin/pipeline
 # ubi-micro cannot be used as it misses the ca-certificates package.
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
-ARG taskKind
-ARG taskSuffix
-ENV ODS_TASK_KIND=$taskKind
-ENV ODS_TASK_SUFFIX=$taskSuffix
-
 COPY --from=builder /usr/local/bin/pipeline-manager /usr/local/bin/pipeline-manager
 EXPOSE 8080
 

--- a/deploy/ods-pipeline/charts/setup/templates/deployment.yaml
+++ b/deploy/ods-pipeline/charts/setup/templates/deployment.yaml
@@ -57,6 +57,10 @@ spec:
               value: '{{int .Values.pipelineRunMinKeepHours}}'
             - name: ODS_PRUNE_MAX_KEEP_RUNS
               value: '{{int .Values.pipelineRunMaxKeepRuns}}'
+            - name: ODS_TASK_KIND
+              value: '{{.Values.global.taskSuffix}}'
+            - name: ODS_TASK_SUFFIX
+              value: '{{default "Task" .Values.global.taskKind}}'
           readinessProbe:
             httpGet:
               path: /health

--- a/deploy/ods-pipeline/charts/setup/templates/deployment.yaml
+++ b/deploy/ods-pipeline/charts/setup/templates/deployment.yaml
@@ -58,9 +58,9 @@ spec:
             - name: ODS_PRUNE_MAX_KEEP_RUNS
               value: '{{int .Values.pipelineRunMaxKeepRuns}}'
             - name: ODS_TASK_KIND
-              value: '{{.Values.global.taskSuffix}}'
-            - name: ODS_TASK_SUFFIX
               value: '{{default "Task" .Values.global.taskKind}}'
+            - name: ODS_TASK_SUFFIX
+              value: '{{.Values.global.taskSuffix}}'
           readinessProbe:
             httpGet:
               path: /health

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-go.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-go.yaml
@@ -1,5 +1,5 @@
 apiVersion: tekton.dev/v1beta1
-kind: '{{default "Task" .Values.taskKind}}'
+kind: '{{default "Task" .Values.global.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-build-go{{.Values.global.taskSuffix}}'
 spec:

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
@@ -1,5 +1,5 @@
 apiVersion: tekton.dev/v1beta1
-kind: '{{default "Task" .Values.taskKind}}'
+kind: '{{default "Task" .Values.global.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-build-gradle{{.Values.global.taskSuffix}}'
 spec:

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-python.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-python.yaml
@@ -1,5 +1,5 @@
 apiVersion: tekton.dev/v1beta1
-kind: '{{default "Task" .Values.taskKind}}'
+kind: '{{default "Task" .Values.global.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-build-python{{.Values.global.taskSuffix}}'
 spec:

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-typescript.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-typescript.yaml
@@ -1,5 +1,5 @@
 apiVersion: tekton.dev/v1beta1
-kind: '{{default "Task" .Values.taskKind}}'
+kind: '{{default "Task" .Values.global.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-build-typescript{{.Values.global.taskSuffix}}'
 spec:

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-deploy-helm.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-deploy-helm.yaml
@@ -1,5 +1,5 @@
 apiVersion: tekton.dev/v1beta1
-kind: '{{default "Task" .Values.taskKind}}'
+kind: '{{default "Task" .Values.global.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-deploy-helm{{.Values.global.taskSuffix}}'
 spec:

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-finish.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-finish.yaml
@@ -1,5 +1,5 @@
 apiVersion: tekton.dev/v1beta1
-kind: '{{default "Task" .Values.taskKind}}'
+kind: '{{default "Task" .Values.global.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-finish{{.Values.global.taskSuffix}}'
 spec:

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-package-image.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-package-image.yaml
@@ -1,5 +1,5 @@
 apiVersion: tekton.dev/v1beta1
-kind: '{{default "Task" .Values.taskKind}}'
+kind: '{{default "Task" .Values.global.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-package-image{{.Values.global.taskSuffix}}'
 spec:

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-start.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-start.yaml
@@ -1,5 +1,5 @@
 apiVersion: tekton.dev/v1beta1
-kind: '{{default "Task" .Values.taskKind}}'
+kind: '{{default "Task" .Values.global.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-start{{.Values.global.taskSuffix}}'
 spec:

--- a/deploy/ods-pipeline/values.yaml
+++ b/deploy/ods-pipeline/values.yaml
@@ -6,6 +6,8 @@ global:
   imageTag: 0.2.0
   # Suffix to append to the task name.
   taskSuffix: -v0-2-0
+  # Custom task kind (defaults to "Task")
+  # taskKind: "ClusterTask"
 
 
 # ####################################### #
@@ -184,9 +186,6 @@ tasks:
 
 
   # Optional Values
-
-  # Custom task kind (defaults to "Task")
-  # taskKind: "ClusterTask"
 
   # Custom task prefix (defaults to "ods")
   # taskPrefix: "foo"


### PR DESCRIPTION
Move definition of `ODS_TASK_KIND` and `ODS_TASK_SUFFIX` from dockerfile to deployment

Closes #478 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
