### PR TITLE
Prepare queueing

### DIFF
--- a/internal/manager/bitbucket.go
+++ b/internal/manager/bitbucket.go
@@ -1,0 +1,88 @@
+package manager
+
+import (
+	"fmt"
+
+	"github.com/opendevstack/pipeline/pkg/bitbucket"
+)
+
+type bitbucketInterface interface {
+	bitbucket.CommitClientInterface
+	bitbucket.RawClientInterface
+	bitbucket.RepoClientInterface
+}
+
+type repository struct {
+	Project struct {
+		Key string `json:"key"`
+	} `json:"project"`
+	Slug string `json:"slug"`
+}
+type requestBitbucket struct {
+	EventKey   string     `json:"eventKey"`
+	Repository repository `json:"repository"`
+	Changes    []struct {
+		Type string `json:"type"`
+		Ref  struct {
+			ID        string `json:"id"`
+			DisplayID string `json:"displayId"`
+			Type      string `json:"type"`
+		} `json:"ref"`
+		FromHash string `json:"fromHash"`
+		ToHash   string `json:"toHash"`
+	} `json:"changes"`
+	PullRequest *struct {
+		FromRef struct {
+			Repository   repository `json:"repository"`
+			ID           string     `json:"id"`
+			DisplayID    string     `json:"displayId"`
+			LatestCommit string     `json:"latestCommit"`
+		} `json:"fromRef"`
+	} `json:"pullRequest"`
+	Comment *struct {
+		Text string `json:"text"`
+	} `json:"comment"`
+}
+
+func getCommitSHA(bitbucketClient bitbucket.CommitClientInterface, project, repository, gitFullRef string) (string, error) {
+	commitList, err := bitbucketClient.CommitList(project, repository, bitbucket.CommitListParams{
+		Until: gitFullRef,
+	})
+	if err != nil {
+		return "", fmt.Errorf("could not get commit list: %w", err)
+	}
+	return commitList.Values[0].ID, nil
+}
+
+type prInfo struct {
+	ID   int
+	Base string
+}
+
+func extractPullRequestInfo(bitbucketClient bitbucket.CommitClientInterface, projectKey, repositorySlug, gitCommit string) (prInfo, error) {
+	var i prInfo
+
+	prPage, err := bitbucketClient.CommitPullRequestList(projectKey, repositorySlug, gitCommit)
+	if err != nil {
+		return i, err
+	}
+
+	for _, v := range prPage.Values {
+		if !v.Open {
+			continue
+		}
+		i.ID = v.ID
+		i.Base = v.ToRef.ID
+		break
+	}
+
+	return i, nil
+}
+
+func shouldSkip(bitbucketClient bitbucket.CommitClientInterface, projectKey, repositorySlug, gitCommit string) bool {
+	c, err := bitbucketClient.CommitGet(projectKey, repositorySlug, gitCommit)
+	if err != nil {
+		return false
+	}
+	return isCiSkipInCommitMessage(c.Message)
+}

--- a/internal/manager/pipeline.go
+++ b/internal/manager/pipeline.go
@@ -1,0 +1,327 @@
+package manager
+
+import (
+	"context"
+	"crypto/sha1"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	tektonClient "github.com/opendevstack/pipeline/internal/tekton"
+	"github.com/opendevstack/pipeline/pkg/config"
+	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	// Label prefix to use for labels applied by this service.
+	labelPrefix = "pipeline.opendevstack.org/"
+	// Label specifying the Bitbucket repository related to the pipeline.
+	repositoryLabel = labelPrefix + "repository"
+	// Label specifying the Git ref (e.g. branch) related to the pipeline.
+	gitRefLabel = labelPrefix + "git-ref"
+	// Label specifying the target stage of the pipeline.
+	stageLabel = labelPrefix + "stage"
+	// tektonAPIVersion specifies the Tekton API version in use
+	tektonAPIVersion = "tekton.dev/v1beta1"
+	// sharedWorkspaceName is the name of the workspace shared by all tasks
+	sharedWorkspaceName = "shared-workspace"
+)
+
+// createPipelineRun creates a PipelineRun resource
+func createPipelineRun(tektonClient tektonClient.ClientPipelineRunInterface, ctxt context.Context, pData PipelineData) (*tekton.PipelineRun, error) {
+	pr, err := tektonClient.CreatePipelineRun(ctxt, &tekton.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-", pData.Name),
+			Labels:       pipelineLabels(pData),
+		},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: tektonAPIVersion,
+			Kind:       "PipelineRun",
+		},
+		Spec: tekton.PipelineRunSpec{
+			PipelineRef:        &tekton.PipelineRef{Name: pData.Name},
+			ServiceAccountName: "pipeline", // TODO
+			Workspaces: []tekton.WorkspaceBinding{
+				{
+					Name: sharedWorkspaceName,
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pData.PVC,
+					},
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return pr, nil
+}
+
+// listPipelineRuns lists pipeline runs associated with repository.
+func listPipelineRuns(tektonClient tektonClient.ClientPipelineRunInterface, ctxt context.Context, repository string) (*tekton.PipelineRunList, error) {
+	labelMap := map[string]string{repositoryLabel: repository}
+	return tektonClient.ListPipelineRuns(
+		ctxt, metav1.ListOptions{LabelSelector: labels.Set(labelMap).String()},
+	)
+}
+
+// makePipelineName generates the name of the pipeline.
+// According to the Kubernetes label rules, a maximum of 63 characters is
+// allowed, see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set.
+// Therefore, the name might be truncated. As this could cause potential clashes
+// between similar named branches, we put a short part of the branch hash value
+// into the name name to make this very unlikely.
+// We cut the pipeline name at 55 chars to allow e.g. pipeline runs to add suffixes.
+func makePipelineName(component string, branch string) string {
+	// 55 is derived from K8s label max length minus room for generateName suffix.
+	return makeValidLabelValue(component+"-", branch, 55)
+}
+
+func makeValidLabelValue(prefix, branch string, maxLength int) string {
+	// Cut all non-alphanumeric characters
+	safeCharsRegex := regexp.MustCompile("[^-a-zA-Z0-9]+")
+	result := prefix + safeCharsRegex.ReplaceAllString(
+		strings.Replace(branch, "/", "-", -1),
+		"",
+	)
+	result = fitStringToMaxLength(result, maxLength)
+	return strings.ToLower(result)
+}
+
+// fitStringToMaxLength ensures s is not longer than max.
+// If s is longer than max, it shortenes s and appends a unique, consistent
+// suffix so that multiple invocations produce the same result. The length
+// of the shortened string will be equal to max.
+func fitStringToMaxLength(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	suffixLength := 7
+	shortened := s[0 : max-suffixLength-1]
+	h := sha1.New()
+	_, err := h.Write([]byte(s))
+	if err != nil {
+		return shortened
+	}
+	bs := h.Sum(nil)
+	suffix := fmt.Sprintf("%x", bs)
+	return fmt.Sprintf("%s-%s", shortened, suffix[0:suffixLength])
+}
+
+// pipelineLabels returns a map of labels to apply to pipelines and related runs.
+func pipelineLabels(data PipelineData) map[string]string {
+	return map[string]string{
+		repositoryLabel: data.Repository,
+		gitRefLabel:     makeValidLabelValue("", data.GitRef, 63),
+		stageLabel:      data.Stage,
+	}
+}
+
+func assemblePipeline(odsConfig *config.ODS, data PipelineData, taskKind tekton.TaskKind, taskSuffix string) *tekton.Pipeline {
+
+	var tasks []tekton.PipelineTask
+	tasks = append(tasks, tekton.PipelineTask{
+		Name:    "ods-start",
+		TaskRef: &tekton.TaskRef{Kind: taskKind, Name: "ods-start" + taskSuffix},
+		Workspaces: []tekton.WorkspacePipelineTaskBinding{
+			{Name: "source", Workspace: sharedWorkspaceName},
+		},
+		Params: []tekton.Param{
+			{
+				Name: "url",
+				Value: tekton.ArrayOrString{
+					StringVal: "$(params.git-repo-url)",
+					Type:      tekton.ParamTypeString,
+				},
+			},
+			{
+				Name: "git-full-ref",
+				Value: tekton.ArrayOrString{
+					StringVal: "$(params.git-full-ref)",
+					Type:      tekton.ParamTypeString,
+				},
+			},
+			{
+				Name: "project",
+				Value: tekton.ArrayOrString{
+					StringVal: "$(params.project)",
+					Type:      tekton.ParamTypeString,
+				},
+			},
+			{
+				Name: "pr-key",
+				Value: tekton.ArrayOrString{
+					StringVal: "$(params.pr-key)",
+					Type:      tekton.ParamTypeString,
+				},
+			},
+			{
+				Name: "pr-base",
+				Value: tekton.ArrayOrString{
+					StringVal: "$(params.pr-base)",
+					Type:      tekton.ParamTypeString,
+				},
+			},
+			{
+				Name: "pipeline-run-name",
+				Value: tekton.ArrayOrString{
+					StringVal: "$(context.pipelineRun.name)",
+					Type:      tekton.ParamTypeString,
+				},
+			},
+			{
+				Name: "environment",
+				Value: tekton.ArrayOrString{
+					StringVal: "$(params.environment)",
+					Type:      tekton.ParamTypeString,
+				},
+			},
+			{
+				Name: "version",
+				Value: tekton.ArrayOrString{
+					StringVal: "$(params.version)",
+					Type:      tekton.ParamTypeString,
+				},
+			},
+		},
+	})
+	if len(odsConfig.Pipeline.Tasks) > 0 {
+		odsConfig.Pipeline.Tasks[0].RunAfter = append(odsConfig.Pipeline.Tasks[0].RunAfter, "ods-start")
+		tasks = append(tasks, odsConfig.Pipeline.Tasks...)
+	}
+
+	var finallyTasks []tekton.PipelineTask
+	finallyTasks = append(finallyTasks, odsConfig.Pipeline.Finally...)
+
+	finallyTasks = append(finallyTasks, tekton.PipelineTask{
+		Name:    "ods-finish",
+		TaskRef: &tekton.TaskRef{Kind: taskKind, Name: "ods-finish" + taskSuffix},
+		Workspaces: []tekton.WorkspacePipelineTaskBinding{
+			{Name: "source", Workspace: sharedWorkspaceName},
+		},
+		Params: []tekton.Param{
+			{
+				Name: "pipeline-run-name",
+				Value: tekton.ArrayOrString{
+					StringVal: "$(context.pipelineRun.name)",
+					Type:      tekton.ParamTypeString,
+				},
+			},
+			{
+				Name: "aggregate-tasks-status",
+				Value: tekton.ArrayOrString{
+					StringVal: "$(tasks.status)",
+					Type:      tekton.ParamTypeString,
+				},
+			},
+		},
+	})
+
+	p := &tekton.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   data.Name,
+			Labels: pipelineLabels(data),
+		},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: tektonAPIVersion,
+			Kind:       "Pipeline",
+		},
+		Spec: tekton.PipelineSpec{
+			Description: "ODS",
+			Params: []tekton.ParamSpec{
+				{
+					Name: "repository",
+					Type: "string",
+					Default: &tekton.ArrayOrString{
+						StringVal: data.Repository,
+						Type:      tekton.ParamTypeString,
+					},
+				},
+				{
+					Name: "project",
+					Type: "string",
+					Default: &tekton.ArrayOrString{
+						StringVal: data.Project,
+						Type:      tekton.ParamTypeString,
+					},
+				},
+				{
+					Name: "component",
+					Type: "string",
+					Default: &tekton.ArrayOrString{
+						StringVal: data.Component,
+						Type:      tekton.ParamTypeString,
+					},
+				},
+				{
+					Name: "git-repo-url",
+					Type: "string",
+					Default: &tekton.ArrayOrString{
+						StringVal: data.GitURI,
+						Type:      tekton.ParamTypeString,
+					},
+				},
+				{
+					Name: "git-full-ref",
+					Type: "string",
+					Default: &tekton.ArrayOrString{
+						StringVal: data.GitFullRef,
+						Type:      tekton.ParamTypeString,
+					},
+				},
+				{
+					Name: "pr-key",
+					Type: "string",
+					Default: &tekton.ArrayOrString{
+						StringVal: strconv.Itoa(data.PullRequestKey),
+						Type:      tekton.ParamTypeString,
+					},
+				},
+				{
+					Name: "pr-base",
+					Type: "string",
+					Default: &tekton.ArrayOrString{
+						StringVal: data.PullRequestBase,
+						Type:      tekton.ParamTypeString,
+					},
+				},
+				{
+					Name: "environment",
+					Type: "string",
+					Default: &tekton.ArrayOrString{
+						StringVal: data.Environment,
+						Type:      tekton.ParamTypeString,
+					},
+				},
+				{
+					Name: "version",
+					Type: "string",
+					Default: &tekton.ArrayOrString{
+						StringVal: data.Version,
+						Type:      tekton.ParamTypeString,
+					},
+				},
+			},
+			Tasks: tasks,
+			Workspaces: []tekton.PipelineWorkspaceDeclaration{
+				{
+					Name: sharedWorkspaceName,
+				},
+			},
+			Finally: finallyTasks,
+		},
+	}
+	return p
+}
+
+// sortPipelineRunsDescending sorts pipeline runs by time (descending)
+func sortPipelineRunsDescending(pipelineRuns []tekton.PipelineRun) {
+	sort.Slice(pipelineRuns, func(i, j int) bool {
+		return pipelineRuns[j].CreationTimestamp.Time.Before(pipelineRuns[i].CreationTimestamp.Time)
+	})
+}

--- a/internal/manager/prune.go
+++ b/internal/manager/prune.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"time"
 
 	tektonClient "github.com/opendevstack/pipeline/internal/tekton"
@@ -125,10 +124,7 @@ func (p *pipelineRunPrunerByStage) categorizePipelineRunsByStage(pipelineRuns []
 // If all pipeline runs of one pipeline can be pruned, the pipeline is
 // returned instead of the individual pipeline runs.
 func (s *pipelineRunPrunerByStage) findPrunableResources(pipelineRuns []tekton.PipelineRun) *prunableResources {
-	// Sort pipeline runs by time (descending)
-	sort.Slice(pipelineRuns, func(i, j int) bool {
-		return pipelineRuns[j].CreationTimestamp.Time.Before(pipelineRuns[i].CreationTimestamp.Time)
-	})
+	sortPipelineRunsDescending(pipelineRuns)
 
 	// Apply cleanup to each bucket.
 	prunablePipelines := []string{}

--- a/internal/manager/pvc.go
+++ b/internal/manager/pvc.go
@@ -1,0 +1,61 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// Annotation to set the storage provisioner for a PVC.
+	storageProvisionerAnnotation = "volume.beta.kubernetes.io/storage-provisioner"
+	// PVC finalizer.
+	pvcProtectionFinalizer = "kubernetes.io/pvc-protection"
+)
+
+// createPVCIfRequired if it does not exist yet
+func (s *Server) createPVCIfRequired(ctxt context.Context, pData PipelineData) error {
+	_, err := s.KubernetesClient.GetPersistentVolumeClaim(ctxt, pData.PVC, metav1.GetOptions{})
+	if err != nil {
+		if !kerrors.IsNotFound(err) {
+			return fmt.Errorf("could not determine if %s already exists: %w", pData.PVC, err)
+		}
+		vm := corev1.PersistentVolumeFilesystem
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        pData.PVC,
+				Labels:      map[string]string{repositoryLabel: pData.Repository},
+				Finalizers:  []string{pvcProtectionFinalizer},
+				Annotations: map[string]string{},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceName(corev1.ResourceStorage): resource.MustParse(s.StorageConfig.Size),
+					},
+				},
+				StorageClassName: &s.StorageConfig.ClassName,
+				VolumeMode:       &vm,
+			},
+		}
+		if s.StorageConfig.Provisioner != "" {
+			pvc.Annotations[storageProvisionerAnnotation] = s.StorageConfig.Provisioner
+		}
+		_, err := s.KubernetesClient.CreatePersistentVolumeClaim(ctxt, pvc, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func makePVCName(component string) string {
+	pvcName := fmt.Sprintf("ods-workspace-%s", strings.ToLower(component))
+	return fitStringToMaxLength(pvcName, 63) // K8s label max length to be on the safe side.
+}

--- a/pkg/bitbucket/repos_test.go
+++ b/pkg/bitbucket/repos_test.go
@@ -26,3 +26,22 @@ func TestRepoCreate(t *testing.T) {
 		t.Fatalf("got %s, want %s", r.Slug, "my-repo")
 	}
 }
+
+func TestRepoList(t *testing.T) {
+	srv, cleanup := testserver.NewTestServer(t)
+	defer cleanup()
+	bitbucketClient := testClient(srv.Server.URL)
+
+	srv.EnqueueResponse(
+		t, "/rest/api/1.0/projects/PRJ/repos",
+		200, "bitbucket/repo-list.json",
+	)
+
+	l, err := bitbucketClient.RepoList("PRJ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if l.Size != 1 {
+		t.Fatalf("got %d, want %d", l.Size, 1)
+	}
+}

--- a/pkg/bitbucket/test_client.go
+++ b/pkg/bitbucket/test_client.go
@@ -9,6 +9,7 @@ import (
 type TestClient struct {
 	Branches     []Branch
 	Tags         []Tag
+	Repos        []Repo
 	Commits      []Commit
 	PullRequests []PullRequest
 	// Files contains byte slices for filenames
@@ -37,6 +38,16 @@ func (c *TestClient) TagGet(projectKey string, repositorySlug string, name strin
 }
 
 func (c *TestClient) TagCreate(projectKey string, repositorySlug string, payload TagCreatePayload) (*Tag, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *TestClient) RepoList(projectKey string) (*RepoPage, error) {
+	return &RepoPage{
+		Values: c.Repos,
+	}, nil
+}
+
+func (c *TestClient) RepoCreate(projectKey string, payload RepoCreatePayload) (*Repo, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/test/testdata/fixtures/bitbucket/repo-list.json
+++ b/test/testdata/fixtures/bitbucket/repo-list.json
@@ -1,0 +1,52 @@
+{
+    "size": 1,
+    "limit": 25,
+    "isLastPage": true,
+    "values": [
+        {
+            "slug": "my-repo",
+            "id": 1,
+            "name": "My repo",
+            "description": "My repo description",
+            "hierarchyId": "e3c939f9ef4a7fae272e",
+            "scmId": "git",
+            "state": "AVAILABLE",
+            "statusMessage": "Available",
+            "forkable": true,
+            "project": {
+                "key": "PRJ",
+                "id": 1,
+                "name": "My Cool Project",
+                "description": "The description for my cool project.",
+                "public": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://link/to/project"
+                        }
+                    ]
+                }
+            },
+            "public": true,
+            "links": {
+                "clone": [
+                    {
+                        "href": "ssh://git@<baseURL>/PRJ/my-repo.git",
+                        "name": "ssh"
+                    },
+                    {
+                        "href": "https://<baseURL>/scm/PRJ/my-repo.git",
+                        "name": "http"
+                    }
+                ],
+                "self": [
+                    {
+                        "href": "http://link/to/repository"
+                    }
+                ]
+            }
+        }
+    ],
+    "start": 0
+}


### PR DESCRIPTION
To make #474 easier to review, I extracted all the prep work into this PR.

The PR here consists of:
* Adding repo list to the Bitbucket client
* Moving source code around to make it easier to find
* Using the logger in the server

There shouldn't be a functional change. Once this is merged, I will rebase #474, and the changes will be much easier to review.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
