### PR TITLE
Do not uninstall tasks via helm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ listed in the changelog.
 - Use UBI8 provided Python 3.9 toolset image ([#457](https://github.com/opendevstack/ods-pipeline/issues/457))
 - Change installation mode from centralized to local/namespaced ([#404](https://github.com/opendevstack/ods-pipeline/pull/404))
 - Removed logging of test reports for TypeScript and Python build tasks ([#470](https://github.com/opendevstack/ods-pipeline/issues/470))
+- Don't remove tasks on `helm` upgrades, rollbacks, etc. ([#477](https://github.com/opendevstack/ods-pipeline/issues/477))
 
 ### Fixed
 - Cannot enable debug mode in some tasks ([#377](https://github.com/opendevstack/ods-pipeline/issues/377))

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-go.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-go.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "Task" .Values.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-build-go{{.Values.global.taskSuffix}}'
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   description: |
     Builds Go (module) applications.

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "Task" .Values.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-build-gradle{{.Values.global.taskSuffix}}'
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   description: |
     Builds Gradle applications.

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-python.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-python.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "Task" .Values.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-build-python{{.Values.global.taskSuffix}}'
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   description: |
     Builds Python applications.

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-typescript.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-typescript.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "Task" .Values.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-build-typescript{{.Values.global.taskSuffix}}'
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   description: |
     Builds Typescript applications.

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-deploy-helm.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-deploy-helm.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "Task" .Values.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-deploy-helm{{.Values.global.taskSuffix}}'
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   description: |
     Deploy Helm charts.

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-finish.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-finish.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "Task" .Values.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-finish{{.Values.global.taskSuffix}}'
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   description: |
     Finishes the pipeline run.

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-package-image.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-package-image.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "Task" .Values.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-package-image{{.Values.global.taskSuffix}}'
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   description: |
     Packages applications into container images using

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-start.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-start.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "Task" .Values.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-start{{.Values.global.taskSuffix}}'
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   description: |
     Starts the pipeline run.


### PR DESCRIPTION
Annotate task definitions with helm's `resource-policy: keep`

Closes #477 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
