### PR TITLE
Run go fmt over packages, not entire directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ listed in the changelog.
 - Change installation mode from centralized to local/namespaced ([#404](https://github.com/opendevstack/ods-pipeline/pull/404))
 - Removed logging of test reports for TypeScript and Python build tasks ([#470](https://github.com/opendevstack/ods-pipeline/issues/470))
 - Don't remove tasks on `helm` upgrades, rollbacks, etc. ([#477](https://github.com/opendevstack/ods-pipeline/issues/477))
+- Run go fmt over packages, not entire directory ([#484](https://github.com/opendevstack/ods-pipeline/issues/484))
 
 ### Fixed
 - Cannot enable debug mode in some tasks ([#377](https://github.com/opendevstack/ods-pipeline/issues/377))

--- a/build/package/scripts/build-go.sh
+++ b/build/package/scripts/build-go.sh
@@ -71,7 +71,8 @@ echo GOMODCACHE="$GOMODCACHE"
 df -h "$ROOT_DIR"
 
 echo "Checking format ..."
-unformatted=$(gofmt -l .)
+# shellcheck disable=SC2046
+unformatted=$(go fmt $(go list ./...))
 if [ -n "${unformatted}" ]; then
   echo "Unformatted files:"
   echo "${unformatted}"


### PR DESCRIPTION
Otherwise the now persistent Go mod cache is checked as well, and builds
will fail if any dependency is not gofmt'd.

Fixes #484.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
