### PR TITLE
Upload artifacts on unsuccessful pipeline runs as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ listed in the changelog.
 - Allow to cache dependencies ([#147](https://github.com/opendevstack/ods-pipeline/issues/147)). See also proposal on caching ([#412](https://github.com/opendevstack/ods-pipeline/pull/412))
 - Support node production builds in docker context ([#357](https://github.com/opendevstack/ods-pipeline/issues/357))
 - Allow to select which tasks (and related BC/IS resources) to install ([#486](https://github.com/opendevstack/ods-pipeline/issues/486))
+- Upload artifacts of unsuccessful pipeline runs as well ([#379](https://github.com/opendevstack/ods-pipeline/issues/379))
 
 ### Changed
 

--- a/cmd/finish/main_test.go
+++ b/cmd/finish/main_test.go
@@ -37,7 +37,7 @@ func TestUploadArtifacts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = uploadArtifacts(logger, nexusClient, nexusRepo, tempWorkingDir, ctxt)
+	err = uploadArtifacts(logger, nexusClient, nexusRepo, tempWorkingDir, ctxt, options{aggregateTasksStatus: "Succeeded"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,6 +47,18 @@ func TestUploadArtifacts(t *testing.T) {
 	wantFile := "/my-project/my-repo/8d351a10fb428c0c1239530256e21cf24f136e73/image-digests/foo.json"
 	if !nexusRepoContains(nexusClient.URLs[nexusRepo], wantFile) {
 		t.Fatalf("want: %s, got: %s", wantFile, nexusClient.URLs[nexusRepo][0])
+	}
+
+	err = uploadArtifacts(logger, nexusClient, nexusRepo, tempWorkingDir, ctxt, options{pipelineRunName: "pipelineRun", aggregateTasksStatus: "Failed"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nexusClient.URLs[nexusRepo]) != 2 {
+		t.Fatalf("expected one additional file upload, got: %v", nexusClient.URLs[nexusRepo])
+	}
+	wantFile = "/my-project/my-repo/8d351a10fb428c0c1239530256e21cf24f136e73/failed-pipelineRun-artifacts/image-digests/foo.json"
+	if !nexusRepoContains(nexusClient.URLs[nexusRepo], wantFile) {
+		t.Fatalf("want: %s, got: %s", wantFile, nexusClient.URLs[nexusRepo][1])
 	}
 }
 


### PR DESCRIPTION
Implement option no. 3 of #379: Upload artifacts also if pipeline run failed.

Closes #379 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
