### PR TITLE
adds kubectl delete cmd to debugging doc file

### DIFF
--- a/docs/debugging.adoc
+++ b/docs/debugging.adoc
@@ -38,7 +38,7 @@ metadata:
   name: ods-pipeline-debug
 spec:
   volumes:
-    - name: ods-workspace-<COMPONENT_NAME>-vol
+    - name: ods-workspace-vol
       persistentVolumeClaim:
         claimName: ods-workspace-<COMPONENT_NAME>
   containers:
@@ -46,7 +46,7 @@ spec:
       image: index.docker.io/crccheck/hello-world
       volumeMounts:
         - mountPath: "/workspace"
-          name: ods-workspace-<COMPONENT_NAME>-vol
+          name: ods-workspace-vol
 
 ----
 

--- a/docs/debugging.adoc
+++ b/docs/debugging.adoc
@@ -38,15 +38,15 @@ metadata:
   name: ods-pipeline-debug
 spec:
   volumes:
-    - name: ods-pipeline-vol
+    - name: ods-workspace-<COMPONENT_NAME>-vol
       persistentVolumeClaim:
-        claimName: ods-pipeline
+        claimName: ods-workspace-<COMPONENT_NAME>
   containers:
     - name: ods-pipeline-debug-container
       image: index.docker.io/crccheck/hello-world
       volumeMounts:
         - mountPath: "/workspace"
-          name: ods-pipeline-vol
+          name: ods-workspace-<COMPONENT_NAME>-vol
 
 ----
 

--- a/docs/debugging.adoc
+++ b/docs/debugging.adoc
@@ -57,4 +57,7 @@ kubectl -n <namespace> apply -f debug-pod.yaml
 kubectl -n <namespace> exec -it ods-pipeline-debug -- /bin/sh
 ```
 
-The workspace is mounted at `/workspace`. Once you have completed debugging, do not forget to delete the pod again. 
+The workspace is mounted at `/workspace`. Once you have completed debugging, do not forget to delete the pod again:
+```
+kubectl -n <namespace> delete -f debug-pod.yaml
+```


### PR DESCRIPTION
I added this because ppl that might not know the above `apply` and `exec` cmds by heart might not know `delete` as well. 

@michaelsauter I think you mentioned the pvc name in this file is wrong, could you fix it, maybe in this branch, or let me know so I can do it?

thx
