### PR TITLE
Bugfix/fix issues in gradle shell script

### DIFF
--- a/build/package/scripts/build-gradle.sh
+++ b/build/package/scripts/build-gradle.sh
@@ -73,7 +73,10 @@ UNIT_TEST_RESULT_DIR="${BUILD_DIR}/test-results/test"
 if [ -d "${UNIT_TEST_RESULT_DIR}" ]; then
     UNIT_TEST_ARTIFACTS_DIR="${ARTIFACTS_DIR}/xunit-reports"
     mkdir -p "${UNIT_TEST_ARTIFACTS_DIR}"
-    cp "${UNIT_TEST_RESULT_DIR}/"*.xml "${UNIT_TEST_ARTIFACTS_DIR}/${ARTIFACT_PREFIX}"
+    # Each test class produces its own report file, but they contain a qualified package
+    # name in their file name. That way we do not need to add an artifact prefix to
+    # distinguish them with reports from other artifacts of the same repo/pipeline build.
+    cp "${UNIT_TEST_RESULT_DIR}/"*.xml "${UNIT_TEST_ARTIFACTS_DIR}"
 else
   echo "Build failed: no unit test results found in ${UNIT_TEST_RESULT_DIR}"
   exit 1

--- a/build/package/scripts/build-gradle.sh
+++ b/build/package/scripts/build-gradle.sh
@@ -73,8 +73,8 @@ UNIT_TEST_RESULT_DIR="${BUILD_DIR}/test-results/test"
 if [ -d "${UNIT_TEST_RESULT_DIR}" ]; then
     UNIT_TEST_ARTIFACTS_DIR="${ARTIFACTS_DIR}/xunit-reports"
     mkdir -p "${UNIT_TEST_ARTIFACTS_DIR}"
-    # Each test class produces its own report file, but they contain a qualified package
-    # name in their file name. That way we do not need to add an artifact prefix to
+    # Each test class produces its own report file, but they contain a fully qualified class
+    # name in their file name. Due to that, we do not need to add an artifact prefix to
     # distinguish them with reports from other artifacts of the same repo/pipeline build.
     cp "${UNIT_TEST_RESULT_DIR}/"*.xml "${UNIT_TEST_ARTIFACTS_DIR}"
 else


### PR DESCRIPTION
As discussed [here](https://github.com/opendevstack/ods-pipeline/commit/729986c3c3d346308b9f24af985f312e6ef9eb3a#r67387581), I'm removing the artifact prefix of the cp command due to this reason:

Each test class produces its own report file, but they contain a fully qualified class
name in their file name. Due to that, we do not need to add an artifact prefix to
distinguish them with reports from other artifacts of the same repo/pipeline build.
