### PR TITLE
Speed up local image build time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ listed in the changelog.
 - Don't remove tasks on `helm` upgrades, rollbacks, etc. ([#477](https://github.com/opendevstack/ods-pipeline/issues/477))
 - Run go fmt over packages, not entire directory ([#484](https://github.com/opendevstack/ods-pipeline/issues/484))
 - Update `golangci-lint` from 1.41 to 1.45 ([#497](https://github.com/opendevstack/ods-pipeline/pull/497))
+- Improve build time of subsequent local container image builds ([#499](https://github.com/opendevstack/ods-pipeline/pull/499))
 
 ### Fixed
 - Cannot enable debug mode in some tasks ([#377](https://github.com/opendevstack/ods-pipeline/issues/377))

--- a/build/package/Dockerfile.buildah
+++ b/build/package/Dockerfile.buildah
@@ -3,8 +3,10 @@ FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12 AS builder
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
 
-# Add Go binaries
-COPY go.* .
+# Build Go binary.
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
 COPY cmd cmd
 COPY internal internal
 COPY pkg pkg

--- a/build/package/Dockerfile.finish
+++ b/build/package/Dockerfile.finish
@@ -3,8 +3,10 @@ FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12 AS builder
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
 
-# Add Go binaries
-COPY go.* .
+# Build Go binary.
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
 COPY cmd cmd
 COPY internal internal
 COPY pkg pkg

--- a/build/package/Dockerfile.helm
+++ b/build/package/Dockerfile.helm
@@ -10,6 +10,15 @@ ENV HELM_VERSION=3.5.2 \
     AGE_VERSION=1.0.0 \
     GOBIN=/usr/local/bin
 
+# Build Go binary.
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY cmd cmd
+COPY internal internal
+COPY pkg pkg
+RUN cd cmd/deploy-with-helm && CGO_ENABLED=0 go build -o /usr/local/bin/deploy-with-helm
+
 # Install Helm.
 RUN mkdir -p /tmp/helm \
     && cd /tmp \
@@ -19,13 +28,6 @@ RUN mkdir -p /tmp/helm \
     && chmod a+x /usr/local/bin/helm \
     && helm version \
     && helm env
-
-# Add Go binaries.
-COPY go.* .
-COPY cmd cmd
-COPY internal internal
-COPY pkg pkg
-RUN cd cmd/deploy-with-helm && CGO_ENABLED=0 go build -o /usr/local/bin/deploy-with-helm
 
 # Install sops.
 RUN go install go.mozilla.org/sops/v3/cmd/sops@v${SOPS_VERSION} \

--- a/build/package/Dockerfile.pipeline-manager
+++ b/build/package/Dockerfile.pipeline-manager
@@ -3,8 +3,10 @@ FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12 AS builder
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
 
-# Add Go binaries
-COPY go.* .
+# Build Go binary.
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
 COPY cmd cmd
 COPY internal internal
 COPY pkg pkg

--- a/build/package/Dockerfile.sonar
+++ b/build/package/Dockerfile.sonar
@@ -6,6 +6,15 @@ USER root
 ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     CNES_REPORT_VERSION=3.2.2
 
+# Build Go binary.
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY cmd cmd
+COPY internal internal
+COPY pkg pkg
+RUN cd cmd/sonar && CGO_ENABLED=0 go build -o /usr/local/bin/sonar
+
 # Install Sonar Scanner.
 RUN cd /tmp \
     && curl -LO https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/${SONAR_SCANNER_VERSION}/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
@@ -18,13 +27,6 @@ RUN cd /tmp \
     && mkdir /usr/local/cnes \
     && mv cnesreport.jar /usr/local/cnes/cnesreport.jar \
     && chmod +x /usr/local/cnes/cnesreport.jar
-
-# Add Go binaries.
-COPY go.* .
-COPY cmd cmd
-COPY internal internal
-COPY pkg pkg
-RUN cd cmd/sonar && CGO_ENABLED=0 go build -o /usr/local/bin/sonar
 
 # Final image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4

--- a/build/package/Dockerfile.start
+++ b/build/package/Dockerfile.start
@@ -10,6 +10,16 @@ ENV TEKTON_VERSION=0.24.0 \
     KO_APP=/ko-app \
     GIT_LFS_VERSION=3.0.2
 
+# Build Go binary.
+RUN mkdir -p /etc/go
+COPY go.mod /etc/go/
+COPY go.sum /etc/go/
+RUN cd /etc/go && go mod download
+COPY cmd /etc/go/cmd
+COPY internal /etc/go/internal
+COPY pkg /etc/go/pkg
+RUN cd /etc/go/cmd/start && CGO_ENABLED=0 go build -o /usr/local/bin/ods-start
+
 RUN mkdir -p $TEKTONCD_PATH && \
     cd /tmp && \
     curl -LO https://github.com/tektoncd/pipeline/archive/refs/tags/v$TEKTON_VERSION.tar.gz && \
@@ -28,14 +38,6 @@ RUN cd /tmp \
 
 RUN CGO_ENABLED=0 go build -o /tmp/openshift-pipelines-git-init ./cmd/git-init && \
     mkdir ${KO_APP} && cp /tmp/openshift-pipelines-git-init ${KO_APP}/${BINARY}
-
-# Add Go binaries
-RUN mkdir -p /etc/go
-COPY go.* /etc/go/
-COPY cmd /etc/go/cmd
-COPY internal /etc/go/internal
-COPY pkg /etc/go/pkg
-RUN cd /etc/go/cmd/start && CGO_ENABLED=0 go build -o /usr/local/bin/ods-start
 
 # Final image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4


### PR DESCRIPTION
On my internet connection, downloading Go modules takes several minutes.
This change re-arranges the Dockerfiles to build the Go binaries first,
and to download the modules immediately after copying go.mod/sum to make use of
the image build cache mechanism.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
