### PR TITLE
Default imageTag to appVersion + release images without leading v

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,21 @@ env:
   IMAGE_BASE: ${{ github.repository }}
 
 jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    steps:
+      - id: createImageTag
+        name: Create image tag
+        run: |
+          IMAGE_TAG=$(echo ${{ github.event.release.tag_name }} | sed 's/v//')
+          echo "::set-output name=imageTag::$IMAGE_TAG"
+    outputs:
+      imageTag: ${{ steps.createImageTag.outputs.imageTag }}
+
   build:
     name: Build and release images
+    needs: setup
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -49,4 +62,4 @@ jobs:
           context: .
           file: build/package/Dockerfile.${{ matrix.image }}
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/ods-${{ matrix.image }}:${{ github.event.release.tag_name }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/ods-${{ matrix.image }}:${{ needs.setup.outputs.imageTag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ listed in the changelog.
 
 ## [Unreleased]
 
+### Changed
+
+- Default imageTag to appVersion + release images without leading v ([#504](https://github.com/opendevstack/ods-pipeline/issues/504))
+
 ## [0.3.0] - 2022-04-07
 
 ### Added

--- a/deploy/ods-pipeline/charts/images/templates/bc-ods-buildah.yaml
+++ b/deploy/ods-pipeline/charts/images/templates/bc-ods-buildah.yaml
@@ -8,7 +8,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: 'ods-buildah:{{.Values.global.imageTag}}'
+      name: 'ods-buildah:{{.Values.global.imageTag | default .Chart.AppVersion}}'
   resources: {}
   successfulBuildsHistoryLimit: 5
   failedBuildsHistoryLimit: 5
@@ -18,7 +18,7 @@ spec:
     dockerStrategy:
       buildArgs:
         - name: imageTag
-          value: '{{.Values.global.imageTag}}'
+          value: '{{.Values.global.imageTag | default .Chart.AppVersion}}'
         - name: aquasecScannerUrl
           value: '{{.Values.aquasecScannerUrl}}'
   source:

--- a/deploy/ods-pipeline/charts/images/templates/bc-ods-finish.yaml
+++ b/deploy/ods-pipeline/charts/images/templates/bc-ods-finish.yaml
@@ -7,7 +7,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: 'ods-finish:{{.Values.global.imageTag}}'
+      name: 'ods-finish:{{.Values.global.imageTag | default .Chart.AppVersion}}'
   resources: {}
   successfulBuildsHistoryLimit: 5
   failedBuildsHistoryLimit: 5
@@ -17,7 +17,7 @@ spec:
     dockerStrategy:
       buildArgs:
         - name: imageTag
-          value: '{{.Values.global.imageTag}}'
+          value: '{{.Values.global.imageTag | default .Chart.AppVersion}}'
   source:
     dockerfile: |-
       {{- .Files.Get "docker/Dockerfile.finish" | nindent 6}}

--- a/deploy/ods-pipeline/charts/images/templates/bc-ods-go-toolset.yaml
+++ b/deploy/ods-pipeline/charts/images/templates/bc-ods-go-toolset.yaml
@@ -8,7 +8,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: 'ods-go-toolset:{{.Values.global.imageTag}}'
+      name: 'ods-go-toolset:{{.Values.global.imageTag | default .Chart.AppVersion}}'
   resources: {}
   successfulBuildsHistoryLimit: 5
   failedBuildsHistoryLimit: 5
@@ -18,7 +18,7 @@ spec:
     dockerStrategy:
       buildArgs:
         - name: imageTag
-          value: '{{.Values.global.imageTag}}'
+          value: '{{.Values.global.imageTag | default .Chart.AppVersion}}'
   source:
     dockerfile: |-
       {{- .Files.Get "docker/Dockerfile.go-toolset" | nindent 6}}

--- a/deploy/ods-pipeline/charts/images/templates/bc-ods-gradle-toolset.yaml
+++ b/deploy/ods-pipeline/charts/images/templates/bc-ods-gradle-toolset.yaml
@@ -8,7 +8,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: 'ods-gradle-toolset:{{.Values.global.imageTag}}'
+      name: 'ods-gradle-toolset:{{.Values.global. | default .Chart.AppVersion}}'
   resources: {}
   successfulBuildsHistoryLimit: 5
   failedBuildsHistoryLimit: 5
@@ -18,7 +18,7 @@ spec:
     dockerStrategy:
       buildArgs:
         - name: imageTag
-          value: '{{.Values.global.imageTag}}'
+          value: '{{.Values.global.imageTag | default .Chart.AppVersion}}'
   source:
     dockerfile: |-
       {{- .Files.Get "docker/Dockerfile.gradle-toolset" | nindent 6}}

--- a/deploy/ods-pipeline/charts/images/templates/bc-ods-helm.yaml
+++ b/deploy/ods-pipeline/charts/images/templates/bc-ods-helm.yaml
@@ -8,7 +8,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: 'ods-helm:{{.Values.global.imageTag}}'
+      name: 'ods-helm:{{.Values.global.imageTag | default .Chart.AppVersion}}'
   resources: {}
   successfulBuildsHistoryLimit: 5
   failedBuildsHistoryLimit: 5
@@ -18,7 +18,7 @@ spec:
     dockerStrategy:
       buildArgs:
         - name: imageTag
-          value: '{{.Values.global.imageTag}}'
+          value: '{{.Values.global.imageTag | default .Chart.AppVersion}}'
   source:
     dockerfile: |-
       {{- .Files.Get "docker/Dockerfile.helm" | nindent 6}}

--- a/deploy/ods-pipeline/charts/images/templates/bc-ods-node16-typescript-toolset.yaml
+++ b/deploy/ods-pipeline/charts/images/templates/bc-ods-node16-typescript-toolset.yaml
@@ -8,7 +8,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: 'ods-node16-typescript-toolset:{{.Values.global.imageTag}}'
+      name: 'ods-node16-typescript-toolset:{{.Values.global.imageTag | default .Chart.AppVersion}}'
   resources: {}
   successfulBuildsHistoryLimit: 5
   failedBuildsHistoryLimit: 5
@@ -18,7 +18,7 @@ spec:
     dockerStrategy:
       buildArgs:
         - name: imageTag
-          value: '{{.Values.global.imageTag}}'
+          value: '{{.Values.global.imageTag | default .Chart.AppVersion}}'
   source:
     dockerfile: |-
       {{- .Files.Get "docker/Dockerfile.node16-typescript-toolset" | nindent 6}}

--- a/deploy/ods-pipeline/charts/images/templates/bc-ods-pipeline-manager.yaml
+++ b/deploy/ods-pipeline/charts/images/templates/bc-ods-pipeline-manager.yaml
@@ -7,7 +7,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: 'ods-pipeline-manager:{{.Values.global.imageTag}}'
+      name: 'ods-pipeline-manager:{{.Values.global.imageTag | default .Chart.AppVersion}}'
   resources: {}
   successfulBuildsHistoryLimit: 5
   failedBuildsHistoryLimit: 5
@@ -17,7 +17,7 @@ spec:
     dockerStrategy:
       buildArgs:
         - name: imageTag
-          value: '{{.Values.global.imageTag}}'
+          value: '{{.Values.global.imageTag | default .Chart.AppVersion}}'
   source:
     dockerfile: |-
       {{- .Files.Get "docker/Dockerfile.pipeline-manager" | nindent 6}}

--- a/deploy/ods-pipeline/charts/images/templates/bc-ods-python-toolset.yaml
+++ b/deploy/ods-pipeline/charts/images/templates/bc-ods-python-toolset.yaml
@@ -8,7 +8,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: 'ods-python-toolset:{{.Values.global.imageTag}}'
+      name: 'ods-python-toolset:{{.Values.global.imageTag | default .Chart.AppVersion}}'
   resources: {}
   successfulBuildsHistoryLimit: 5
   failedBuildsHistoryLimit: 5
@@ -18,7 +18,7 @@ spec:
     dockerStrategy:
       buildArgs:
         - name: imageTag
-          value: '{{.Values.global.imageTag}}'
+          value: '{{.Values.global.imageTag | default .Chart.AppVersion}}'
   source:
     dockerfile: |-
       {{- .Files.Get "docker/Dockerfile.python-toolset" | nindent 6}}

--- a/deploy/ods-pipeline/charts/images/templates/bc-ods-sonar.yaml
+++ b/deploy/ods-pipeline/charts/images/templates/bc-ods-sonar.yaml
@@ -7,7 +7,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: 'ods-sonar:{{.Values.global.imageTag}}'
+      name: 'ods-sonar:{{.Values.global.imageTag | default .Chart.AppVersion}}'
   resources: {}
   successfulBuildsHistoryLimit: 5
   failedBuildsHistoryLimit: 5
@@ -17,7 +17,7 @@ spec:
     dockerStrategy:
       buildArgs:
         - name: imageTag
-          value: '{{.Values.global.imageTag}}'
+          value: '{{.Values.global.imageTag | default .Chart.AppVersion}}'
   source:
     dockerfile: |-
       {{- .Files.Get "docker/Dockerfile.sonar" | nindent 6}}

--- a/deploy/ods-pipeline/charts/images/templates/bc-ods-start.yaml
+++ b/deploy/ods-pipeline/charts/images/templates/bc-ods-start.yaml
@@ -7,7 +7,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: 'ods-start:{{.Values.global.imageTag}}'
+      name: 'ods-start:{{.Values.global.imageTag | default .Chart.AppVersion}}'
   resources: {}
   successfulBuildsHistoryLimit: 5
   failedBuildsHistoryLimit: 5
@@ -17,7 +17,7 @@ spec:
     dockerStrategy:
       buildArgs:
         - name: imageTag
-          value: '{{.Values.global.imageTag}}'
+          value: '{{.Values.global.imageTag | default .Chart.AppVersion}}'
   source:
     dockerfile: |-
       {{- .Files.Get "docker/Dockerfile.start" | nindent 6}}

--- a/deploy/ods-pipeline/charts/tasks/templates/_sonar-step.tpl
+++ b/deploy/ods-pipeline/charts/tasks/templates/_sonar-step.tpl
@@ -1,7 +1,7 @@
 {{- define "sonar-step"}}
 - name: scan-with-sonar
   # Image is built from build/package/Dockerfile.sonar.
-  image: '{{.Values.registry}}/{{default .Release.Namespace .Values.namespace}}/ods-sonar:{{.Values.global.imageTag}}'
+  image: '{{.Values.registry}}/{{default .Release.Namespace .Values.namespace}}/ods-sonar:{{.Values.global.imageTag | default .Chart.AppVersion}}'
   env:
     - name: HOME
       value: '/tekton/home'

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-go.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-go.yaml
@@ -100,7 +100,7 @@ spec:
   steps:
     - name: build-go-binary
       # Image is built from build/package/Dockerfile.go-toolset.
-      image: '{{.Values.registry}}/{{default .Release.Namespace .Values.namespace}}/ods-go-toolset:{{.Values.global.imageTag}}'
+      image: '{{.Values.registry}}/{{default .Release.Namespace .Values.namespace}}/ods-go-toolset:{{.Values.global.imageTag | default .Chart.AppVersion}}'
       env:
         - name: HOME
           value: '/tekton/home'

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
@@ -146,7 +146,7 @@ spec:
   steps:
     - name: build-gradle-binary
       # Image is built from build/package/Dockerfile.gradle-toolset.
-      image: '{{.Values.registry}}/{{default .Release.Namespace .Values.namespace}}/ods-gradle-toolset:{{.Values.global.imageTag}}'
+      image: '{{.Values.registry}}/{{default .Release.Namespace .Values.namespace}}/ods-gradle-toolset:{{.Values.global.imageTag | default .Chart.AppVersion}}'
       env:
         - name: DEBUG
           valueFrom:

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-python.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-python.yaml
@@ -79,7 +79,7 @@ spec:
   steps:
     - name: build-python
       # Image is built from build/package/Dockerfile.python-toolset.
-      image: '{{.Values.registry}}/{{default .Release.Namespace .Values.namespace}}/ods-python-toolset:{{.Values.global.imageTag}}'
+      image: '{{.Values.registry}}/{{default .Release.Namespace .Values.namespace}}/ods-python-toolset:{{.Values.global.imageTag | default .Chart.AppVersion}}'
       env:
         - name: HOME
           value: '/tekton/home'

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-typescript.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-typescript.yaml
@@ -116,7 +116,7 @@ spec:
   steps:
     - name: build-typescript
       # Image is built from build/package/Dockerfile.node-xx-typescript-toolset.
-      image: '{{.Values.registry}}/{{default .Release.Namespace .Values.namespace}}/ods-node$(params.node-version)-typescript-toolset:{{.Values.global.imageTag}}'
+      image: '{{.Values.registry}}/{{default .Release.Namespace .Values.namespace}}/ods-node$(params.node-version)-typescript-toolset:{{.Values.global.imageTag | default .Chart.AppVersion}}'
       env:
         - name: HOME
           value: '/tekton/home'

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-deploy-helm.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-deploy-helm.yaml
@@ -92,7 +92,7 @@ spec:
   steps:
     - name: helm-upgrade-from-repo
       # Image is built from build/package/Dockerfile.helm.
-      image: '{{.Values.registry}}/{{default .Release.Namespace .Values.namespace}}/ods-helm:{{.Values.global.imageTag}}'
+      image: '{{.Values.registry}}/{{default .Release.Namespace .Values.namespace}}/ods-helm:{{.Values.global.imageTag | default .Chart.AppVersion}}'
       env:
         - name: DEBUG
           valueFrom:

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-package-image.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-package-image.yaml
@@ -85,7 +85,7 @@ spec:
   steps:
     - name: build-and-push-image
       # Image is built from build/package/Dockerfile.buildah.
-      image: '{{.Values.registry}}/{{default .Release.Namespace .Values.namespace}}/ods-buildah:{{.Values.global.imageTag}}'
+      image: '{{.Values.registry}}/{{default .Release.Namespace .Values.namespace}}/ods-buildah:{{.Values.global.imageTag | default .Chart.AppVersion}}'
       env:
         - name: HOME
           value: '/tekton/home'

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-start.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-start.yaml
@@ -124,7 +124,7 @@ spec:
   steps:
     - name: ods-start
       # Image is built from build/package/Dockerfile.start.
-      image: '{{.Values.registry}}/{{default .Release.Namespace .Values.namespace}}/ods-start:{{.Values.global.imageTag}}'
+      image: '{{.Values.registry}}/{{default .Release.Namespace .Values.namespace}}/ods-start:{{.Values.global.imageTag | default .Chart.AppVersion}}'
       env:
         - name: HOME
           value: '/tekton/home'

--- a/deploy/ods-pipeline/values.yaml
+++ b/deploy/ods-pipeline/values.yaml
@@ -2,8 +2,8 @@
 # UMBRELLA                                #
 # ####################################### #
 global:
-  # Image tag to use for images referenced by tasks.
-  imageTag: 0.3.0
+  # Image tag to use for images referenced by tasks (defaults to the chart appVersion).
+  imageTag: ''
   # Suffix to append to the task name.
   taskSuffix: -v0-3-0
   # Custom task kind (defaults to "Task")


### PR DESCRIPTION
Fixes #504 

A successful release can be found in my forked repo: https://github.com/henninggross/ods-pipeline/actions/runs/2189267994

I am unsure how to handle the change log here - how should we approach this?
Should this be made part of 0.3.0 or shall we create a 0.3.1 patch version for this (also to release #461)? 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
