### PR TITLE
Inject binary version and commit SHA during build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ listed in the changelog.
 ### Changed
 
 - Default imageTag to appVersion + release images without leading v ([#504](https://github.com/opendevstack/ods-pipeline/issues/504))
+- Display both version and Git commit SHA in `artifact-download -version` ([#507](https://github.com/opendevstack/ods-pipeline/issues/507))
 
 ## [0.3.0] - 2022-04-07
 

--- a/Makefile
+++ b/Makefile
@@ -46,15 +46,15 @@ build-artifact-download: build-artifact-download-linux build-artifact-download-d
 .PHONY: build-artifact-download
 
 build-artifact-download-linux: ## Build artifact-download Linux binary.
-	cd cmd/artifact-download && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -gcflags "all=-trimpath=$(CURDIR);$(shell go env GOPATH)" -o artifact-download-linux-amd64
+	cd scripts && ./build-artifact-download.sh --go-os=linux --go-arch=amd64
 .PHONY: build-artifact-download-linux
 
 build-artifact-download-darwin: ## Build artifact-download macOS binary.
-	cd cmd/artifact-download && GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -gcflags "all=-trimpath=$(CURDIR);$(shell go env GOPATH)" -o artifact-download-darwin-amd64
+	cd scripts && ./build-artifact-download.sh --go-os=darwin --go-arch=amd64
 .PHONY: build-artifact-download-darwin
 
 build-artifact-download-windows: ## Build artifact-download Windows binary.
-	cd cmd/artifact-download && GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -gcflags "all=-trimpath=$(CURDIR);$(shell go env GOPATH)" -o artifact-download-windows-amd64.exe
+	cd scripts && ./build-artifact-download.sh --go-os=windows --go-arch=amd64
 .PHONY: build-artifact-download-windows
 
 ##@ Testing

--- a/cmd/artifact-download/main.go
+++ b/cmd/artifact-download/main.go
@@ -31,6 +31,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+// Version information injected at build time.
+var Version string
+var GitCommit string
+
 // options configures the program.
 // The struct is filled from the flags this program handles.
 type options struct {
@@ -73,7 +77,8 @@ func main() {
 	flag.Parse()
 
 	if opts.version {
-		fmt.Println("0.3.0")
+		fmt.Println("Version:", Version)
+		fmt.Println("Commit: ", GitCommit)
 		os.Exit(0)
 	}
 

--- a/scripts/build-artifact-download.sh
+++ b/scripts/build-artifact-download.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -ue
+
+GO_OS=""
+GO_ARCH=""
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+
+    --go-os) GO_OS="$2"; shift;;
+    --go-os=*) GO_OS="${1#*=}";;
+
+    --go-arch) GO_ARCH="$2"; shift;;
+    --go-arch=*) GO_ARCH="${1#*=}";;
+
+  *) echo "Unknown parameter passed: $1"; exit 1;;
+esac; shift; done
+
+cd ../cmd/artifact-download
+
+GIT_COMMIT=$(git rev-parse --short HEAD)
+VERSION=$(git tag --contains "${GIT_COMMIT}" | grep ^v | sort -V | tail -n 1)
+if [ -z "${VERSION}" ]; then
+    VERSION="dev"
+fi
+
+OUTFILE="artifact-download-${GO_OS}-${GO_ARCH}"
+if [ "${OUTFILE}" == "windows" ]; then
+    OUTFILE="${OUTFILE}.exe"
+fi
+
+GOOS=${GO_OS} GOARCH=${GO_ARCH} CGO_ENABLED=0 go build \
+	-gcflags "all=-trimpath=$(pwd);$(go env GOPATH)" \
+	-ldflags "-X main.GitCommit=${GIT_COMMIT} -X main.Version=${VERSION}" \
+	-o "${OUTFILE}"


### PR DESCRIPTION
Closes https://github.com/opendevstack/ods-pipeline/issues/507.

Follow-up PR coming which will add Apple Silicon builds.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
