### PR TITLE
Build arm64 variant for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ test/testdata/workspaces/workspace-*
 ods.external.yaml
 artifact-download-linux-amd64
 artifact-download-darwin-amd64
+artifact-download-darwin-arm64
 artifact-download-windows-amd64.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ listed in the changelog.
 ### Added
 
 - Support for optional build task caching. The main use case is to avoid lengthy builds in repos with multiple build tasks ([#461](https://github.com/opendevstack/ods-pipeline/issues/461). See the `docs/adr/20220314-caching-build-tasks.md`for details.
+- Provide Apple silicon builds of artifact-download binary ([#510](https://github.com/opendevstack/ods-pipeline/issues/510)
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -42,16 +42,20 @@ docs: ## Render documentation for tasks.
 	go run cmd/docs/main.go
 .PHONY: docs
 
-build-artifact-download: build-artifact-download-linux build-artifact-download-darwin build-artifact-download-windows ## Build artifact-download binary for each supported OS/arch.
+build-artifact-download: build-artifact-download-linux build-artifact-download-darwin-amd64 build-artifact-download-darwin-arm64 build-artifact-download-windows ## Build artifact-download binary for each supported OS/arch.
 .PHONY: build-artifact-download
 
 build-artifact-download-linux: ## Build artifact-download Linux binary.
 	cd scripts && ./build-artifact-download.sh --go-os=linux --go-arch=amd64
 .PHONY: build-artifact-download-linux
 
-build-artifact-download-darwin: ## Build artifact-download macOS binary.
+build-artifact-download-darwin-amd64: ## Build artifact-download macOS binary (Intel).
 	cd scripts && ./build-artifact-download.sh --go-os=darwin --go-arch=amd64
-.PHONY: build-artifact-download-darwin
+.PHONY: build-artifact-download-darwin-amd64
+
+build-artifact-download-darwin-arm64: ## Build artifact-download macOS binary (Apple Silicon).
+	cd scripts && ./build-artifact-download.sh --go-os=darwin --go-arch=arm64
+.PHONY: build-artifact-download-darwin-arm64
 
 build-artifact-download-windows: ## Build artifact-download Windows binary.
 	cd scripts && ./build-artifact-download.sh --go-os=windows --go-arch=amd64


### PR DESCRIPTION
Closes #510

Tasks: 
- [ ] Updated design documents in `docs/design` directory or not applicable
- [ ] Updated user-facing documentation in `docs` directory or not applicable
- [ ] Ran tests (e.g. `make test`) or not applicable
- [ ] Updated changelog or not applicable
