### PR TITLE
Improve Bitbucket error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ listed in the changelog.
 
 - Default imageTag to appVersion + release images without leading v ([#504](https://github.com/opendevstack/ods-pipeline/issues/504))
 - Display both version and Git commit SHA in `artifact-download -version` ([#507](https://github.com/opendevstack/ods-pipeline/issues/507))
+- Add more context to Bitbucket client errors ([#515](https://github.com/opendevstack/ods-pipeline/issues/515))
 
 ### Removed
 

--- a/cmd/pipeline-manager/main.go
+++ b/cmd/pipeline-manager/main.go
@@ -180,7 +180,7 @@ func serve() error {
 	time.AfterFunc(initialWatchWait, func() {
 		repos, err := manager.GetRepoNames(bitbucketClient, project)
 		if err != nil {
-			logger.Warnf(err.Error())
+			logger.Warnf("get repo names to check for queued runs: %s", err)
 		}
 		for _, r := range repos {
 			pendingRunReposChan <- r

--- a/internal/manager/bitbucket.go
+++ b/internal/manager/bitbucket.go
@@ -93,7 +93,7 @@ func GetRepoNames(bitbucketClient bitbucket.RepoClientInterface, projectKey stri
 	repos := []string{}
 	rl, err := bitbucketClient.RepoList(projectKey)
 	if err != nil {
-		return repos, err
+		return repos, fmt.Errorf("list repos of project %s: %w", projectKey, err)
 	}
 	for _, n := range rl.Values {
 		repos = append(repos, n.Name)

--- a/pkg/bitbucket/branches.go
+++ b/pkg/bitbucket/branches.go
@@ -60,14 +60,17 @@ func (c *Client) BranchList(projectKey string, repositorySlug string, params Bra
 		repositorySlug,
 		q.Encode(),
 	)
-	_, response, err := c.get(urlPath)
+	statusCode, response, err := c.get(urlPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("retrieve %s: %w", urlPath, err)
+	}
+	if statusCode != 200 {
+		return nil, fmtStatusCodeError(statusCode, response)
 	}
 	var branchPage BranchPage
 	err = json.Unmarshal(response, &branchPage)
 	if err != nil {
-		return nil, err
+		return nil, wrapUnmarshalError(err, statusCode, response)
 	}
 	return &branchPage, nil
 }

--- a/pkg/bitbucket/branches_test.go
+++ b/pkg/bitbucket/branches_test.go
@@ -1,6 +1,7 @@
 package bitbucket
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/opendevstack/pipeline/test/testserver"
@@ -15,12 +16,31 @@ func TestBranchList(t *testing.T) {
 		t, "/rest/api/1.0/projects/myproject/repos/my-repo/branches",
 		200, "bitbucket/branch-list.json",
 	)
-
 	l, err := bitbucketClient.BranchList("myproject", "my-repo", BranchListParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if l.Size != 1 {
 		t.Fatalf("got %d, want %d", l.Size, 1)
+	}
+
+	srv.EnqueueResponse(
+		t, "/rest/api/1.0/projects/myproject/repos/my-repo/branches",
+		500, "bitbucket/error.txt",
+	)
+	_, err = bitbucketClient.BranchList("myproject", "my-repo", BranchListParams{})
+	want := "status code: 500, body: error description"
+	if strings.TrimSpace(err.Error()) != want {
+		t.Fatalf("got error: %s. want: %s", err, want)
+	}
+
+	srv.EnqueueResponse(
+		t, "/rest/api/1.0/projects/myproject/repos/my-repo/branches",
+		200, "bitbucket/error.txt",
+	)
+	_, err = bitbucketClient.BranchList("myproject", "my-repo", BranchListParams{})
+	want = "unmarshal: invalid character 'e' looking for beginning of value. status code: 200, body: error description"
+	if strings.TrimSpace(err.Error()) != want {
+		t.Fatalf("got error: %s. want: %s", err, want)
 	}
 }

--- a/pkg/bitbucket/build_status.go
+++ b/pkg/bitbucket/build_status.go
@@ -36,7 +36,7 @@ func (c *Client) BuildStatusCreate(gitCommit string, payload BuildStatusCreatePa
 		return fmt.Errorf("request returned error: %w", err)
 	}
 	if statusCode != 204 {
-		return fmt.Errorf("request returned unexpected response code: %d, body: %s", statusCode, string(response))
+		return fmtStatusCodeError(statusCode, response)
 	}
 	return nil
 }
@@ -72,15 +72,13 @@ func (c *Client) BuildStatusList(gitCommit string) (*BuildStatusPage, error) {
 		var buildStatusPage BuildStatusPage
 		err = json.Unmarshal(response, &buildStatusPage)
 		if err != nil {
-			return nil, fmt.Errorf(
-				"could not unmarshal response: %w. status code: %d, body: %s", err, statusCode, string(response),
-			)
+			return nil, wrapUnmarshalError(err, statusCode, response)
 		}
 		return &buildStatusPage, nil
 	case 401:
 		return nil, fmt.Errorf("you are not permitted to get the build status of git commit %s", gitCommit)
 	default:
-		return nil, fmt.Errorf("unexpected status code %d", statusCode)
+		return nil, fmtStatusCodeError(statusCode, response)
 	}
 
 }

--- a/pkg/bitbucket/build_status_test.go
+++ b/pkg/bitbucket/build_status_test.go
@@ -1,6 +1,7 @@
 package bitbucket
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/opendevstack/pipeline/test/testserver"
@@ -13,19 +14,70 @@ func TestBuildStatusCreate(t *testing.T) {
 	defer cleanup()
 	bitbucketClient := testClient(srv.Server.URL)
 
-	srv.EnqueueResponse(
-		t, "/rest/build-status/1.0/commits/"+sha,
-		204, "",
-	)
-
-	err := bitbucketClient.BuildStatusCreate(sha, BuildStatusCreatePayload{
+	payload := BuildStatusCreatePayload{
 		State:       "INPROGRESS",
 		Key:         sha,
 		Name:        sha,
 		URL:         "http://acme.org/pipeline-run",
 		Description: "ODS Pipeline Build",
-	})
+	}
+
+	srv.EnqueueResponse(
+		t, "/rest/build-status/1.0/commits/"+sha,
+		204, "",
+	)
+	err := bitbucketClient.BuildStatusCreate(sha, payload)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	srv.EnqueueResponse(
+		t, "/rest/build-status/1.0/commits/"+sha,
+		500, "bitbucket/error.txt",
+	)
+	err = bitbucketClient.BuildStatusCreate(sha, payload)
+	want := "status code: 500, body: error description"
+	if strings.TrimSpace(err.Error()) != want {
+		t.Fatalf("got error: %s. want: %s", err, want)
+	}
+}
+
+func TestBuildStatusList(t *testing.T) {
+	sha := "56625c80087b034847001d22502063adae9759f2"
+
+	srv, cleanup := testserver.NewTestServer(t)
+	defer cleanup()
+	bitbucketClient := testClient(srv.Server.URL)
+
+	srv.EnqueueResponse(
+		t, "/rest/build-status/1.0/commits/"+sha,
+		200, "bitbucket/build-status-list.json",
+	)
+	l, err := bitbucketClient.BuildStatusList(sha)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if l.Size != 1 {
+		t.Fatalf("got %d, want %d", l.Size, 1)
+	}
+
+	srv.EnqueueResponse(
+		t, "/rest/build-status/1.0/commits/"+sha,
+		500, "bitbucket/error.txt",
+	)
+	_, err = bitbucketClient.BuildStatusList(sha)
+	want := "status code: 500, body: error description"
+	if strings.TrimSpace(err.Error()) != want {
+		t.Fatalf("got error: %s. want: %s", err, want)
+	}
+
+	srv.EnqueueResponse(
+		t, "/rest/build-status/1.0/commits/"+sha,
+		200, "bitbucket/error.txt",
+	)
+	_, err = bitbucketClient.BuildStatusList(sha)
+	want = "unmarshal: invalid character 'e' looking for beginning of value. status code: 200, body: error description"
+	if strings.TrimSpace(err.Error()) != want {
+		t.Fatalf("got error: %s. want: %s", err, want)
 	}
 }

--- a/pkg/bitbucket/client.go
+++ b/pkg/bitbucket/client.go
@@ -100,3 +100,13 @@ func (c *Client) do(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Authorization", "Bearer "+c.clientConfig.APIToken)
 	return c.httpClient.Do(req)
 }
+
+// wrapUnmarshalError wraps err and includes statusCode/response.
+func wrapUnmarshalError(err error, statusCode int, response []byte) error {
+	return fmt.Errorf("unmarshal: %w. status code: %d, body: %s", err, statusCode, string(response))
+}
+
+// fmtStatusCodeError returns an error containing statusCode/response.
+func fmtStatusCodeError(statusCode int, response []byte) error {
+	return fmt.Errorf("status code: %d, body: %s", statusCode, string(response))
+}

--- a/pkg/bitbucket/code_insights.go
+++ b/pkg/bitbucket/code_insights.go
@@ -66,9 +66,7 @@ func (c *Client) InsightReportCreate(projectKey, repositorySlug, commitID, key s
 	var insightReport InsightReport
 	err = json.Unmarshal(response, &insightReport)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"could not unmarshal response: %w. status code: %d, body: %s", err, statusCode, string(response),
-		)
+		return nil, wrapUnmarshalError(err, statusCode, response)
 	}
 	return &insightReport, nil
 }

--- a/pkg/bitbucket/commits.go
+++ b/pkg/bitbucket/commits.go
@@ -130,14 +130,17 @@ func (c *Client) CommitList(projectKey string, repositorySlug string, params Com
 		repositorySlug,
 		q.Encode(),
 	)
-	_, response, err := c.get(urlPath)
+	statusCode, response, err := c.get(urlPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("retrieve %s: %w", urlPath, err)
+	}
+	if statusCode != 200 {
+		return nil, fmtStatusCodeError(statusCode, response)
 	}
 	var commitPage CommitPage
 	err = json.Unmarshal(response, &commitPage)
 	if err != nil {
-		return nil, err
+		return nil, wrapUnmarshalError(err, statusCode, response)
 	}
 	return &commitPage, nil
 }
@@ -154,14 +157,15 @@ func (c *Client) CommitGet(projectKey, repositorySlug, commitID string) (*Commit
 	)
 	statusCode, response, err := c.get(urlPath)
 	if err != nil {
-		return nil, fmt.Errorf("request returned error: %w", err)
+		return nil, fmt.Errorf("retrieve %s: %w", urlPath, err)
+	}
+	if statusCode != 200 {
+		return nil, fmtStatusCodeError(statusCode, response)
 	}
 	var commit Commit
 	err = json.Unmarshal(response, &commit)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"could not unmarshal response: %w. status code: %d, body: %s", err, statusCode, string(response),
-		)
+		return nil, wrapUnmarshalError(err, statusCode, response)
 	}
 	return &commit, nil
 }
@@ -178,14 +182,15 @@ func (c *Client) CommitPullRequestList(projectKey, repositorySlug, commitID stri
 	)
 	statusCode, response, err := c.get(urlPath)
 	if err != nil {
-		return nil, fmt.Errorf("request returned error: %w", err)
+		return nil, fmt.Errorf("retrieve %s: %w", urlPath, err)
+	}
+	if statusCode != 200 {
+		return nil, fmtStatusCodeError(statusCode, response)
 	}
 	var prPage PullRequestPage
 	err = json.Unmarshal(response, &prPage)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"could not unmarshal response: %w. status code: %d, body: %s", err, statusCode, string(response),
-		)
+		return nil, wrapUnmarshalError(err, statusCode, response)
 	}
 	return &prPage, nil
 }

--- a/pkg/bitbucket/projects.go
+++ b/pkg/bitbucket/projects.go
@@ -48,9 +48,7 @@ func (c *Client) ProjectCreate(payload ProjectCreatePayload) (*Project, error) {
 	var project Project
 	err = json.Unmarshal(response, &project)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"could not unmarshal response: %w. status code: %d, body: %s", err, statusCode, string(response),
-		)
+		return nil, wrapUnmarshalError(err, statusCode, response)
 	}
 	return &project, nil
 }

--- a/pkg/bitbucket/tags.go
+++ b/pkg/bitbucket/tags.go
@@ -60,14 +60,17 @@ func (c *Client) TagList(projectKey string, repositorySlug string, params TagLis
 		repositorySlug,
 		q.Encode(),
 	)
-	_, response, err := c.get(urlPath)
+	statusCode, response, err := c.get(urlPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("retrieve %s: %w", urlPath, err)
+	}
+	if statusCode != 200 {
+		return nil, fmtStatusCodeError(statusCode, response)
 	}
 	var tagPage TagPage
 	err = json.Unmarshal(response, &tagPage)
 	if err != nil {
-		return nil, err
+		return nil, wrapUnmarshalError(err, statusCode, response)
 	}
 	return &tagPage, nil
 }
@@ -83,14 +86,17 @@ func (c *Client) TagGet(projectKey string, repositorySlug string, name string) (
 		repositorySlug,
 		name,
 	)
-	_, response, err := c.get(urlPath)
+	statusCode, response, err := c.get(urlPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("retrieve %s: %w", urlPath, err)
+	}
+	if statusCode != 200 {
+		return nil, fmtStatusCodeError(statusCode, response)
 	}
 	var tag Tag
 	err = json.Unmarshal(response, &tag)
 	if err != nil {
-		return nil, err
+		return nil, wrapUnmarshalError(err, statusCode, response)
 	}
 	return &tag, nil
 }
@@ -122,9 +128,7 @@ func (c *Client) TagCreate(projectKey string, repositorySlug string, payload Tag
 	var tag Tag
 	err = json.Unmarshal(response, &tag)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"could not unmarshal response: %w. status code: %d, body: %s", err, statusCode, string(response),
-		)
+		return nil, wrapUnmarshalError(err, statusCode, response)
 	}
 	return &tag, nil
 }

--- a/pkg/bitbucket/webhooks.go
+++ b/pkg/bitbucket/webhooks.go
@@ -44,9 +44,7 @@ func (c *Client) WebhookCreate(projectKey, repositorySlug string, payload Webhoo
 	var webhook Webhook
 	err = json.Unmarshal(response, &webhook)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"could not unmarshal response: %w. status code: %d, body: %s", err, statusCode, string(response),
-		)
+		return nil, wrapUnmarshalError(err, statusCode, response)
 	}
 	return &webhook, nil
 }

--- a/test/testdata/fixtures/bitbucket/build-status-list.json
+++ b/test/testdata/fixtures/bitbucket/build-status-list.json
@@ -1,0 +1,16 @@
+{
+    "size": 1,
+    "limit": 25,
+    "isLastPage": true,
+    "values": [
+        {
+            "state": "SUCCESSFUL",
+            "key": "REPO-MASTER",
+            "name": "REPO-MASTER-42",
+            "url": "https://bamboo.example.com/browse/REPO-MASTER-42",
+            "description": "Changes by John Doe",
+            "dateAdded": 1621231641519
+        }
+    ],
+    "start": 0
+}

--- a/test/testdata/fixtures/bitbucket/error.txt
+++ b/test/testdata/fixtures/bitbucket/error.txt
@@ -1,0 +1,1 @@
+error description


### PR DESCRIPTION
Closes #515.

There is much more that could/should be done, but I stopped working further on it for now. The Bitbucket client contains so a lot of code duplication in unmarshaling / error handling, which really should be fixed by using Go 1.18 generics features. I've experimented a bit with it and it is really straightforward, but I would hold off a bit until we get a Go 1.18 UBI image from RedHat. Therefore, I suggest to merge this PR as it makes it is already an improvement over the current situation, and do another sweep once we are able to use generics.

For those interested in the WIP: https://github.com/opendevstack/ods-pipeline/compare/refactor/bitbucket-client-generics?expand=1

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
