### PR TITLE
Fix buildah image user

### DIFF
--- a/build/package/Dockerfile.buildah
+++ b/build/package/Dockerfile.buildah
@@ -23,7 +23,7 @@ ENV BUILDAH_VERSION=1.24 \
 COPY --from=builder /usr/local/bin/ods-build-push-image /usr/local/bin/ods-build-push-image
 
 # Don't include container-selinux and remove directories used by yum that are just taking up space.
-RUN useradd build \
+RUN useradd -u 1001 build \
     && dnf -y module enable container-tools:rhel8 \
     && dnf -y update \
     && dnf -y reinstall shadow-utils \
@@ -41,8 +41,9 @@ RUN chmod 644 /etc/containers/containers.conf \
     && touch /var/lib/shared/vfs-layers/layers.lock
 
 # Define uid/gid ranges for our user https://github.com/containers/buildah/issues/3053
-RUN echo -e "build:1:999\nbuild:1001:64535" > /etc/subuid \
-    && echo -e "build:1:999\nbuild:1001:64535" > /etc/subgid \
+# Also see https://github.com/containers/buildah/commit/41d384c3bc77d1a9b2a365c057f3186742597363.
+RUN echo -e "build:1:1000\nbuild:1002:64535" > /etc/subuid \
+    && echo -e "build:1:1000\nbuild:1002:64535" > /etc/subgid \
     && mkdir -p /home/build/.local/share/containers \
     && chown -R build:build /home/build
 
@@ -52,3 +53,5 @@ VOLUME /home/build/.local/share/containers
 # Set an environment variable to default to chroot isolation for RUN
 # instructions and "buildah run".
 ENV BUILDAH_ISOLATION=chroot
+
+USER 1001

--- a/build/package/Dockerfile.finish
+++ b/build/package/Dockerfile.finish
@@ -18,3 +18,5 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 ENV OPENSSL_VERSION=1.1
 COPY --from=builder /usr/local/bin/ods-finish /usr/local/bin/ods-finish
 RUN microdnf install --nodocs openssl-${OPENSSL_VERSION}* && microdnf clean all
+
+USER 1001


### PR DESCRIPTION
Previously, the `build` user was created with UID 1000, but the wrapper Dockerfile made the container to start as UID 1001 (see  https://github.com/opendevstack/ods-pipeline/blob/master/deploy/ods-pipeline/charts/images/docker/Dockerfile.buildah#L22). Now we create the `build` user with UID 1001, to be consistent with all other images. The subuid/subgid ranges have been adapted appropriately.

This fixes an issue introduced in #522, which was not officially released yet, therefore this does not need a changelog entry.

The change made to `Dockerfile.finish` is for consistency only, it doesn't have any effect actually since the `USER` instruction is overriden by the wrapper Dockerfile anyway.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
