### PR TITLE
Switch to root user before downloading Aquasec binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ listed in the changelog.
 
 ## [Unreleased]
 
+### Fixed
+- Wrapper image cannot write aquasec binary ([#539](https://github.com/opendevstack/ods-pipeline/issues/539))
+
+
 ## [0.4.0] - 2022-05-31
 
 ### Added

--- a/deploy/ods-pipeline/charts/images/docker/Dockerfile.buildah
+++ b/deploy/ods-pipeline/charts/images/docker/Dockerfile.buildah
@@ -3,6 +3,9 @@ ARG imageTag="latest"
 FROM ghcr.io/opendevstack/ods-pipeline/ods-buildah:$imageTag
 
 ARG aquasecScannerUrl
+ARG privateCertServer
+
+USER root
 
 # Optionally install Aqua scanner.
 RUN if [ -z $aquasecScannerUrl ] ; then echo 'Skipping Aqua scanner installation!' ; else echo 'Installing Aqua scanner... getting binary from' $aquasecScannerUrl \
@@ -14,9 +17,8 @@ RUN if [ -z $aquasecScannerUrl ] ; then echo 'Skipping Aqua scanner installation
     && echo 'Aqua scanner installation completed!'; \
     fi
 
-ARG privateCertServer
-USER root
 RUN if [ -n "${privateCertServer}" ]; then openssl s_client -showcerts -connect "${privateCertServer}" </dev/null \
     | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > "/etc/pki/ca-trust/source/anchors/${privateCertServer%:*}.pem" && \
     update-ca-trust; fi
+
 USER 1001


### PR DESCRIPTION
Fixes #539.

This does not affect the user under which the container actually runs
later on, that is still fixed to 1001.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
