### PR TITLE
Automatically build images after Helm upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ listed in the changelog.
 
 ## [Unreleased]
 
+### Added
+
+- Automatically build images after Helm upgrade ([#525](https://github.com/opendevstack/ods-pipeline/issues/525))
+
 ### Fixed
 - Wrapper image cannot write aquasec binary ([#539](https://github.com/opendevstack/ods-pipeline/issues/539))
 - When a commit is skipped, the log message contains weird output ([#542](https://github.com/opendevstack/ods-pipeline/issues/542))

--- a/deploy/ods-pipeline/charts/images/templates/job-start-builds.yaml
+++ b/deploy/ods-pipeline/charts/images/templates/job-start-builds.yaml
@@ -1,0 +1,31 @@
+{{if default true .Values.autoBuild}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ods-start-builds
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  template:
+    spec:
+      serviceAccountName: pipeline
+      restartPolicy: Never
+      containers:
+      - name: post-upgrade-job
+        image: '{{.Values.autoBuildImage | default "quay.io/openshift/origin-cli:4.10"}}'
+        command: ["/bin/sh","-c"]
+        # Attempt to start builds for all possible build configs. Some may not
+        # actually exist, but the failure will simply be ignored.
+        args: ["oc start-build ods-buildah;
+                oc start-build ods-finish;
+                oc start-build ods-go-toolset;
+                oc start-build ods-gradle-toolset;
+                oc start-build ods-helm;
+                oc start-build ods-node16-npm-toolset;
+                oc start-build ods-pipeline-manager;
+                oc start-build ods-python-toolset;
+                oc start-build ods-sonar;
+                oc start-build ods-start"]
+{{end}}

--- a/deploy/ods-pipeline/charts/images/templates/job-start-builds.yaml
+++ b/deploy/ods-pipeline/charts/images/templates/job-start-builds.yaml
@@ -16,16 +16,5 @@ spec:
       - name: post-upgrade-job
         image: '{{.Values.autoBuildImage | default "quay.io/openshift/origin-cli:4.10"}}'
         command: ["/bin/sh","-c"]
-        # Attempt to start builds for all possible build configs. Some may not
-        # actually exist, but the failure will simply be ignored.
-        args: ["oc start-build ods-buildah;
-                oc start-build ods-finish;
-                oc start-build ods-go-toolset;
-                oc start-build ods-gradle-toolset;
-                oc start-build ods-helm;
-                oc start-build ods-node16-npm-toolset;
-                oc start-build ods-pipeline-manager;
-                oc start-build ods-python-toolset;
-                oc start-build ods-sonar;
-                oc start-build ods-start"]
+        args: ["set -e; oc get bc -l=app.kubernetes.io/name=ods-pipeline -o=name | xargs -I % sh -c 'oc start-build %'"]
 {{end}}

--- a/deploy/ods-pipeline/values.yaml
+++ b/deploy/ods-pipeline/values.yaml
@@ -27,6 +27,11 @@ images:
   # privateCertServer: 'example.com:443'
   # if needed, enable images even though related tasks are disabled, e.g.
   # pythonToolset: true
+  # autoBuild controls whether builds for all BuildConfig resources are started
+  # automatically after a successful Helm upgrade. autoBuild is enabled by default.
+  # autoBuild: true
+  # autoBuildImage allows to override the image used for starting builds.
+  # autoBuildImage: 'quay.io/openshift/origin-cli:4.9'
 
 
 # ####################################### #

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -458,6 +458,21 @@ The OpenShift namespace is used to retrieve configuration and secrets required t
 For all repositories in scope, the artifacts in the corresponding groups in Nexus are downloaded to the local host. The files are placed into `artifacts-out/<TAG>` (customizable via `--output`).
 |===
 
+===== Installation / Update
+
+[cols="1,1,3"]
+|===
+| SDS-SETUP-1
+| Helm chart `ods-pipeline`
+a| The Helm chart consists of three subhcharts:
+
+* `images`: Contains `BuildConfig`/`ImageStream` resources
+* `tasks`: Contains `Task` resources
+* `setup`: Contains resources related to the pipeline manager and config maps / secrets supporting pipeline runs
+
+The `images` chart is only used within an OpenShift context. It contains a `post-install/upgrade` hook which starts builds for all available `BuildConfig` resources to automatically build new container images to be used in tasks and the pipeline manager.
+|===
+
 
 === Third-party components
 

--- a/docs/design/software-requirements-specification.adoc
+++ b/docs/design/software-requirements-specification.adoc
@@ -59,6 +59,9 @@ The tasks shall create artifacts of their work. Those artifacts shall be stored 
 
 | SRS-GENERAL-4
 | ODS Pipeline shall function within corporate networks (HTTP proxy, private CA).
+
+| SRS-GENERAL-5
+| ODS Pipeline shall automatically build container images after installation / update.
 |===
 
 === Pipeline Manager Requirements

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -101,6 +101,8 @@ IMPORTANT: In ODS 4.0.0, the central Nexus instance does not have the repositori
 
 Now fill in the variables as described in the comments in both (values.yaml and secrets.yaml) files. Then you can install the resources via `./install.sh -n <your_cd_namespace> -f values.yaml,secrets.yaml` (make sure to replace the namespace). You may also use `--dry-run` to see the changes first.
 
+NOTE: After successful installation in OpenShift, builds for the container images used in the pipeline manager and Tekton tasks will be triggered automatically. It is recommended to check that all builds succeed before proceeding.
+
 Finally, run `oc -n <your_cd_namespace> expose svc ods-pipeline` to expose the service listener. Make a note of the exposed URL as you'll need it to create webhooks in Bitbucket (together with the webhook secret that is stored in the `Secret/ods-bitbucket-webhook` resource).
 
 IMPORTANT: The `pipeline` serviceaccount needs at least `edit` or even `admin` permissions in the Kubernetes namespaces it deploys to (e.g. `foo-dev` and `foo-test`).
@@ -125,5 +127,7 @@ git subtree merge --prefix=deploy subtree-split-branch-$pipelineGitRef --squash
 Now, compare if any new values have been introduced and update the values and secrets file accordingly.
 
 Afterwards you can update the resources via `./install.sh -n <your_cd_namespace> -f values.yaml,secrets.yaml`. You may also use `--dry-run` to see the changes first.
+
+NOTE: After successful installation in OpenShift, builds for the container images used in the pipeline manager and Tekton tasks will be triggered automatically. It is recommended to check that all builds succeed before proceeding.
 
 Once the resources in your namespace are updated, you can update the `ods.yaml` files in your repository and point to the new tasks, e.g. changing `ods-build-go-v0-3-0` to `ods-build-go-v0-4-0`.


### PR DESCRIPTION
Closes #525.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
