### PR TITLE
Fix log message when commit is skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ listed in the changelog.
 
 ### Fixed
 - Wrapper image cannot write aquasec binary ([#539](https://github.com/opendevstack/ods-pipeline/issues/539))
+- When a commit is skipped, the log message contains weird output ([#542](https://github.com/opendevstack/ods-pipeline/issues/542))
 
 
 ## [0.4.0] - 2022-05-31

--- a/internal/manager/receive.go
+++ b/internal/manager/receive.go
@@ -166,8 +166,8 @@ func (s *BitbucketWebhookReceiver) Handle(w http.ResponseWriter, r *http.Request
 
 	skip := shouldSkip(s.BitbucketClient, pInfo.Project, pInfo.Repository, commitSHA)
 	if skip {
-		msg := "Commit should be skipped"
-		s.Logger.Infof("%s: %s", msg, err)
+		msg := fmt.Sprintf("Commit %s should be skipped", commitSHA)
+		s.Logger.Infof(msg)
 		// According to MDN (https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418),
 		// "some websites use this response for requests they do not wish to handle [..]".
 		http.Error(w, msg, http.StatusTeapot)

--- a/internal/manager/receive_test.go
+++ b/internal/manager/receive_test.go
@@ -161,7 +161,7 @@ func TestWebhookHandling(t *testing.T) {
 				},
 			},
 			wantStatus:         http.StatusTeapot,
-			wantBody:           "Commit should be skipped",
+			wantBody:           "Commit 0e183aa3bc3c6deb8f40b93fb2fc4354533cf62f should be skipped",
 			wantPipelineConfig: false,
 		},
 		"repo:refs_changed triggers pipeline": {


### PR DESCRIPTION
Fixes #542.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
