### PR TITLE
Allow to use build script located in repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ listed in the changelog.
 ### Added
 
 - Automatically build images after Helm upgrade ([#525](https://github.com/opendevstack/ods-pipeline/issues/525))
+- Allow to use build script located in repository ([#536](https://github.com/opendevstack/ods-pipeline/issues/536))
 
 ### Changed
 

--- a/build/package/scripts/copy-artifacts.sh
+++ b/build/package/scripts/copy-artifacts.sh
@@ -26,5 +26,6 @@ tmp_artifacts_dir="${ROOT_DIR}/.ods/tmp-artifacts"
 
 # Copying ods artifacts which are mostly reports (see artifacts.adoc)
 echo "Copying build artifacts from $tmp_artifacts_dir to $ods_artifacts_dir"
+mkdir -p "$tmp_artifacts_dir"
 mkdir -p "$ods_artifacts_dir"
 "$CP" -v -r "$tmp_artifacts_dir/." "$ods_artifacts_dir"

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-go.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-go.yaml
@@ -80,6 +80,15 @@ spec:
         For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
       type: string
       default: "false"
+    - name: build-script
+      description: >-
+        Build script to execute. The
+        link:https://github.com/opendevstack/ods-pipeline/blob/master/build/package/scripts/build-go.sh[default script]
+        is located in the container image. If you specify a relative path
+        instead, it will be resolved from the workspace. See the task definition
+        for details how the build script is invoked.
+      type: string
+      default: "/usr/local/bin/build-go"
     - name: pre-test-script
       description: Script to execute before running tests, relative to the working directory.
       type: string
@@ -128,9 +137,9 @@ spec:
           --debug=${DEBUG} ; then
           exit 0
         fi
-        # build-go is build/package/scripts/build-go.sh.
+        # Default build script is build/package/scripts/build-go.sh.
         set +e 
-        build-go \
+        $(params.build-script) \
           --working-dir=$(params.working-dir) \
           --enable-cgo=$(params.enable-cgo) \
           --go-os=$(params.go-os) \

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
@@ -136,6 +136,15 @@ spec:
         This directory may then later be used as Docker context for example.
       type: string
       default: docker
+    - name: build-script
+      description: >-
+        Build script to execute. The
+        link:https://github.com/opendevstack/ods-pipeline/blob/master/build/package/scripts/build-gradle.sh[default script]
+        is located in the container image. If you specify a relative path
+        instead, it will be resolved from the workspace. See the task definition
+        for details how the build script is invoked.
+      type: string
+      default: "/usr/local/bin/build-gradle"
     - name: sonar-quality-gate
       description: Whether the SonarQube quality gate needs to pass for the task to succeed.
       type: string
@@ -182,8 +191,8 @@ spec:
       resources:
         {{- (.Values.gradle).resources | default dict | toYaml | nindent 8 }}
       script: |
-        # build-gradle is build/package/scripts/build-gradle.sh.
-        build-gradle \
+        # Default build script is build/package/scripts/build-gradle.sh.
+        $(params.build-script) \
           --working-dir=$(params.working-dir) \
           --output-dir=$(params.output-dir) \
           --gradle-additional-tasks="$(params.gradle-additional-tasks)" \

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-npm.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-npm.yaml
@@ -73,6 +73,15 @@ spec:
         For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
       type: string
       default: "false"
+    - name: build-script
+      description: >-
+        Build script to execute. The
+        link:https://github.com/opendevstack/ods-pipeline/blob/master/build/package/scripts/build-npm.sh[default script]
+        is located in the container image. If you specify a relative path
+        instead, it will be resolved from the workspace. See the task definition
+        for details how the build script is invoked.
+      type: string
+      default: "/usr/local/bin/build-npm"
     - name: sonar-quality-gate
       description: Whether quality gate needs to pass.
       type: string
@@ -152,9 +161,9 @@ spec:
           --debug=${DEBUG} ; then
           exit 0
         fi
-        # build-npm is build/package/scripts/build-npm.sh.
+        # Default build script is build/package/scripts/build-npm.sh.
         set +e 
-        build-npm \
+        $(params.build-script) \
           --working-dir=$(params.working-dir) \
           --output-dir=$(params.output-dir) \
           --debug=${DEBUG} \

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-python.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-python.yaml
@@ -63,6 +63,15 @@ spec:
       description: Script to execute before running tests, relative to the working directory.
       type: string
       default: ""
+    - name: build-script
+      description: >-
+        Build script to execute. The
+        link:https://github.com/opendevstack/ods-pipeline/blob/master/build/package/scripts/build-python.sh[default script]
+        is located in the container image. If you specify a relative path
+        instead, it will be resolved from the workspace. See the task definition
+        for details how the build script is invoked.
+      type: string
+      default: "/usr/local/bin/build-python"
     - name: sonar-quality-gate
       description: Whether quality gate needs to pass.
       type: string
@@ -122,9 +131,9 @@ spec:
           --debug=${DEBUG} ; then
           exit 0
         fi
-        # build-python is build/package/scripts/build-python.sh.
+        # Default build script is build/package/scripts/build-python.sh.
         set +e 
-        build-python \
+        $(params.build-script) \
           --working-dir=$(params.working-dir) \
           --max-line-length=$(params.max-line-length) \
           --pre-test-script=$(params.pre-test-script) \

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -121,6 +121,7 @@ Input parameters:
 * `go-arch`: sets target architecture (`GOARCH`)
 * `output-dir`: sets destination directory of built binary
 * `pre-test-script`: specifies script to run prior to tests
+* `build-script`: specifies path to build script
 * `sonar-quality-gate`: enables quality gate check
 * `sonar-skip`: skips SonarQube analysis
 * `cache-build`: if 'true' build skipping is enabled.
@@ -167,6 +168,7 @@ Input parameters:
 * `gradle-additional-tasks`: additional gradle tasks to be passed to the gradle build
 * `gradle-options`: options to be passed to the gradle build
 * `output-dir`: sets destination directory of built binary
+* `build-script`: specifies path to build script
 * `sonar-quality-gate`: enables quality gate check
 * `sonar-skip`: skips SonarQube analysis
 
@@ -268,7 +270,9 @@ a| The task defines two steps:
   This step supports build skipping (executing SDS-SHARED-5 and/or SDS-SHARED-4 if enabled with parameter `cache-build`)
 . Analyze source code (referencing SDS-SHARED-1 and executing SDS-SHARED-2)
 
-Input parameters: TODO
+Input parameters:
+
+* `build-script`: specifies path to build script
 
 | SDS-TASK-14
 | `ods-python-toolset` container image
@@ -311,6 +315,7 @@ Input parameters:
 * `copy-node-modules`: enables copying node_modules directory to the output directory
 * `max-lint-warnings`: maximum of allowed linting warnings after which eslint will exit with an error
 * `lint-file-ext`: file extensions to lint
+* `build-script`: specifies path to build script
 * `sonar-quality-gate`: enables quality gate check
 * `sonar-skip`: skips SonarQube analysis
 * `cache-build`: if 'true' build skipping is enabled.

--- a/docs/design/software-requirements-specification.adoc
+++ b/docs/design/software-requirements-specification.adoc
@@ -167,6 +167,9 @@ a| The task shall build a Go module based Go binary.
 | SRS-TASK-BUILD-GO-7
 | See SRS-TASK-SHARED-3.
 
+| SRS-TASK-BUILD-GO-8
+| See SRS-TASK-SHARED-4.
+
 |===
 
 ==== Task `ods-build-gradle`
@@ -190,6 +193,9 @@ a| The task shall run tests, creating code coverage and xUnit report.
 
 | SRS-TASK-BUILD-GRADLE-4
 | See SRS-TASK-SHARED-2.
+
+| SRS-TASK-BUILD-GRADLE-5
+| See SRS-TASK-SHARED-4.
 
 |===
 
@@ -220,6 +226,9 @@ a| The task shall build a Python application.
 | SRS-TASK-BUILD-PYTHON-6
 | See SRS-TASK-SHARED-3.
 
+| SRS-TASK-BUILD-PYTHON-7
+| See SRS-TASK-SHARED-4.
+
 |===
 
 ==== Task `ods-build-npm`
@@ -247,6 +256,9 @@ a| The task shall build a Node.JS application using npm.
 
 | SRS-TASK-BUILD-NPM-6
 | See SRS-TASK-SHARED-3.
+
+| SRS-TASK-BUILD-NPM-7
+| See SRS-TASK-SHARED-4.
 
 |===
 
@@ -315,6 +327,9 @@ a| The task shall be able to run in a subdirectory of the checked out repository
 
 | SRS-TASK-SHARED-3
 a| The task shall be able to optionally use a build output and report cache so that future execution of build scripts can be skipped if the subdirectory of the checked out repository did not change.
+
+| SRS-TASK-SHARED-4
+a| The task shall be configurable to use a build script located in the workspace instead of the built-in build script.
 
 |===
 

--- a/docs/tasks/ods-build-go.adoc
+++ b/docs/tasks/ods-build-go.adoc
@@ -81,6 +81,11 @@ without leading `./` and trailing `/`.
 | If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that a build can be skipped if the `working-dir` contents did not change. For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
 
 
+| build-script
+| /usr/local/bin/build-go
+| Build script to execute. The link:https://github.com/opendevstack/ods-pipeline/blob/master/build/package/scripts/build-go.sh[default script] is located in the container image. If you specify a relative path instead, it will be resolved from the workspace. See the task definition for details how the build script is invoked.
+
+
 | pre-test-script
 | 
 | Script to execute before running tests, relative to the working directory.

--- a/docs/tasks/ods-build-gradle.adoc
+++ b/docs/tasks/ods-build-gradle.adoc
@@ -131,6 +131,11 @@ without leading `./` and trailing `/`.
 | Path to the directory into which the resulting Java application jar should be copied, relative to `working-dir`. This directory may then later be used as Docker context for example.
 
 
+| build-script
+| /usr/local/bin/build-gradle
+| Build script to execute. The link:https://github.com/opendevstack/ods-pipeline/blob/master/build/package/scripts/build-gradle.sh[default script] is located in the container image. If you specify a relative path instead, it will be resolved from the workspace. See the task definition for details how the build script is invoked.
+
+
 | sonar-quality-gate
 | false
 | Whether the SonarQube quality gate needs to pass for the task to succeed.

--- a/docs/tasks/ods-build-npm.adoc
+++ b/docs/tasks/ods-build-npm.adoc
@@ -71,6 +71,11 @@ without leading `./` and trailing `/`.
 | If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that a build can be skipped if the `working-dir` contents did not change. For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
 
 
+| build-script
+| /usr/local/bin/build-npm
+| Build script to execute. The link:https://github.com/opendevstack/ods-pipeline/blob/master/build/package/scripts/build-npm.sh[default script] is located in the container image. If you specify a relative path instead, it will be resolved from the workspace. See the task definition for details how the build script is invoked.
+
+
 | sonar-quality-gate
 | false
 | Whether quality gate needs to pass.

--- a/docs/tasks/ods-build-python.adoc
+++ b/docs/tasks/ods-build-python.adoc
@@ -63,6 +63,11 @@ without leading `./` and trailing `/`.
 | Script to execute before running tests, relative to the working directory.
 
 
+| build-script
+| /usr/local/bin/build-python
+| Build script to execute. The link:https://github.com/opendevstack/ods-pipeline/blob/master/build/package/scripts/build-python.sh[default script] is located in the container image. If you specify a relative path instead, it will be resolved from the workspace. See the task definition for details how the build script is invoked.
+
+
 | sonar-quality-gate
 | false
 | Whether quality gate needs to pass.


### PR DESCRIPTION
Closes #536.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
