### PR TITLE
Signal when pruning should kick in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ listed in the changelog.
 
 ## [Unreleased]
 
+### Fixed
+- Pipeline runs are not pruned ([#557](https://github.com/opendevstack/ods-pipeline/issues/557))
 
 ## [0.5.0] - 2022-06-09
 

--- a/cmd/pipeline-manager/main.go
+++ b/cmd/pipeline-manager/main.go
@@ -145,6 +145,7 @@ func serve() error {
 
 	s := &manager.Scheduler{
 		TriggeredPipelines: triggeredPipelinesChan,
+		TriggeredRepos:     triggeredReposChan,
 		PendingRunRepos:    pendingRunReposChan,
 		TektonClient:       tClient,
 		KubernetesClient:   kClient,

--- a/internal/manager/schedule.go
+++ b/internal/manager/schedule.go
@@ -26,7 +26,9 @@ type StorageConfig struct {
 type Scheduler struct {
 	// Channel to read newly received runs from
 	TriggeredPipelines chan PipelineConfig
-	// Channel to send pending runs on
+	// Channel to send triggered repos on (signalling to start pruning)
+	TriggeredRepos chan string
+	// Channel to send pending runs on (singalling to start watching)
 	PendingRunRepos  chan string
 	TektonClient     tektonClient.ClientInterface
 	KubernetesClient kubernetesClient.ClientInterface
@@ -98,6 +100,8 @@ func (s *Scheduler) schedule(ctx context.Context, pData PipelineConfig) bool {
 		s.Logger.Errorf(err.Error())
 		return false
 	}
+	// Trigger pruning
+	s.TriggeredRepos <- pData.Repository
 	return needQueueing
 }
 

--- a/internal/manager/schedule_test.go
+++ b/internal/manager/schedule_test.go
@@ -17,7 +17,8 @@ func TestSchedule(t *testing.T) {
 
 	cfg := PipelineConfig{
 		PipelineInfo: PipelineInfo{
-			Name: "pipeline",
+			Name:       "pipeline",
+			Repository: "repo",
 		},
 		PVC: "pvc",
 	}
@@ -87,7 +88,8 @@ func TestSchedule(t *testing.T) {
 					ClassName:   "class",
 					Size:        "1Gi",
 				},
-				Logger: &logging.LeveledLogger{Level: logging.LevelNull},
+				Logger:         &logging.LeveledLogger{Level: logging.LevelNull},
+				TriggeredRepos: make(chan string, 100),
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -104,6 +106,9 @@ func TestSchedule(t *testing.T) {
 			}
 			if len(tc.tektonClient.CreatedPipelineRuns) != 1 {
 				t.Fatal("one pipeline run should have been created")
+			}
+			if gotTriggered := <-s.TriggeredRepos; gotTriggered != "repo" {
+				t.Fatal("channel should have received the repository name")
 			}
 			if tc.wantQueuedRun != gotQueued {
 				t.Fatalf("want queued: %v, got: %v", tc.wantQueuedRun, gotQueued)


### PR DESCRIPTION
Without sending on the channel, pruning will never happen 🤦 

Fixes #557.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
