### PR TITLE
Do not add chart labels to tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ listed in the changelog.
 
 ### Fixed
 - Pipeline runs are not pruned ([#557](https://github.com/opendevstack/ods-pipeline/issues/557))
+- Pipeline pods are listed under deployment pods ([#555](https://github.com/opendevstack/ods-pipeline/issues/555))
 
 ## [0.5.0] - 2022-06-09
 

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-go.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-go.yaml
@@ -3,8 +3,6 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "Task" .Values.global.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-build-go{{- include "taskSuffix" .}}'
-  labels:
-    {{- include "chart.labels" . | nindent 4}}
   annotations:
     "helm.sh/resource-policy": keep
 spec:

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
@@ -3,8 +3,6 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "Task" .Values.global.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-build-gradle{{- include "taskSuffix" .}}'
-  labels:
-    {{- include "chart.labels" . | nindent 4}}
   annotations:
     "helm.sh/resource-policy": keep
 spec:

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-npm.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-npm.yaml
@@ -3,8 +3,6 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "Task" .Values.global.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-build-npm{{- include "taskSuffix" .}}'
-  labels:
-    {{- include "chart.labels" . | nindent 4}}
   annotations:
     "helm.sh/resource-policy": keep
 spec:

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-python.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-python.yaml
@@ -3,8 +3,6 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "Task" .Values.global.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-build-python{{- include "taskSuffix" .}}'
-  labels:
-    {{- include "chart.labels" . | nindent 4}}
   annotations:
     "helm.sh/resource-policy": keep
 spec:

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-deploy-helm.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-deploy-helm.yaml
@@ -3,8 +3,6 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "Task" .Values.global.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-deploy-helm{{- include "taskSuffix" .}}'
-  labels:
-    {{- include "chart.labels" . | nindent 4}}
   annotations:
     "helm.sh/resource-policy": keep
 spec:

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-finish.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-finish.yaml
@@ -2,8 +2,6 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "Task" .Values.global.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-finish{{- include "taskSuffix" .}}'
-  labels:
-    {{- include "chart.labels" . | nindent 4}}
   annotations:
     "helm.sh/resource-policy": keep
 spec:

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-package-image.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-package-image.yaml
@@ -3,8 +3,6 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "Task" .Values.global.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-package-image{{- include "taskSuffix" .}}'
-  labels:
-    {{- include "chart.labels" . | nindent 4}}
   annotations:
     "helm.sh/resource-policy": keep
 spec:

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-start.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-start.yaml
@@ -2,8 +2,6 @@ apiVersion: tekton.dev/v1beta1
 kind: '{{default "Task" .Values.global.taskKind}}'
 metadata:
   name: '{{default "ods" .Values.taskPrefix}}-start{{- include "taskSuffix" .}}'
-  labels:
-    {{- include "chart.labels" . | nindent 4}}
   annotations:
     "helm.sh/resource-policy": keep
 spec:


### PR DESCRIPTION
The labels were added recently in #550.

However, I was unaware that Tekton propagates the labels of tasks to the
pods: https://tekton.dev/docs/pipelines/labels/#label-propagation.

This propagation has the unwanted effect that the `ods-pipeline`
deployment now considers all pods that are created from pipelines as
part of the deployment.

Unfortunately there seems to be no way to have the labels for the tasks,
but not propagated to the pods.

An alternative solution would have been to change the selector in the
deployment, but that would not change that the pods are labelled as
being "managed by Helm", which isn't correct so instead we just do not
add labels to the tasks, even though that also does not look right.
However technically it should be fine (and #550 needs the labels only
for the build config resources).

Fixes #555.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
