### PR TITLE
Handle trailing slash in URL values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ listed in the changelog.
 
 ## [Unreleased]
 
+### Fixed
+- Trailing slash in service URLs is not handled properly ([#526](https://github.com/opendevstack/ods-pipeline/issues/526))
+
 ## [0.5.1] - 2022-06-10
 
 ### Fixed

--- a/cmd/artifact-download/main.go
+++ b/cmd/artifact-download/main.go
@@ -133,7 +133,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("Could not create Bitbucket client config: %s. Are you logged into the cluster?", err)
 	}
-	bitbucketClient := bitbucket.NewClient(bcc)
+	bitbucketClient, err := bitbucket.NewClient(bcc)
+	if err != nil {
+		log.Fatal("bitbucket client:", err)
+	}
 
 	err = run(logger, opts, nexusClient, nr, bitbucketClient, workingDir)
 	if err != nil {

--- a/cmd/build-push-image/main.go
+++ b/cmd/build-push-image/main.go
@@ -158,11 +158,11 @@ func main() {
 			}
 			fmt.Println(string(stdout))
 
-			aquaScanUrl := fmt.Sprintf(
-				"%s/#/images/%s/%s/vulns",
-				opts.aquaURL, url.QueryEscape(opts.aquaRegistry), url.QueryEscape(aquaImage),
-			)
-			fmt.Printf("Aqua vulnerability report is at %s ...\n", aquaScanUrl)
+			asu, err := aquaScanURL(opts, aquaImage)
+			if err != nil {
+				log.Fatal("aqua scan URL:", err)
+			}
+			fmt.Printf("Aqua vulnerability report is at %s ...\n", asu)
 
 			err = copyAquaReportsToArtifacts(htmlReportFile, jsonReportFile)
 			if err != nil {
@@ -170,7 +170,7 @@ func main() {
 			}
 
 			fmt.Println("Creating Bitbucket code insight report ...")
-			err = createBitbucketInsightReport(opts, aquaScanUrl, scanSuccessful, ctxt)
+			err = createBitbucketInsightReport(opts, asu, scanSuccessful, ctxt)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -418,4 +418,21 @@ func writeImageDigestToResults(imageDigest string) error {
 func aquasecInstalled() bool {
 	_, err := exec.LookPath(aquasecBin)
 	return err == nil
+}
+
+// aquaScanURL returns an URL to the given aquaImage.
+func aquaScanURL(opts options, aquaImage string) (string, error) {
+	aquaURL, err := url.Parse(opts.aquaURL)
+	if err != nil {
+		return "", fmt.Errorf("parse base URL: %w", err)
+	}
+	aquaPath := fmt.Sprintf(
+		"/#/images/%s/%s/vulns",
+		url.QueryEscape(opts.aquaRegistry), url.QueryEscape(aquaImage),
+	)
+	fullURL, err := aquaURL.Parse(aquaPath)
+	if err != nil {
+		return "", fmt.Errorf("parse URL path: %w", err)
+	}
+	return fullURL.String(), nil
 }

--- a/cmd/build-push-image/main.go
+++ b/cmd/build-push-image/main.go
@@ -340,17 +340,20 @@ func createBitbucketInsightReport(opts options, aquaScanUrl string, success bool
 	if opts.debug {
 		logger = &logging.LeveledLogger{Level: logging.LevelDebug}
 	}
-	bitbucketClient := bitbucket.NewClient(&bitbucket.ClientConfig{
+	bitbucketClient, err := bitbucket.NewClient(&bitbucket.ClientConfig{
 		APIToken: opts.bitbucketAccessToken,
 		BaseURL:  opts.bitbucketURL,
 		Logger:   logger,
 	})
+	if err != nil {
+		return fmt.Errorf("bitbucket client: %w", err)
+	}
 	reportKey := "org.opendevstack.aquasec"
 	scanResult := bitbucket.InsightReportFail
 	if success {
 		scanResult = bitbucket.InsightReportPass
 	}
-	_, err := bitbucketClient.InsightReportCreate(
+	_, err = bitbucketClient.InsightReportCreate(
 		ctxt.Project,
 		ctxt.Repository,
 		ctxt.GitCommitSHA,

--- a/cmd/build-push-image/main_test.go
+++ b/cmd/build-push-image/main_test.go
@@ -85,3 +85,29 @@ func TestNexusBuildArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestAquaScanURL(t *testing.T) {
+	tests := map[string]struct {
+		aquaURL string
+	}{
+		"base URL without trailing slash": {
+			aquaURL: "https://console.example.com",
+		},
+		"base URL with trailing slash": {
+			aquaURL: "https://console.example.com/",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			opts := options{aquaURL: tc.aquaURL, aquaRegistry: "ods"}
+			u, err := aquaScanURL(opts, "foo")
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := "https://console.example.com/#/images/ods/foo/vulns"
+			if u != want {
+				t.Fatalf("want: %s, got: %s", want, u)
+			}
+		})
+	}
+}

--- a/cmd/finish/main.go
+++ b/cmd/finish/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/opendevstack/pipeline/internal/kubernetes"
 	"github.com/opendevstack/pipeline/internal/notification"
+	"github.com/opendevstack/pipeline/internal/tekton"
 	"github.com/opendevstack/pipeline/pkg/bitbucket"
 	"github.com/opendevstack/pipeline/pkg/config"
 	"github.com/opendevstack/pipeline/pkg/logging"
@@ -83,17 +84,17 @@ func main() {
 	if err != nil {
 		log.Fatal("bitbucket client:", err)
 	}
-	pipelineRunURL := fmt.Sprintf(
-		"%s/k8s/ns/%s/tekton.dev~v1beta1~PipelineRun/%s/",
-		opts.consoleURL,
-		ctxt.Namespace,
-		opts.pipelineRunName,
-	)
+
+	prURL, err := tekton.PipelineRunURL(opts.consoleURL, ctxt.Namespace, opts.pipelineRunName)
+	if err != nil {
+		log.Fatal("pipeline run URL:", err)
+	}
+
 	err = bitbucketClient.BuildStatusCreate(ctxt.GitCommitSHA, bitbucket.BuildStatusCreatePayload{
 		State:       getBitbucketBuildStatus(opts.aggregateTasksStatus),
 		Key:         ctxt.GitCommitSHA,
 		Name:        ctxt.GitCommitSHA,
-		URL:         pipelineRunURL,
+		URL:         prURL,
 		Description: "ODS Pipeline Build",
 	})
 	if err != nil {

--- a/cmd/finish/main.go
+++ b/cmd/finish/main.go
@@ -75,11 +75,14 @@ func main() {
 	}
 
 	logger.Infof("Setting Bitbucket build status ...")
-	bitbucketClient := bitbucket.NewClient(&bitbucket.ClientConfig{
+	bitbucketClient, err := bitbucket.NewClient(&bitbucket.ClientConfig{
 		APIToken: opts.bitbucketAccessToken,
 		BaseURL:  opts.bitbucketURL,
 		Logger:   logger,
 	})
+	if err != nil {
+		log.Fatal("bitbucket client:", err)
+	}
 	pipelineRunURL := fmt.Sprintf(
 		"%s/k8s/ns/%s/tekton.dev~v1beta1~PipelineRun/%s/",
 		opts.consoleURL,

--- a/cmd/finish/main.go
+++ b/cmd/finish/main.go
@@ -139,7 +139,7 @@ func main() {
 	if notificationClient.ShouldNotify(opts.aggregateTasksStatus) {
 		err = notificationClient.CallWebhook(ctx, notification.PipelineRunResult{
 			PipelineRunName: opts.pipelineRunName,
-			PipelineRunURL:  pipelineRunURL,
+			PipelineRunURL:  prURL,
 			OverallStatus:   opts.aggregateTasksStatus,
 			ODSContext:      ctxt,
 		})

--- a/cmd/pipeline-manager/main.go
+++ b/cmd/pipeline-manager/main.go
@@ -129,6 +129,9 @@ func serve() error {
 		APIToken: token,
 		BaseURL:  strings.TrimSuffix(repoBase, "/scm"),
 	})
+	if err != nil {
+		return fmt.Errorf("bitbucket client: %w", err)
+	}
 
 	// triggeredReposChan is used to communicate repos for which pipelines
 	// have been triggered between receiver and pruner.

--- a/cmd/pipeline-manager/main.go
+++ b/cmd/pipeline-manager/main.go
@@ -125,7 +125,7 @@ func serve() error {
 	}
 
 	// Initialize Bitbucket client.
-	bitbucketClient := bitbucket.NewClient(&bitbucket.ClientConfig{
+	bitbucketClient, err := bitbucket.NewClient(&bitbucket.ClientConfig{
 		APIToken: token,
 		BaseURL:  strings.TrimSuffix(repoBase, "/scm"),
 	})

--- a/cmd/sonar/main.go
+++ b/cmd/sonar/main.go
@@ -57,13 +57,16 @@ func main() {
 		log.Fatal(err)
 	}
 
-	sonarClient := sonar.NewClient(&sonar.ClientConfig{
+	sonarClient, err := sonar.NewClient(&sonar.ClientConfig{
 		APIToken:      opts.sonarAuthToken,
 		BaseURL:       opts.sonarURL,
 		ServerEdition: opts.sonarEdition,
 		Debug:         opts.debug,
 		Logger:        logger,
 	})
+	if err != nil {
+		log.Fatal("sonar client:", err)
+	}
 
 	err = sonarScan(logger, opts, ctxt, sonarClient)
 	if err != nil {

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -463,22 +462,4 @@ func gitLfsEnableAndPullFiles(logger logging.LeveledLoggerInterface, dir string)
 	}
 	logger.Infof(string(stdout))
 	return err
-}
-
-// pipelineRunURL returns an URL to the pipeline run given in opts.
-func pipelineRunURL(ctxt *pipelinectxt.ODSContext, opts options) (string, error) {
-	consoleURL, err := url.Parse(opts.consoleURL)
-	if err != nil {
-		return "", fmt.Errorf("parse base URL: %w", err)
-	}
-	consolePath := fmt.Sprintf(
-		"/k8s/ns/%s/tekton.dev~v1beta1~PipelineRun/%s/",
-		ctxt.Namespace,
-		opts.pipelineRunName,
-	)
-	fullURL, err := consoleURL.Parse(consolePath)
-	if err != nil {
-		return "", fmt.Errorf("parse URL path: %w", err)
-	}
-	return fullURL.String(), nil
 }

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -141,11 +141,14 @@ func main() {
 	logger.Infof("Assembled pipeline context: %+v", ctxt)
 
 	logger.Infof("Setting Bitbucket build status to 'in progress' ...")
-	bitbucketClient := bitbucket.NewClient(&bitbucket.ClientConfig{
+	bitbucketClient, err := bitbucket.NewClient(&bitbucket.ClientConfig{
 		APIToken: opts.bitbucketAccessToken,
 		BaseURL:  opts.bitbucketURL,
 		Logger:   logger,
 	})
+	if err != nil {
+		log.Fatal("bitbucket client:", err)
+	}
 	pipelineRunURL := fmt.Sprintf(
 		"%s/k8s/ns/%s/tekton.dev~v1beta1~PipelineRun/%s/",
 		opts.consoleURL,

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -149,17 +150,17 @@ func main() {
 	if err != nil {
 		log.Fatal("bitbucket client:", err)
 	}
-	pipelineRunURL := fmt.Sprintf(
-		"%s/k8s/ns/%s/tekton.dev~v1beta1~PipelineRun/%s/",
-		opts.consoleURL,
-		ctxt.Namespace,
-		opts.pipelineRunName,
-	)
+
+	prURL, err := pipelineRunURL(ctxt, opts)
+	if err != nil {
+		log.Fatal("pipeline run URL:", err)
+	}
+
 	err = bitbucketClient.BuildStatusCreate(ctxt.GitCommitSHA, bitbucket.BuildStatusCreatePayload{
 		State:       bitbucket.BuildStatusInProgress,
 		Key:         ctxt.GitCommitSHA,
 		Name:        ctxt.GitCommitSHA,
-		URL:         pipelineRunURL,
+		URL:         prURL,
 		Description: "ODS Pipeline Build",
 	})
 	if err != nil {
@@ -461,4 +462,22 @@ func gitLfsEnableAndPullFiles(logger logging.LeveledLoggerInterface, dir string)
 	}
 	logger.Infof(string(stdout))
 	return err
+}
+
+// pipelineRunURL returns an URL to the pipeline run given in opts.
+func pipelineRunURL(ctxt *pipelinectxt.ODSContext, opts options) (string, error) {
+	consoleURL, err := url.Parse(opts.consoleURL)
+	if err != nil {
+		return "", fmt.Errorf("parse base URL: %w", err)
+	}
+	consolePath := fmt.Sprintf(
+		"/k8s/ns/%s/tekton.dev~v1beta1~PipelineRun/%s/",
+		ctxt.Namespace,
+		opts.pipelineRunName,
+	)
+	fullURL, err := consoleURL.Parse(consolePath)
+	if err != nil {
+		return "", fmt.Errorf("parse URL path: %w", err)
+	}
+	return fullURL.String(), nil
 }

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/opendevstack/pipeline/internal/command"
 	"github.com/opendevstack/pipeline/internal/repository"
+	"github.com/opendevstack/pipeline/internal/tekton"
 	"github.com/opendevstack/pipeline/pkg/bitbucket"
 	"github.com/opendevstack/pipeline/pkg/config"
 	"github.com/opendevstack/pipeline/pkg/logging"
@@ -151,7 +152,7 @@ func main() {
 		log.Fatal("bitbucket client:", err)
 	}
 
-	prURL, err := pipelineRunURL(ctxt, opts)
+	prURL, err := tekton.PipelineRunURL(opts.consoleURL, ctxt.Namespace, opts.pipelineRunName)
 	if err != nil {
 		log.Fatal("pipeline run URL:", err)
 	}

--- a/cmd/start/main_test.go
+++ b/cmd/start/main_test.go
@@ -189,33 +189,6 @@ func TestApplyVersionTags(t *testing.T) {
 	}
 }
 
-func TestPipelineRunURL(t *testing.T) {
-	tests := map[string]struct {
-		consoleURL string
-	}{
-		"base URL without trailing slash": {
-			consoleURL: "https://console.example.com",
-		},
-		"base URL with trailing slash": {
-			consoleURL: "https://console.example.com/",
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			ctxt := &pipelinectxt.ODSContext{Namespace: "foo"}
-			opts := options{consoleURL: tc.consoleURL, pipelineRunName: "bar-ab12c"}
-			u, err := pipelineRunURL(ctxt, opts)
-			if err != nil {
-				t.Fatal(err)
-			}
-			want := "https://console.example.com/k8s/ns/foo/tekton.dev~v1beta1~PipelineRun/bar-ab12c/"
-			if u != want {
-				t.Fatalf("want: %s, got: %s", want, u)
-			}
-		})
-	}
-}
-
 func lastTagPayload(t *testing.T, srv *testserver.TestServer) bitbucket.TagCreatePayload {
 	req, err := srv.LastRequest()
 	if err != nil {

--- a/cmd/start/main_test.go
+++ b/cmd/start/main_test.go
@@ -189,6 +189,33 @@ func TestApplyVersionTags(t *testing.T) {
 	}
 }
 
+func TestPipelineRunURL(t *testing.T) {
+	tests := map[string]struct {
+		consoleURL string
+	}{
+		"base URL without trailing slash": {
+			consoleURL: "https://console.example.com",
+		},
+		"base URL with trailing slash": {
+			consoleURL: "https://console.example.com/",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctxt := &pipelinectxt.ODSContext{Namespace: "foo"}
+			opts := options{consoleURL: tc.consoleURL, pipelineRunName: "bar-ab12c"}
+			u, err := pipelineRunURL(ctxt, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := "https://console.example.com/k8s/ns/foo/tekton.dev~v1beta1~PipelineRun/bar-ab12c/"
+			if u != want {
+				t.Fatalf("want: %s, got: %s", want, u)
+			}
+		})
+	}
+}
+
 func lastTagPayload(t *testing.T, srv *testserver.TestServer) bitbucket.TagCreatePayload {
 	req, err := srv.LastRequest()
 	if err != nil {

--- a/cmd/start/main_test.go
+++ b/cmd/start/main_test.go
@@ -23,10 +23,13 @@ func TestApplyVersionTags(t *testing.T) {
 	}
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	bitbucketClient := bitbucket.NewClient(&bitbucket.ClientConfig{
+	bitbucketClient, err := bitbucket.NewClient(&bitbucket.ClientConfig{
 		APIToken: "s3cr3t", // does not matter
 		BaseURL:  srv.Server.URL,
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	tests := map[string]struct {
 		env             *config.Environment

--- a/deploy/ods-pipeline/charts/setup/templates/configmap-aqua.yaml
+++ b/deploy/ods-pipeline/charts/setup/templates/configmap-aqua.yaml
@@ -5,5 +5,5 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4}}
 data:
-  url: '{{.Values.aquaUrl}}'
+  url: '{{.Values.aquaUrl | trimSuffix "/"}}'
   registry: '{{.Values.aquaRegistry}}'

--- a/deploy/ods-pipeline/charts/setup/templates/configmap-bitbucket.yaml
+++ b/deploy/ods-pipeline/charts/setup/templates/configmap-bitbucket.yaml
@@ -5,5 +5,5 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4}}
 data:
-  url: '{{.Values.bitbucketUrl}}'
-  repoBase: '{{.Values.bitbucketUrl}}/scm'
+  url: '{{.Values.bitbucketUrl | trimSuffix "/"}}'
+  repoBase: '{{.Values.bitbucketUrl | trimSuffix "/"}}/scm'

--- a/deploy/ods-pipeline/charts/setup/templates/configmap-cluster.yaml
+++ b/deploy/ods-pipeline/charts/setup/templates/configmap-cluster.yaml
@@ -5,4 +5,4 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4}}
 data:
-  consoleUrl: '{{.Values.consoleUrl}}'
+  consoleUrl: '{{.Values.consoleUrl | trimSuffix "/"}}'

--- a/deploy/ods-pipeline/charts/setup/templates/configmap-nexus.yaml
+++ b/deploy/ods-pipeline/charts/setup/templates/configmap-nexus.yaml
@@ -5,6 +5,6 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4}}
 data:
-  url: '{{.Values.nexusUrl}}'
+  url: '{{.Values.nexusUrl | trimSuffix "/"}}'
   temporaryRepository: '{{.Values.nexusTemporaryRepository}}'
   permanentRepository: '{{.Values.nexusPermanentRepository}}'

--- a/deploy/ods-pipeline/charts/setup/templates/configmap-sonar.yaml
+++ b/deploy/ods-pipeline/charts/setup/templates/configmap-sonar.yaml
@@ -5,5 +5,5 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4}}
 data:
-  url: '{{.Values.sonarUrl}}'
+  url: '{{.Values.sonarUrl | trimSuffix "/"}}'
   edition: '{{.Values.sonarEdition | default "community" }}'

--- a/deploy/ods-pipeline/charts/setup/templates/secret-bitbucket-auth.yaml
+++ b/deploy/ods-pipeline/charts/setup/templates/secret-bitbucket-auth.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4}}
   annotations:
-    tekton.dev/git-0: '{{.Values.bitbucketUrl}}'
+    tekton.dev/git-0: '{{.Values.bitbucketUrl | trimSuffix "/"}}'
 stringData:
   password: '{{.Values.bitbucketAccessToken}}'
   username: '{{.Values.bitbucketUsername}}'

--- a/deploy/ods-pipeline/values.yaml
+++ b/deploy/ods-pipeline/values.yaml
@@ -51,13 +51,15 @@ setup:
   debug: 'false'
 
   # Bitbucket
-  # Bitbucket URL (including scheme). Example: https://bitbucket.example.com.
+  # Bitbucket URL (including scheme, without trailing slash).
+  # Example: https://bitbucket.example.com.
   bitbucketUrl: ''
   # Bitbucket username. Example: cd_user.
   bitbucketUsername: ''
 
   # Nexus
-  # Nexus URL (including scheme). Example: https://nexus.example.com.
+  # Nexus URL (including scheme, without trailing slash).
+  # Example: https://nexus.example.com.
   nexusUrl: ''
   # Nexus username. Example: developer.
   nexusUsername: ''
@@ -67,13 +69,15 @@ setup:
   nexusPermanentRepository: 'ods-permanent-artifacts'
 
   # Sonar
-  # SonarQube URL (including scheme). Example: https://sonarqube.example.com.
+  # SonarQube URL (including scheme, without trailing slash).
+  # Example: https://sonarqube.example.com.
   sonarUrl: ''
   # SonarQube edition. Valid options: 'community', 'developer', 'enterprise' or 'datacenter'
   sonarEdition: 'community'
 
   # Aqua
-  # Aqua URL (including scheme). Example: https://aqua.example.com.
+  # Aqua URL (including scheme, without trailing slash).
+  # Example: https://aqua.example.com.
   # Leave empty when not using Aqua.
   aquaUrl: ''
   # Aqua registry name.
@@ -84,7 +88,7 @@ setup:
   aquaUsername: ''
 
   # Cluster
-  # URL (including scheme) of the OpenShift Web Console.
+  # URL (including scheme, without trailing slash) of the OpenShift Web Console.
   consoleUrl: 'http://example.com'
 
   # Notification Webhook

--- a/internal/tekton/pipelinerun.go
+++ b/internal/tekton/pipelinerun.go
@@ -2,6 +2,8 @@ package tekton
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 
 	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,4 +40,22 @@ func (c *Client) UpdatePipelineRun(ctxt context.Context, pipelineRun *tekton.Pip
 func (c *Client) DeletePipelineRun(ctxt context.Context, name string, options metav1.DeleteOptions) error {
 	c.logger().Debugf("Delete pipeline run %s", name)
 	return c.pipelineRunsClient().Delete(ctxt, name, options)
+}
+
+// PipelineRunURL returns an URL to the pipeline run given in opts.
+func PipelineRunURL(consoleURL, namespace, name string) (string, error) {
+	cURL, err := url.Parse(consoleURL)
+	if err != nil {
+		return "", fmt.Errorf("parse base URL: %w", err)
+	}
+	cPath := fmt.Sprintf(
+		"/k8s/ns/%s/tekton.dev~v1beta1~PipelineRun/%s/",
+		namespace,
+		name,
+	)
+	fullURL, err := cURL.Parse(cPath)
+	if err != nil {
+		return "", fmt.Errorf("parse URL path: %w", err)
+	}
+	return fullURL.String(), nil
 }

--- a/internal/tekton/pipelinerun_test.go
+++ b/internal/tekton/pipelinerun_test.go
@@ -1,0 +1,28 @@
+package tekton
+
+import "testing"
+
+func TestPipelineRunURL(t *testing.T) {
+	tests := map[string]struct {
+		consoleURL string
+	}{
+		"base URL without trailing slash": {
+			consoleURL: "https://console.example.com",
+		},
+		"base URL with trailing slash": {
+			consoleURL: "https://console.example.com/",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			u, err := PipelineRunURL(tc.consoleURL, "foo", "bar-ab12c")
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := "https://console.example.com/k8s/ns/foo/tekton.dev~v1beta1~PipelineRun/bar-ab12c/"
+			if u != want {
+				t.Fatalf("want: %s, got: %s", want, u)
+			}
+		})
+	}
+}

--- a/pkg/bitbucket/branches_test.go
+++ b/pkg/bitbucket/branches_test.go
@@ -10,7 +10,7 @@ import (
 func TestBranchList(t *testing.T) {
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	bitbucketClient := testClient(srv.Server.URL)
+	bitbucketClient := testClient(t, srv.Server.URL)
 
 	srv.EnqueueResponse(
 		t, "/rest/api/1.0/projects/myproject/repos/my-repo/branches",

--- a/pkg/bitbucket/build_status_test.go
+++ b/pkg/bitbucket/build_status_test.go
@@ -12,7 +12,7 @@ func TestBuildStatusCreate(t *testing.T) {
 
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	bitbucketClient := testClient(srv.Server.URL)
+	bitbucketClient := testClient(t, srv.Server.URL)
 
 	payload := BuildStatusCreatePayload{
 		State:       "INPROGRESS",
@@ -47,7 +47,7 @@ func TestBuildStatusList(t *testing.T) {
 
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	bitbucketClient := testClient(srv.Server.URL)
+	bitbucketClient := testClient(t, srv.Server.URL)
 
 	srv.EnqueueResponse(
 		t, "/rest/build-status/1.0/commits/"+sha,

--- a/pkg/bitbucket/client_test.go
+++ b/pkg/bitbucket/client_test.go
@@ -1,8 +1,52 @@
 package bitbucket
 
-func testClient(serverURL string) *Client {
-	return NewClient(&ClientConfig{
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func testClient(t *testing.T, serverURL string) *Client {
+	c, err := NewClient(&ClientConfig{
 		APIToken: "s3cr3t", // does not matter
 		BaseURL:  serverURL,
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func TestGetRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, r.URL.Path)
+	}))
+	defer srv.Close()
+	tests := map[string]struct {
+		baseURL string
+	}{
+		"base URL without trailing slash": {
+			baseURL: srv.URL,
+		},
+		"base URL with trailing slash": {
+			baseURL: srv.URL + "/",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			bitbucketClient := testClient(t, tc.baseURL)
+			requestPath := "/foo"
+			code, out, err := bitbucketClient.get(requestPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if code != 200 {
+				t.Fatal("expected 200")
+			}
+			if string(out) != requestPath {
+				t.Fatalf("expected %s, got: %s", requestPath, string(out))
+			}
+		})
+	}
 }

--- a/pkg/bitbucket/code_insights_test.go
+++ b/pkg/bitbucket/code_insights_test.go
@@ -15,7 +15,7 @@ func TestInsightReportCreate(t *testing.T) {
 
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	bitbucketClient := testClient(srv.Server.URL)
+	bitbucketClient := testClient(t, srv.Server.URL)
 
 	srv.EnqueueResponse(
 		t, "/rest/insights/1.0/projects/PRJ/repos/my-repo/commits/"+sha+"/reports/report.key",

--- a/pkg/bitbucket/commits_test.go
+++ b/pkg/bitbucket/commits_test.go
@@ -11,7 +11,7 @@ func TestCommitGet(t *testing.T) {
 
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	bitbucketClient := testClient(srv.Server.URL)
+	bitbucketClient := testClient(t, srv.Server.URL)
 
 	srv.EnqueueResponse(
 		t, "/rest/api/1.0/projects/myproject/repos/my-repo/commits/"+sha,
@@ -30,7 +30,7 @@ func TestCommitGet(t *testing.T) {
 func TestCommitList(t *testing.T) {
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	bitbucketClient := testClient(srv.Server.URL)
+	bitbucketClient := testClient(t, srv.Server.URL)
 
 	srv.EnqueueResponse(
 		t, "/rest/api/1.0/projects/myproject/repos/my-repo/commits",
@@ -51,7 +51,7 @@ func TestCommitPullRequestList(t *testing.T) {
 
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	bitbucketClient := testClient(srv.Server.URL)
+	bitbucketClient := testClient(t, srv.Server.URL)
 
 	srv.EnqueueResponse(
 		t, "/rest/api/1.0/projects/myproject/repos/my-repo/commits/"+sha+"/pull-requests",

--- a/pkg/bitbucket/projects_test.go
+++ b/pkg/bitbucket/projects_test.go
@@ -9,7 +9,7 @@ import (
 func TestProjectCreate(t *testing.T) {
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	bitbucketClient := testClient(srv.Server.URL)
+	bitbucketClient := testClient(t, srv.Server.URL)
 
 	srv.EnqueueResponse(
 		t, "/rest/api/1.0/projects",

--- a/pkg/bitbucket/raw_test.go
+++ b/pkg/bitbucket/raw_test.go
@@ -12,7 +12,7 @@ func TestRawGet(t *testing.T) {
 
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	bitbucketClient := testClient(srv.Server.URL)
+	bitbucketClient := testClient(t, srv.Server.URL)
 
 	tests := map[string]struct {
 		EnqueuedPath       string

--- a/pkg/bitbucket/repos_test.go
+++ b/pkg/bitbucket/repos_test.go
@@ -9,7 +9,7 @@ import (
 func TestRepoCreate(t *testing.T) {
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	bitbucketClient := testClient(srv.Server.URL)
+	bitbucketClient := testClient(t, srv.Server.URL)
 
 	srv.EnqueueResponse(
 		t, "/rest/api/1.0/projects/PRJ/repos",
@@ -30,7 +30,7 @@ func TestRepoCreate(t *testing.T) {
 func TestRepoList(t *testing.T) {
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	bitbucketClient := testClient(srv.Server.URL)
+	bitbucketClient := testClient(t, srv.Server.URL)
 
 	srv.EnqueueResponse(
 		t, "/rest/api/1.0/projects/PRJ/repos",

--- a/pkg/bitbucket/tags_test.go
+++ b/pkg/bitbucket/tags_test.go
@@ -9,7 +9,7 @@ import (
 func TestTagCreate(t *testing.T) {
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	bitbucketClient := testClient(srv.Server.URL)
+	bitbucketClient := testClient(t, srv.Server.URL)
 
 	srv.EnqueueResponse(
 		t, "/rest/api/1.0/projects/PRJ/repos/my-repo/tags",
@@ -30,7 +30,7 @@ func TestTagCreate(t *testing.T) {
 func TestTagList(t *testing.T) {
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	bitbucketClient := testClient(srv.Server.URL)
+	bitbucketClient := testClient(t, srv.Server.URL)
 
 	srv.EnqueueResponse(
 		t, "/rest/api/1.0/projects/myproject/repos/my-repo/tags",
@@ -49,7 +49,7 @@ func TestTagList(t *testing.T) {
 func TestTagGet(t *testing.T) {
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	bitbucketClient := testClient(srv.Server.URL)
+	bitbucketClient := testClient(t, srv.Server.URL)
 
 	srv.EnqueueResponse(
 		t, "/rest/api/1.0/projects/myproject/repos/my-repo/tags/release-2.0.0",

--- a/pkg/bitbucket/webhooks_test.go
+++ b/pkg/bitbucket/webhooks_test.go
@@ -9,7 +9,7 @@ import (
 func TestWebhookCreate(t *testing.T) {
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	bitbucketClient := testClient(srv.Server.URL)
+	bitbucketClient := testClient(t, srv.Server.URL)
 
 	srv.EnqueueResponse(
 		t, "/rest/api/1.0/projects/PRJ/repos/my-repo/webhooks",

--- a/pkg/sonar/client_test.go
+++ b/pkg/sonar/client_test.go
@@ -1,5 +1,49 @@
 package sonar
 
-func testClient(baseURL string) *Client {
-	return NewClient(&ClientConfig{BaseURL: baseURL})
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func testClient(t *testing.T, baseURL string) *Client {
+	c, err := NewClient(&ClientConfig{BaseURL: baseURL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func TestGetRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, r.URL.Path)
+	}))
+	defer srv.Close()
+	tests := map[string]struct {
+		baseURL string
+	}{
+		"base URL without trailing slash": {
+			baseURL: srv.URL,
+		},
+		"base URL with trailing slash": {
+			baseURL: srv.URL + "/",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			bitbucketClient := testClient(t, tc.baseURL)
+			requestPath := "/foo"
+			code, out, err := bitbucketClient.get(requestPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if code != 200 {
+				t.Fatal("expected 200")
+			}
+			if string(out) != requestPath {
+				t.Fatalf("expected %s, got: %s", requestPath, string(out))
+			}
+		})
+	}
 }

--- a/pkg/sonar/compute_engine_test.go
+++ b/pkg/sonar/compute_engine_test.go
@@ -10,7 +10,7 @@ func TestComputeEngineTaskGet(t *testing.T) {
 
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	c := testClient(srv.Server.URL)
+	c := testClient(t, srv.Server.URL)
 
 	tests := map[string]struct {
 		Fixture    string

--- a/pkg/sonar/quality_gate_test.go
+++ b/pkg/sonar/quality_gate_test.go
@@ -10,7 +10,7 @@ func TestQualityGateGet(t *testing.T) {
 
 	srv, cleanup := testserver.NewTestServer(t)
 	defer cleanup()
-	c := testClient(srv.Server.URL)
+	c := testClient(t, srv.Server.URL)
 
 	tests := map[string]struct {
 		Fixture    string

--- a/pkg/sonar/scan_test.go
+++ b/pkg/sonar/scan_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestExtractComputeEngineTaskID(t *testing.T) {
 
-	c := testClient("")
+	c := testClient(t, "")
 	want := "AVAn5RKqYwETbXvgas-I"
 	fixture := filepath.Join(projectpath.Root, "test/testdata/fixtures/sonar", ReportTaskFilename)
 	got, err := c.ExtractComputeEngineTaskID(fixture)

--- a/pkg/tasktesting/bitbucket.go
+++ b/pkg/tasktesting/bitbucket.go
@@ -24,5 +24,9 @@ func BitbucketClientOrFatal(t *testing.T, c *kclient.Clientset, namespace string
 		t.Fatalf("could not create Bitbucket client config: %s", err)
 	}
 	bcc.BaseURL = strings.Replace(bcc.BaseURL, BitbucketKinDHost, "localhost", 1)
-	return bitbucket.NewClient(bcc)
+	bc, err := bitbucket.NewClient(bcc)
+	if err != nil {
+		t.Fatalf("bitbucket client: %s", err)
+	}
+	return bc
 }

--- a/test/tasks/common_test.go
+++ b/test/tasks/common_test.go
@@ -171,11 +171,14 @@ func checkSonarQualityGate(t *testing.T, c *kclient.Clientset, namespace, sonarP
 		t.Fatalf("could not get SonarQube token: %s", err)
 	}
 
-	sonarClient := sonar.NewClient(&sonar.ClientConfig{
+	sonarClient, err := sonar.NewClient(&sonar.ClientConfig{
 		APIToken:      sonarToken,
 		BaseURL:       "http://localhost:9000", // use localhost instead of ods-test-sonarqube.kind!
 		ServerEdition: "community",
 	})
+	if err != nil {
+		t.Fatalf("sonar client: %s", err)
+	}
 
 	if qualityGateFlag {
 		qualityGateResult, err := sonarClient.QualityGateGet(


### PR DESCRIPTION
Closes #526.

Addresses the issue on multiple levels:
* comment in Helm template to explain which value is expected
* trim trailing slash in Helm template for consistency
* handle values with trailing slash in Go code when concatenating URL parts

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
