### PR TITLE
 Add timestamp and tag to log messages in pipeline manager deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ listed in the changelog.
 
 ## [Unreleased]
 
+### Changed
+
+- Add timestamp and tag to log messages in pipeline manager deployment ([#554](https://github.com/opendevstack/ods-pipeline/issues/554))
+
 ### Fixed
 - Trailing slash in service URLs is not handled properly ([#526](https://github.com/opendevstack/ods-pipeline/issues/526))
 

--- a/cmd/pipeline-manager/main.go
+++ b/cmd/pipeline-manager/main.go
@@ -57,9 +57,9 @@ func main() {
 func serve() error {
 	var logger logging.LeveledLoggerInterface
 	if os.Getenv("DEBUG") == "true" {
-		logger = &logging.LeveledLogger{Level: logging.LevelDebug}
+		logger = &logging.LeveledLogger{Timestamp: true, Level: logging.LevelDebug}
 	} else {
-		logger = &logging.LeveledLogger{Level: logging.LevelInfo}
+		logger = &logging.LeveledLogger{Timestamp: true, Level: logging.LevelInfo}
 	}
 	logger.Infof("Booting ...")
 
@@ -152,7 +152,7 @@ func serve() error {
 		PendingRunRepos:    pendingRunReposChan,
 		TektonClient:       tClient,
 		KubernetesClient:   kClient,
-		Logger:             logger,
+		Logger:             logger.WithTag("scheduler"),
 		TaskKind:           tekton.TaskKind(taskKind),
 		TaskSuffix:         taskSuffix,
 		StorageConfig: manager.StorageConfig{
@@ -166,7 +166,7 @@ func serve() error {
 	p := &manager.Pruner{
 		TriggeredRepos: triggeredReposChan,
 		TektonClient:   tClient,
-		Logger:         logger,
+		Logger:         logger.WithTag("pruner"),
 		MinKeepHours:   pruneMinKeepHours,
 		MaxKeepRuns:    pruneMaxKeepRuns,
 	}
@@ -176,7 +176,7 @@ func serve() error {
 		PendingRunRepos: pendingRunReposChan,
 		Queues:          map[string]bool{},
 		TektonClient:    tClient,
-		Logger:          logger,
+		Logger:          logger.WithTag("watcher"),
 	}
 	go w.Run(ctx)
 	// As there is no persistent state, check for queued pipeline runs for all
@@ -193,7 +193,7 @@ func serve() error {
 
 	r := &manager.BitbucketWebhookReceiver{
 		TriggeredPipelines: triggeredPipelinesChan,
-		Logger:             logger,
+		Logger:             logger.WithTag("receiver"),
 		BitbucketClient:    bitbucketClient,
 		WebhookSecret:      webhookSecret,
 		Namespace:          namespace,

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -1,0 +1,97 @@
+package logging
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+// fixedClock is frozen in time.
+type fixedClock struct{}
+
+// Now always returns the same time.
+func (fixedClock) Now() time.Time {
+	const longForm = "Jan 2, 2006 at 3:04pm (MST)"
+	t, _ := time.Parse(longForm, "Feb 3, 2013 at 7:54pm (PST)")
+	return t
+}
+
+func TestLogger(t *testing.T) {
+	var logger LeveledLoggerInterface
+	tests := map[string]struct {
+		timestamp bool
+		tag       string
+		level     Level
+		want      string
+	}{
+		"without time": {
+			level: LevelDebug,
+			want:  "INFO  | bar",
+		},
+		"with time": {
+			timestamp: true,
+			level:     LevelInfo,
+			want:      "2013-02-03T19:54:00Z | INFO  | bar",
+		},
+		"higher level": {
+			level: LevelError,
+			want:  "",
+		},
+		"with tag": {
+			tag:   "foo",
+			level: LevelInfo,
+			want:  "INFO  | foo: bar",
+		},
+		"with time and tag": {
+			timestamp: true,
+			tag:       "foo",
+			level:     LevelInfo,
+			want:      "2013-02-03T19:54:00Z | INFO  | foo: bar",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := bytes.NewBuffer([]byte{})
+			logger = &LeveledLogger{
+				StdoutOverride: b,
+				Tag:            tc.tag,
+				Timestamp:      tc.timestamp,
+				ClockOverride:  fixedClock{},
+				Level:          tc.level,
+			}
+			want := tc.want
+			if tc.want != "" {
+				want = want + "\n"
+			}
+			logger.Infof("bar")
+			got := b.String()
+			if got != want {
+				t.Fatalf("want: %s, got: %s", want, got)
+			}
+		})
+	}
+}
+
+func TestWithTag(t *testing.T) {
+	var logger LeveledLoggerInterface
+	stdout := bytes.NewBuffer([]byte("stdout\n"))
+	stderr := bytes.NewBuffer([]byte("stderr\n"))
+	logger = &LeveledLogger{
+		StdoutOverride: stdout,
+		StderrOverride: stderr,
+		Tag:            "initial",
+		Timestamp:      true,
+		ClockOverride:  fixedClock{},
+		Level:          LevelDebug,
+	}
+	taggedLogger := logger.WithTag("tagged")
+	taggedLogger.Errorf("oops")
+	wantStdout := "stdout\n"
+	if stdout.String() != wantStdout {
+		t.Fatalf("wamt %s, got: %s", wantStdout, stdout.String())
+	}
+	wantStderr := "stderr\n2013-02-03T19:54:00Z | ERROR | tagged: oops\n"
+	if stderr.String() != wantStderr {
+		t.Fatalf("wamt %s, got: %s", wantStderr, stderr.String())
+	}
+}


### PR DESCRIPTION
Thought about adding a logging library instead, but it looks like the popular ones all have speed as their major concern and come with quite a few other dependencies. Since we do not care that much about speed here, and rather want a simple way to use the logger, I added the extra functionality to the existing logging.

Closes #554.

Logs now look like this:
```
2022-06-17T08:27:09Z | INFO  | Booting ...
2022-06-17T08:27:09Z | INFO  | Ready to accept requests!
2022-06-17T08:27:09Z | DEBUG | pruner: Prune settings: MinKeepHours=48 MaxKeepRuns=20
2022-06-17T08:27:50Z | DEBUG | watcher: Advancing pipeline run queue for queue 'foo-app' ...
2022-06-17T08:27:50Z | DEBUG | watcher: Found 0 pipeline runs related to repository foo-app.
```

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
