### PR TITLE
Massage confusing Helm diff output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ listed in the changelog.
 
 ### Fixed
 - Trailing slash in service URLs is not handled properly ([#526](https://github.com/opendevstack/ods-pipeline/issues/526))
+- Helm diff result log filtering does not work anymore ([#563](https://github.com/opendevstack/ods-pipeline/issues/563))
 
 ## [0.5.1] - 2022-06-10
 

--- a/cmd/deploy-with-helm/main.go
+++ b/cmd/deploy-with-helm/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
@@ -35,21 +34,6 @@ const (
 	// required by helm secrets plugin.
 	ageKeyFilePath = "./key.txt"
 )
-
-// confusingHelmDiffMessage is the message Helm prints when helm-diff is
-// configured to exit with a non-zero exit code when drift is detected,
-// provided helm-secrets is also installed but no secrets are decrypted.
-const confusingHelmDiffMessage = `Error: identified at least one change, exiting with non-zero exit code (detailed-exitcode parameter enabled)
-Error: plugin "diff" exited with error
-Error: plugin "secrets" exited with error`
-
-// confusingHelmDiffDecryptionMessage is like confusingHelmDiffMessage but occurs
-// when helm-secrets is required to decrypt secrets to perform the diff.
-const confusingHelmDiffDecryptionMessage = `Error: identified at least one change, exiting with non-zero exit code (detailed-exitcode parameter enabled)
-Error: plugin "diff" exited with error
-
-/usr/local/helm/plugins/helm-secrets/scripts/commands/helm.sh: line 34: xargs: command not found
-Error: plugin "secrets" exited with error`
 
 type options struct {
 	// Location of Helm chart directory.
@@ -395,7 +379,7 @@ func main() {
 	}
 	// Replace confusing stderr messages while still printing stderr in general
 	// to surface any other issues that might be logged there.
-	diffStderr := replaceConfusingHelmLogMessages(stderr)
+	diffStderr := cleanHelmDiffOutput(stderr)
 	fmt.Println(string(stdout))
 	fmt.Println(string(diffStderr))
 	err = writeDeploymentArtifact(stdout, "diff", opts.chartDir, targetConfig.Name)
@@ -455,25 +439,6 @@ func getChartVersion(contextVersion string, hc *helmChart) string {
 		return contextVersion
 	}
 	return hc.Version
-}
-
-// replaceConfusingHelmLogMessages replaces confusing stderr messages with
-// easier to understand ones. The tests in ods-deploy-helm_test.go ensure this
-// still works when Helm is upgraded.
-func replaceConfusingHelmLogMessages(logs []byte) []byte {
-	cleaned := bytes.Replace(
-		logs,
-		[]byte(confusingHelmDiffMessage),
-		[]byte("plugin \"diff\" identified at least one change"),
-		1,
-	)
-	cleaned = bytes.Replace(
-		cleaned,
-		[]byte(confusingHelmDiffDecryptionMessage),
-		[]byte("plugin \"diff\" identified at least one change"),
-		1,
-	)
-	return cleaned
 }
 
 func artifactFilename(filename, chartDir, targetEnv string) string {

--- a/cmd/deploy-with-helm/output.go
+++ b/cmd/deploy-with-helm/output.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"bytes"
+	"regexp"
+)
+
+const helmDiffDetectedMarker = `Error: identified at least one change, exiting with non-zero exit code (detailed-exitcode parameter enabled)`
+const desiredDiffMessage = `plugin "diff" identified at least one change`
+
+// cleanHelmDiffOutput removes error messages from the given Helm output.
+// Those error messages are confusing, because they do not come from  an actual
+// error, but from detecting drift between desired and current Helm state.
+func cleanHelmDiffOutput(out []byte) []byte {
+	if !bytes.Contains(out, []byte(helmDiffDetectedMarker)) {
+		return out
+	}
+	cleanedOut := bytes.Replace(
+		out, []byte(helmDiffDetectedMarker), []byte(desiredDiffMessage), -1,
+	)
+	r := regexp.MustCompile(`Error: plugin "(diff|secrets)" exited with error[\n]?`)
+	cleanedOut = r.ReplaceAll(cleanedOut, []byte{})
+	r = regexp.MustCompile(`helm.go:81: \[debug\] plugin "(diff|secrets)" exited with error[\n]?`)
+	cleanedOut = r.ReplaceAll(cleanedOut, []byte{})
+	return cleanedOut
+}

--- a/cmd/deploy-with-helm/output_test.go
+++ b/cmd/deploy-with-helm/output_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCleanHelmDiffOutput(t *testing.T) {
+	tests := map[string]struct {
+		example string
+		want    string
+	}{
+		"diff detected drift": {
+			example: `Error: identified at least one change, exiting with non-zero exit code (detailed-exitcode parameter enabled)
+Error: plugin "diff" exited with error
+
+[helm-secrets] Removed: ./chart/secrets.dev.yaml.dec
+Error: plugin "secrets" exited with error`,
+			want: `plugin "diff" identified at least one change
+
+[helm-secrets] Removed: ./chart/secrets.dev.yaml.dec
+`,
+		},
+		"diff detected drift with debug turned on": {
+			example: `Error: identified at least one change, exiting with non-zero exit code (detailed-exitcode parameter enabled)
+Error: plugin "diff" exited with error
+helm.go:81: [debug] plugin "diff" exited with error
+
+[helm-secrets] Removed: ./chart/secrets.dev.yaml.dec
+Error: plugin "secrets" exited with error
+helm.go:81: [debug] plugin "secrets" exited with error`,
+			want: `plugin "diff" identified at least one change
+
+[helm-secrets] Removed: ./chart/secrets.dev.yaml.dec
+`,
+		},
+		"diff encounters an error": {
+			example: `Error: This command needs 2 arguments: release name, chart path
+
+Use "diff [command] --help" for more information about a command.
+
+Error: plugin "diff" exited with error`,
+			want: `Error: This command needs 2 arguments: release name, chart path
+
+Use "diff [command] --help" for more information about a command.
+
+Error: plugin "diff" exited with error`,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := cleanHelmDiffOutput([]byte(tc.example))
+			if diff := cmp.Diff(tc.want, string(got)); diff != "" {
+				t.Fatalf("output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/test/tasks/ods-deploy-helm_test.go
+++ b/test/tasks/ods-deploy-helm_test.go
@@ -95,7 +95,7 @@ func TestTaskODSDeployHelm(t *testing.T) {
 					}
 
 					// Verify log output massaging
-					doNotWantLogMsg := "/usr/local/helm/plugins/helm-secrets/scripts/commands/helm.sh: line 34: xargs: command not found"
+					doNotWantLogMsg := "plugin \"diff\" exited with error"
 					if strings.Contains(string(ctxt.CollectedLogs), doNotWantLogMsg) {
 						t.Fatalf("Do not want:\n%s\n\nGot:\n%s", doNotWantLogMsg, string(ctxt.CollectedLogs))
 					}


### PR DESCRIPTION
Originally implemented in #268, however the test wasn't bullet-proof, so
it did not fail when #469 was merged. Since then, the log output
replacement didn't work. Further, the detection did not work when debug
mode was enabled as that produced more output than expected.

The new approach first detects if there is a diff, then tries to remove
all offending output.

Closes #563.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
