### PR TITLE
Build arm64 images on M1

### DIFF
--- a/scripts/bitbucket/.gitignore
+++ b/scripts/bitbucket/.gitignore
@@ -1,0 +1,1 @@
+docker-atlassian-bitbucket-server/

--- a/scripts/run-bitbucket.sh
+++ b/scripts/run-bitbucket.sh
@@ -11,7 +11,6 @@ BITBUCKET_SERVER_HOST_PORT="7990"
 BITBUCKET_SERVER_CONTAINER_NAME="ods-test-bitbucket-server"
 BITBUCKET_SERVER_IMAGE_NAME="atlassian/bitbucket"
 BITBUCKET_SERVER_IMAGE_TAG="7.6.5"
-BITBUCKET_POSTGRES_HOST_PORT="5432"
 BITBUCKET_POSTGRES_CONTAINER_NAME="ods-test-bitbucket-postgres"
 BITBUCKET_POSTGRES_IMAGE_TAG="12"
 HELM_VALUES_FILE="${ODS_PIPELINE_DIR}/deploy/ods-pipeline/values.generated.yaml"
@@ -29,11 +28,29 @@ docker rm -f ${BITBUCKET_POSTGRES_CONTAINER_NAME} || true
 docker run  --name ${BITBUCKET_POSTGRES_CONTAINER_NAME} \
   -v "${ODS_PIPELINE_DIR}"/test/testdata/bitbucket-sql:/docker-entrypoint-initdb.d \
   -e POSTGRES_PASSWORD=jellyfish -e POSTGRES_USER=bitbucketuser -e POSTGRES_DB=bitbucket \
-  -d --net kind -p "${BITBUCKET_POSTGRES_HOST_PORT}:5432" \
+  -d --net kind \
   postgres:${BITBUCKET_POSTGRES_IMAGE_TAG}
 
 echo "Run Bitbucket Server pointing to Postgres"
 docker rm -f ${BITBUCKET_SERVER_CONTAINER_NAME} || true
+
+cd "${SCRIPT_DIR}"/bitbucket
+
+if [ "$(uname -m)" = "arm64" ]; then
+  BITBUCKET_SERVER_ARM_IMAGE_NAME="ods-test-bitbucket-arm"
+  if [ "$(docker images -q ${BITBUCKET_SERVER_ARM_IMAGE_NAME}:${BITBUCKET_SERVER_IMAGE_TAG} 2> /dev/null)" == "" ]; then
+    echo "Building Bitbucket Server arm64 image ..."
+    rm -rf docker-atlassian-bitbucket-server || true
+    git clone --recurse-submodules https://bitbucket.org/atlassian-docker/docker-atlassian-bitbucket-server.git
+    cd docker-atlassian-bitbucket-server
+    git checkout 0e57b62 # Last known working Git commit (no branches / tags available)
+    docker build -t ${BITBUCKET_SERVER_ARM_IMAGE_NAME}:${BITBUCKET_SERVER_IMAGE_TAG} --build-arg BITBUCKET_VERSION=${BITBUCKET_SERVER_IMAGE_TAG} .
+  else
+    echo "Using existing ${BITBUCKET_SERVER_ARM_IMAGE_NAME}:${BITBUCKET_SERVER_IMAGE_TAG} image"
+  fi
+  BITBUCKET_SERVER_IMAGE_NAME="${BITBUCKET_SERVER_ARM_IMAGE_NAME}"
+fi
+
 docker run --name ${BITBUCKET_SERVER_CONTAINER_NAME} \
   -e JDBC_DRIVER=org.postgresql.Driver \
   -e JDBC_USER=bitbucketuser \

--- a/scripts/sonarqube/.gitignore
+++ b/scripts/sonarqube/.gitignore
@@ -1,0 +1,1 @@
+docker-sonarqube/

--- a/scripts/sonarqube/Dockerfile
+++ b/scripts/sonarqube/Dockerfile
@@ -1,3 +1,8 @@
-FROM sonarqube:8.4-community
+ARG from=""
+FROM $from
 
 RUN echo "sonar.forceAuthentication=true" >> conf/sonar.properties
+
+# Uncomment the following line to see debug output, e.g. in case SonarQube is
+# not starting up properly.
+# RUN echo "sonar.log.level=DEBUG" >> conf/sonar.properties


### PR DESCRIPTION
There are no official images for Bitbucket and SonarQube, however
building the official Dockerfiles on an M1 seems to work just fine.

Closes #363.
Closes #361.

Note that the Bitbucket repository does not offer any branches / tags we
could consume. SonarQube does, but for some reason the latest release
(9.5) has no corresponding tag.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
