### PR TITLE
Handle diff error and diff detection separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ listed in the changelog.
 ### Fixed
 - Trailing slash in service URLs is not handled properly ([#526](https://github.com/opendevstack/ods-pipeline/issues/526))
 - Helm diff result log filtering does not work anymore ([#563](https://github.com/opendevstack/ods-pipeline/issues/563))
+- Handle diff error and diff detection separately ([#584](https://github.com/opendevstack/ods-pipeline/issues/584))
 
 ## [0.5.1] - 2022-06-10
 

--- a/cmd/deploy-with-helm/helm.go
+++ b/cmd/deploy-with-helm/helm.go
@@ -22,6 +22,9 @@ const helmDiffDetectedMarker = `Error: identified at least one change, exiting w
 // desiredDiffMessage is the message that should be presented to the user.
 const desiredDiffMessage = `plugin "diff" identified at least one change`
 
+// exit code returned from helm-diff when diff is detected.
+const diffExitCode = 2
+
 type helmChart struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`

--- a/test/tasks/ods-deploy-helm_test.go
+++ b/test/tasks/ods-deploy-helm_test.go
@@ -142,6 +142,19 @@ func TestTaskODSDeployHelm(t *testing.T) {
 						t.Fatalf("Want ENV username = %s, got: %s", wantEnvValue, gotEnvValue)
 					}
 				},
+				AdditionalRuns: []tasktesting.TaskRunCase{{
+					// inherits funcs from primary task only set explicitly
+					PreRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
+						// ctxt still in place from prior run
+					},
+					WantRunSuccess: true,
+					PostRunFunc: func(t *testing.T, ctxt *tasktesting.TaskRunContext) {
+						wantLogMsg := "No diff detected, skipping helm upgrade"
+						if !strings.Contains(string(ctxt.CollectedLogs), wantLogMsg) {
+							t.Fatalf("Want:\n%s\n\nGot:\n%s", wantLogMsg, string(ctxt.CollectedLogs))
+						}
+					},
+				}},
 			},
 		},
 	)


### PR DESCRIPTION
Closes #583.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
