### PR TITLE
Always print Aqua scan stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ listed in the changelog.
 
 ## [0.6.0] - 2022-07-20
 
+### Changed
+
+- Always print Aqua log output ([#593](https://github.com/opendevstack/ods-pipeline/issues/593))
+
 ### Added
 
 - Enable build caching for gradle builds according to `docs/adr/20220314-caching-build-tasks.md`.

--- a/cmd/build-push-image/aqua.go
+++ b/cmd/build-push-image/aqua.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os/exec"
+
+	"github.com/opendevstack/pipeline/internal/command"
+)
+
+const (
+	aquasecBin                           = "aquasec"
+	scanComplianceFailureExitCode        = 4
+	scanLicenseValidationFailureExitCode = 5
+)
+
+// aquaScanRunner exists for testing purposes.
+type aquaScanRunner interface {
+	aquaScanRun(opts options, image, htmlReportFile, jsonReportFile string) ([]byte, []byte, error)
+}
+
+// aquaScanRunnerFunc is a type implementing the aquaScanRunner interface (like http.HandlerFunc).
+type aquaScanRunnerFunc func(opts options, image, htmlReportFile, jsonReportFile string) ([]byte, []byte, error)
+
+// aquaScanRun calls the function it is implemented on.
+func (f aquaScanRunnerFunc) aquaScanRun(opts options, image, htmlReportFile, jsonReportFile string) ([]byte, []byte, error) {
+	return f(opts, image, htmlReportFile, jsonReportFile)
+}
+
+// aquaScanRun runs an Aqua scan on given image.
+func aquaScanRun(opts options, image, htmlReportFile, jsonReportFile string) ([]byte, []byte, error) {
+	return command.Run(aquasecBin, []string{
+		"scan",
+		"--dockerless", "--register", "--text",
+		fmt.Sprintf("--htmlfile=%s", htmlReportFile),
+		fmt.Sprintf("--jsonfile=%s", jsonReportFile),
+		"-w", "/tmp",
+		fmt.Sprintf("--user=%s", opts.aquaUsername),
+		fmt.Sprintf("--password=%s", opts.aquaPassword),
+		fmt.Sprintf("--host=%s", opts.aquaURL),
+		image,
+		fmt.Sprintf("--registry=%s", opts.aquaRegistry),
+	})
+}
+
+// aquaScan executes the given aquaScanRunner and handles its result.
+// If the scan run did not return an err, the scan is considered successful.
+// If the scan did return an err, the scan is not successful, and an error is
+// returned unless the scan run indicates that the failure is due to compliance
+// reasons.
+func aquaScan(as aquaScanRunner, opts options, aquaImage, htmlReportFile, jsonReportFile string) (bool, string, error) {
+	scanSuccessful := false
+	// STDERR contains the scan log output
+	// STDOUT contains the scan summary (incl. ASCII table)
+	stdout, stderr, err := as.aquaScanRun(opts, aquaImage, htmlReportFile, jsonReportFile)
+	out := fmt.Sprintf("%s\n%s", string(stderr), string(stdout))
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) { // failure during Aqua scan
+			if ee.ExitCode() != scanComplianceFailureExitCode {
+				return false, out, fmt.Errorf("scan failed: %w", err)
+			}
+		} else { // error e.g. when binary is not found / executable
+			return false, out, fmt.Errorf("scan error: %w", err)
+		}
+	} else {
+		scanSuccessful = true
+	}
+	return scanSuccessful, out, nil
+}
+
+// aquasecInstalled checks whether the Aqua binary is in the $PATH.
+func aquasecInstalled() bool {
+	_, err := exec.LookPath(aquasecBin)
+	return err == nil
+}
+
+// aquaScanURL returns an URL to the given aquaImage.
+func aquaScanURL(opts options, aquaImage string) (string, error) {
+	aquaURL, err := url.Parse(opts.aquaURL)
+	if err != nil {
+		return "", fmt.Errorf("parse base URL: %w", err)
+	}
+	aquaPath := fmt.Sprintf(
+		"/#/images/%s/%s/vulns",
+		url.QueryEscape(opts.aquaRegistry), url.QueryEscape(aquaImage),
+	)
+	fullURL, err := aquaURL.Parse(aquaPath)
+	if err != nil {
+		return "", fmt.Errorf("parse URL path: %w", err)
+	}
+	return fullURL.String(), nil
+}

--- a/cmd/build-push-image/aqua_test.go
+++ b/cmd/build-push-image/aqua_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/opendevstack/pipeline/internal/command"
+)
+
+// TestAquaScanError covers the cases when the aqua scanner can be invoked, but may succeed or fail.
+func TestAquaScan(t *testing.T) {
+	tests := map[string]struct {
+		cmdStdout   string
+		cmdStderr   string
+		cmdExitCode int
+		wantSuccess bool
+		wantOut     string
+		wantErr     bool
+	}{
+		"scan exits with license validation failure exit code": {
+			cmdStdout:   "summary",
+			cmdStderr:   "log output",
+			cmdExitCode: scanLicenseValidationFailureExitCode,
+			wantSuccess: false,
+			wantOut:     "log output\n\nsummary\n",
+			wantErr:     true,
+		},
+		"scan exits with compliance failure exit code": {
+			cmdStdout:   "summary",
+			cmdStderr:   "log output",
+			cmdExitCode: scanComplianceFailureExitCode,
+			wantSuccess: false,
+			wantOut:     "log output\n\nsummary\n",
+			wantErr:     false,
+		},
+		"scan passes": {
+			cmdStdout:   "summary",
+			cmdStderr:   "log output",
+			cmdExitCode: 0,
+			wantSuccess: true,
+			wantOut:     "log output\n\nsummary\n",
+			wantErr:     false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fakeAquaScan := aquaScanRunnerFunc(func(opts options, image, htmlReportFile, jsonReportFile string) ([]byte, []byte, error) {
+				return command.Run("../../test/scripts/exit-with-code.sh", []string{tc.cmdStdout, tc.cmdStderr, strconv.Itoa(tc.cmdExitCode)})
+			})
+			success, out, err := aquaScan(fakeAquaScan, options{}, "image", "html", "json")
+			if tc.wantErr && err == nil {
+				t.Fatal("want err, got none")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("want no err, got %s", err)
+			}
+			if diff := cmp.Diff(tc.wantOut, out); diff != "" {
+				t.Fatalf("output mismatch (-want +got):\n%s", diff)
+			}
+			if tc.wantSuccess != success {
+				t.Fatalf("want success=%v, got success=%v", tc.wantSuccess, success)
+			}
+		})
+	}
+}
+
+// TestAquaScanError covers the case when the aqua scanner cannot be invoked at all.
+func TestAquaScanError(t *testing.T) {
+	fakeAquaScan := aquaScanRunnerFunc(func(opts options, image, htmlReportFile, jsonReportFile string) ([]byte, []byte, error) {
+		return command.Run("bogus.sh", []string{})
+	})
+	success, out, err := aquaScan(fakeAquaScan, options{}, "image", "html", "json")
+	if err == nil || err.Error() != "scan error: fork/exec bogus.sh: no such file or directory" {
+		t.Fatal("want err, got none")
+	}
+	if success {
+		t.Fatal("scan should not be successful")
+	}
+	if diff := cmp.Diff("\n", out); diff != "" {
+		t.Fatalf("output mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/test/scripts/exit-with-code.sh
+++ b/test/scripts/exit-with-code.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -ue
+
+# This script prints the first argument to stdout, prints the second argument to
+# stderr and exits with the exit code given as the third argument.
+# It can be used in tests to mimick the behaviour of real binaries.
+
+echo $1
+>&2 echo $2
+exit $3


### PR DESCRIPTION
The log output is written to stderr, so even in the successful case we
want to print that.

Further, the new code now handles the case when the aquasec scanner
cannot be executed at all properly.

Closes #593.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
