### PR TITLE
Buildah, Aqua and Helm log output improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ listed in the changelog.
 
 ## [0.6.0] - 2022-07-20
 
+### Changed
+
+- Stream Buildah and Aqua log output ([#596](https://github.com/opendevstack/ods-pipeline/issues/596))
+
+### Fixed
+
+- Aqua and helm-diff log output is incomplete ([#593](https://github.com/opendevstack/ods-pipeline/issues/593))
+
 ### Added
 
 - Enable build caching for gradle builds according to `docs/adr/20220314-caching-build-tasks.md`.

--- a/cmd/build-push-image/aqua.go
+++ b/cmd/build-push-image/aqua.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os/exec"
+
+	"github.com/opendevstack/pipeline/internal/command"
+)
+
+const (
+	aquasecBin                           = "aquasec"
+	scanComplianceFailureExitCode        = 4
+	scanLicenseValidationFailureExitCode = 5
+)
+
+// aquasecInstalled checks whether the Aqua binary is in the $PATH.
+func aquasecInstalled() bool {
+	_, err := exec.LookPath(aquasecBin)
+	return err == nil
+}
+
+// aquaScanURL returns an URL to the given aquaImage.
+func aquaScanURL(opts options, aquaImage string) (string, error) {
+	aquaURL, err := url.Parse(opts.aquaURL)
+	if err != nil {
+		return "", fmt.Errorf("parse base URL: %w", err)
+	}
+	aquaPath := fmt.Sprintf(
+		"/#/images/%s/%s/vulns",
+		url.QueryEscape(opts.aquaRegistry), url.QueryEscape(aquaImage),
+	)
+	fullURL, err := aquaURL.Parse(aquaPath)
+	if err != nil {
+		return "", fmt.Errorf("parse URL path: %w", err)
+	}
+	return fullURL.String(), nil
+}
+
+// aquaScan runs the scan and returns whether there was a policy incompliance or not.
+// An error is returned when the scan cannot be started or encounters failures
+// unrelated to policy compliance.
+func aquaScan(exe string, args []string, outWriter, errWriter io.Writer) (bool, error) {
+	// STDERR contains the scan log output, hence we read it before STDOUT.
+	// STDOUT contains the scan summary (incl. ASCII table).
+	return command.RunWithStreamingOutputReversed(
+		exe, args, []string{}, outWriter, errWriter, scanComplianceFailureExitCode,
+	)
+}
+
+// aquaAssembleScanArgs creates args/flags to pass to the Aqua scanner based on given arguments.
+func aquaAssembleScanArgs(opts options, image, htmlReportFile, jsonReportFile string) []string {
+	return []string{
+		"scan",
+		"--dockerless", "--register", "--text",
+		fmt.Sprintf("--htmlfile=%s", htmlReportFile),
+		fmt.Sprintf("--jsonfile=%s", jsonReportFile),
+		"-w", "/tmp",
+		fmt.Sprintf("--user=%s", opts.aquaUsername),
+		fmt.Sprintf("--password=%s", opts.aquaPassword),
+		fmt.Sprintf("--host=%s", opts.aquaURL),
+		image,
+		fmt.Sprintf("--registry=%s", opts.aquaRegistry),
+	}
+}

--- a/cmd/build-push-image/aqua_test.go
+++ b/cmd/build-push-image/aqua_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+)
+
+func TestAquaScan(t *testing.T) {
+	tests := map[string]struct {
+		cmdExitCode int
+		wantSuccess bool
+		wantErr     bool
+	}{
+		"scan exits with license validation failure exit code": {
+			cmdExitCode: scanLicenseValidationFailureExitCode,
+			wantSuccess: false,
+			wantErr:     true,
+		},
+		"scan exits with compliance failure exit code": {
+			cmdExitCode: scanComplianceFailureExitCode,
+			wantSuccess: false,
+			wantErr:     false,
+		},
+		"scan passes": {
+			cmdExitCode: 0,
+			wantSuccess: true,
+			wantErr:     false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			success, err := aquaScan(
+				"../../test/scripts/exit-with-code.sh",
+				[]string{"", "", strconv.Itoa(tc.cmdExitCode)},
+				&stdout, &stderr,
+			)
+			if tc.wantErr && err == nil {
+				t.Fatal("want err, got none")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("want no err, got %s", err)
+			}
+			if tc.wantSuccess != success {
+				t.Fatalf("want success=%v, got success=%v", tc.wantSuccess, success)
+			}
+		})
+	}
+}

--- a/cmd/build-push-image/buildah.go
+++ b/cmd/build-push-image/buildah.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"path/filepath"
+
+	"github.com/google/shlex"
+	"github.com/opendevstack/pipeline/internal/command"
+)
+
+// buildahBuild builds a local image using the Dockerfile and context directory
+// given in opts, tagging the resulting image with given tag.
+func buildahBuild(opts options, tag string, outWriter, errWriter io.Writer) error {
+	extraArgs, err := shlex.Split(opts.buildahBuildExtraArgs)
+	if err != nil {
+		return fmt.Errorf("parse extra args (%s): %w", opts.buildahBuildExtraArgs, err)
+	}
+
+	args := []string{
+		fmt.Sprintf("--storage-driver=%s", opts.storageDriver),
+		"bud",
+		fmt.Sprintf("--format=%s", opts.format),
+		fmt.Sprintf("--tls-verify=%v", opts.tlsVerify),
+		fmt.Sprintf("--cert-dir=%s", opts.certDir),
+		"--no-cache",
+		fmt.Sprintf("--file=%s", opts.dockerfile),
+		fmt.Sprintf("--tag=%s", tag),
+	}
+	args = append(args, extraArgs...)
+	nexusArgs, err := nexusBuildArgs(opts)
+	if err != nil {
+		return fmt.Errorf("add nexus build args: %w", err)
+	}
+	args = append(args, nexusArgs...)
+
+	if opts.debug {
+		args = append(args, "--log-level=debug")
+	}
+	_, err = command.RunWithStreamingOutput(
+		"buildah",
+		append(args, opts.contextDir),
+		[]string{},
+		outWriter, errWriter,
+		-1, // no special exit code handling
+	)
+	return err
+}
+
+// buildahPush pushes a local image to the given imageRef.
+func buildahPush(opts options, workingDir, imageRef string, outWriter, errWriter io.Writer) error {
+	extraArgs, err := shlex.Split(opts.buildahPushExtraArgs)
+	if err != nil {
+		log.Printf("could not parse extra args (%s): %s", opts.buildahPushExtraArgs, err)
+	}
+	args := []string{
+		fmt.Sprintf("--storage-driver=%s", opts.storageDriver),
+		"push",
+		fmt.Sprintf("--tls-verify=%v", opts.tlsVerify),
+		fmt.Sprintf("--cert-dir=%s", opts.certDir),
+		fmt.Sprintf("--digestfile=%s", filepath.Join(workingDir, "image-digest")),
+	}
+	args = append(args, extraArgs...)
+	if opts.debug {
+		args = append(args, "--log-level=debug")
+	}
+	_, err = command.RunWithStreamingOutput(
+		"buildah",
+		append(args, imageRef, fmt.Sprintf("docker://%s", imageRef)),
+		[]string{},
+		outWriter, errWriter,
+		-1, // no special exit code handling
+	)
+	return err
+}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -1,7 +1,11 @@
 package command
 
 import (
+	"bufio"
 	"bytes"
+	"errors"
+	"fmt"
+	"io"
 	"os"
 	"os/exec"
 )
@@ -40,4 +44,65 @@ func RunWithExtraEnvs(executable string, args []string, extraEnvs []string) (out
 	outBytes = stdout.Bytes()
 	errBytes = stderr.Bytes()
 	return outBytes, errBytes, err
+}
+
+// RunWithStreamingOutput invokes exe with given args and env. Stdout and stderr
+// are streamed to outWriter and errWriter, respectively. If exe errors with an
+// exit code equal to failureExitCode, no error is returned to the caller,
+// but success is false. If exe does not error, success is true.
+func RunWithStreamingOutput(exe string, args []string, env []string, outWriter, errWriter io.Writer, failureExitCode int) (success bool, err error) {
+	return runWithStreamingOutput(exe, args, env, outWriter, errWriter, failureExitCode, false)
+}
+
+// RunWithStreamingOutput invokes exe with given args and env. Stdout and stderr
+// are streamed to outWriter and errWriter, respectively. If exe errors with an
+// exit code equal to failureExitCode, no error is returned to the caller,
+// but success is false. If exe does not error, success is true.
+// RunWithStreamingOutputReversed is identical to RunWithStreamingOutput,
+// except for streaming stderr before stdout.
+func RunWithStreamingOutputReversed(exe string, args []string, env []string, outWriter, errWriter io.Writer, failureExitCode int) (success bool, err error) {
+	return runWithStreamingOutput(exe, args, env, outWriter, errWriter, failureExitCode, true)
+}
+
+// runWithStreamingOutput is the private implementation of RunWithStreamingOutput(Reversed).
+func runWithStreamingOutput(exe string, args []string, env []string, outWriter, errWriter io.Writer, failureExitCode int, stderrFirst bool) (success bool, err error) {
+	cmd := exec.Command(exe, args...)
+	cmd.Env = append(os.Environ(), env...)
+	cmdStderr, err := cmd.StderrPipe()
+	if err != nil {
+		return false, fmt.Errorf("connect stderr pipe: %w", err)
+	}
+	cmdStdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return false, fmt.Errorf("connect stdout pipe: %w", err)
+	}
+	err = cmd.Start()
+	if err != nil {
+		return false, fmt.Errorf("start cmd: %w", err)
+	}
+
+	if stderrFirst {
+		collectOutput(cmdStderr, errWriter)
+		collectOutput(cmdStdout, outWriter)
+	} else {
+		collectOutput(cmdStdout, outWriter)
+		collectOutput(cmdStderr, errWriter)
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) && ee.ExitCode() == failureExitCode {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func collectOutput(rc io.ReadCloser, w io.Writer) {
+	scanner := bufio.NewScanner(rc)
+	for scanner.Scan() {
+		fmt.Fprintln(w, scanner.Text())
+	}
 }

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -1,0 +1,76 @@
+package command
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestRunWithStreamingOutput covers the cases when helm-diff can be invoked, but may detect drift or not.
+func TestRunWithStreamingOutput(t *testing.T) {
+	tests := map[string]struct {
+		cmdExitCode int
+		wantSuccess bool
+		wantErr     bool
+	}{
+		"cmd exits with generic exit code": {
+			cmdExitCode: 1,
+			wantSuccess: false,
+			wantErr:     true,
+		},
+		"cmd exits with special failure exit code": {
+			cmdExitCode: 2,
+			wantSuccess: false,
+			wantErr:     false,
+		},
+		"cmd finishes without error": {
+			cmdExitCode: 0,
+			wantSuccess: true,
+			wantErr:     false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			driftDetected, err := RunWithStreamingOutput(
+				"../../test/scripts/exit-with-code.sh",
+				[]string{"value of FOO=${FOO}", "log msg", strconv.Itoa(tc.cmdExitCode)},
+				[]string{"FOO=bar"},
+				&stdout, &stderr,
+				2,
+			)
+			if tc.wantErr && err == nil {
+				t.Fatal("want err, got none")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("want no err, got %s", err)
+			}
+			wantStdout := "value of FOO=bar"
+			wantStderr := "log msg"
+			if diff := cmp.Diff(wantStdout+"\n", stdout.String()); diff != "" {
+				t.Fatalf("stdout mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(wantStderr+"\n", stderr.String()); diff != "" {
+				t.Fatalf("stderr mismatch (-want +got):\n%s", diff)
+			}
+			if tc.wantSuccess != driftDetected {
+				t.Fatalf("want success=%v, got success=%v", tc.wantSuccess, driftDetected)
+			}
+		})
+	}
+}
+
+// TestRunWithStreamingOutputError covers the case when the aqua scanner cannot be invoked at all.
+func TestRunWithStreamingOutputError(t *testing.T) {
+	success, err := RunWithStreamingOutput(
+		"./bogus.sh", []string{}, []string{}, &bytes.Buffer{}, &bytes.Buffer{}, -1,
+	)
+	if err == nil || err.Error() != "start cmd: fork/exec ./bogus.sh: no such file or directory" {
+		t.Fatalf("want err, got: %+v", err)
+	}
+	if success {
+		t.Fatal("cmd should not be successful")
+	}
+}

--- a/test/scripts/exit-with-code.sh
+++ b/test/scripts/exit-with-code.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ue
+
+# This script prints the first argument to stdout, the second argument to
+# stderr and exits with the code given as the third argument.
+# It can be used in tests to mimick the behaviour of real binaries.
+# The strings printed to stdout and stderr are eval'd to facilitate testing of
+# environment variables.
+
+eval echo "$1"
+>&2 eval echo "$2"
+exit "$3"


### PR DESCRIPTION
Various log output improvements

Ensure to print all of STDOUT and STDERR from invoked commands to help
user diagnose issues.

Stream STDOUT and STDERR from invoked commands to provide better
progress indication.

Closes #593.
Closes #596.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
