### PR TITLE
Update skopeo (1.6 to 1.8) and buildah (1.24 to 1.26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ listed in the changelog.
 ### Changed
 
 - Stream Buildah and Aqua log output ([#596](https://github.com/opendevstack/ods-pipeline/issues/596))
+- Update skopeo (1.6 to 1.8) and buildah (1.24 to 1.26) ([#598](https://github.com/opendevstack/ods-pipeline/issues/598))
 
 ### Fixed
 

--- a/build/package/Dockerfile.buildah
+++ b/build/package/Dockerfile.buildah
@@ -17,8 +17,8 @@ RUN cd cmd/build-push-image && CGO_ENABLED=0 go build -o /usr/local/bin/ods-buil
 # and https://github.com/containers/buildah/blob/main/contrib/buildahimage/stable/Dockerfile.
 FROM registry.access.redhat.com/ubi8:8.4
 
-ENV BUILDAH_VERSION=1.24 \
-    SKOPEO_VERSION=1.6
+ENV BUILDAH_VERSION=1.26 \
+    SKOPEO_VERSION=1.8
 
 COPY --from=builder /usr/local/bin/ods-build-push-image /usr/local/bin/ods-build-push-image
 

--- a/build/package/Dockerfile.helm
+++ b/build/package/Dockerfile.helm
@@ -43,7 +43,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 ENV HELM_PLUGIN_DIFF_VERSION=3.3.2 \
     HELM_PLUGIN_SECRETS_VERSION=3.10.0 \
     HELM_PLUGINS=/usr/local/helm/plugins \
-    SKOPEO_VERSION=1.6 \
+    SKOPEO_VERSION=1.8 \
     TAR_VERSION=1.30 \
     GIT_VERSION=2.31 \
     FINDUTILS_VERSION=4.6 \

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -569,13 +569,13 @@ a| The script is supposed to be downloaded and piped into bash. The script insta
 
 | SDS-EXT-17
 | Skopeo
-| 1.6
+| 1.8
 | Tool for moving container images between different types of container storages.
 | https://github.com/containers/skopeo
 
 | SDS-EXT-18
 | Buildah
-| 1.24
+| 1.26
 | Tool that facilitates building OCI images.
 | https://github.com/containers/buildah
 


### PR DESCRIPTION
Fixes #598

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
