### PR TITLE
Remove usage of io/ioutil package

### DIFF
--- a/cmd/artifact-download/main_test.go
+++ b/cmd/artifact-download/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -228,7 +227,7 @@ func TestRun(t *testing.T) {
 	}
 
 	// Temporary output directory.
-	artifactsDir, err := ioutil.TempDir(".", "test-artifacts-")
+	artifactsDir, err := os.MkdirTemp(".", "test-artifacts-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/build-push-image/main.go
+++ b/cmd/build-push-image/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -319,7 +318,7 @@ func getImageDigestFromRegistry(imageRef string, opts options) (string, error) {
 
 // getImageDigestFromFile reads the image digest from the file written to by buildah.
 func getImageDigestFromFile(workingDir string) (string, error) {
-	content, err := ioutil.ReadFile(filepath.Join(workingDir, "image-digest"))
+	content, err := os.ReadFile(filepath.Join(workingDir, "image-digest"))
 	if err != nil {
 		return "", err
 	}
@@ -332,5 +331,5 @@ func writeImageDigestToResults(imageDigest string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile("/tekton/results/image-digest", []byte(imageDigest), 0644)
+	return os.WriteFile("/tekton/results/image-digest", []byte(imageDigest), 0644)
 }

--- a/cmd/deploy-with-helm/helm.go
+++ b/cmd/deploy-with-helm/helm.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -49,7 +49,7 @@ func helmDiff(exe string, args []string, outWriter, errWriter io.Writer) (bool, 
 
 // getHelmChart reads given filename into a helmChart struct.
 func getHelmChart(filename string) (*helmChart, error) {
-	y, err := ioutil.ReadFile(filename)
+	y, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("could not read chart: %w", err)
 	}

--- a/cmd/deploy-with-helm/main.go
+++ b/cmd/deploy-with-helm/main.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -113,9 +112,9 @@ func main() {
 	fmt.Printf("releaseNamespace=%s\n", releaseNamespace)
 
 	// Find subrepos
-	var subrepos []fs.FileInfo
+	var subrepos []fs.DirEntry
 	if _, err := os.Stat(pipelinectxt.SubreposPath); err == nil {
-		f, err := ioutil.ReadDir(pipelinectxt.SubreposPath)
+		f, err := os.ReadDir(pipelinectxt.SubreposPath)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -168,7 +167,7 @@ func main() {
 		fmt.Println("Copying images into release namespace ...")
 		for _, artifactFile := range files {
 			var imageArtifact artifact.Image
-			artifactContent, err := ioutil.ReadFile(artifactFile)
+			artifactContent, err := os.ReadFile(artifactFile)
 			if err != nil {
 				log.Fatalf("could not read image artifact file %s: %s", artifactFile, err)
 			}
@@ -293,7 +292,7 @@ func main() {
 		}
 	}
 
-	subcharts, err := ioutil.ReadDir(chartsDir)
+	subcharts, err := os.ReadDir(chartsDir)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -421,7 +420,7 @@ func writeDeploymentArtifact(content []byte, filename, chartDir, targetEnv strin
 		return err
 	}
 	f := artifactFilename(filename, chartDir, targetEnv) + ".txt"
-	return ioutil.WriteFile(filepath.Join(pipelinectxt.DeploymentsPath, f), content, 0644)
+	return os.WriteFile(filepath.Join(pipelinectxt.DeploymentsPath, f), content, 0644)
 }
 
 func storeAgeKey(secret *corev1.Secret, ageKeySecretField string) (errBytes []byte, err error) {
@@ -446,7 +445,7 @@ func tokenFromSecret(clientset *kubernetes.Clientset, namespace, name string) (s
 }
 
 func getTrimmedFileContent(filename string) (string, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}
@@ -456,7 +455,7 @@ func getTrimmedFileContent(filename string) (string, error) {
 func collectImageDigests(imageDigestsDir string) ([]string, error) {
 	var files []string
 	if _, err := os.Stat(imageDigestsDir); err == nil {
-		f, err := ioutil.ReadDir(imageDigestsDir)
+		f, err := os.ReadDir(imageDigestsDir)
 		if err != nil {
 			return files, fmt.Errorf("could not read image digests dir: %w", err)
 		}

--- a/cmd/finish/main_test.go
+++ b/cmd/finish/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -96,7 +95,7 @@ func TestHandleArtifacts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ioutil.WriteFile(filepath.Join(tempWorkingDir, "ods.yaml"), out, 0644)
+	err = os.WriteFile(filepath.Join(tempWorkingDir, "ods.yaml"), out, 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +153,7 @@ func nexusRepoContains(haystack []string, needle string) bool {
 // artifacts manifest file. The returned function should be used for cleanup.
 func prepareTempWorkingDir(nexusRepo string) (string, func(), error) {
 	cleanup := func() {}
-	tempWorkingDir, err := ioutil.TempDir(".", "test-upload-")
+	tempWorkingDir, err := os.MkdirTemp(".", "test-upload-")
 	if err != nil {
 		return tempWorkingDir, cleanup, err
 	}
@@ -192,7 +191,7 @@ func writeArtifactFile(artifactsDir, subdir, filename string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join(artifactsSubDir, filename), []byte("test"), 0644)
+	return os.WriteFile(filepath.Join(artifactsSubDir, filename), []byte("test"), 0644)
 }
 
 // writeArtifactsManifest writes an artigact manifest JSON file into artifactsDir.

--- a/cmd/pipeline-manager/main.go
+++ b/cmd/pipeline-manager/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
@@ -217,7 +216,7 @@ func health(w http.ResponseWriter, r *http.Request) {
 }
 
 func getFileContent(filename string) (string, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/pipeline-manager/main_test.go
+++ b/cmd/pipeline-manager/main_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,7 +16,7 @@ func TestHealthEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/sonar/main_test.go
+++ b/cmd/sonar/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -127,7 +126,7 @@ func TestSonarScan(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tempDir, err := ioutil.TempDir(".", "test-cmd-sonar-")
+			tempDir, err := os.MkdirTemp(".", "test-cmd-sonar-")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -435,7 +434,7 @@ func checkoutAndAssembleContext(
 }
 
 func getCommitSHA(dir string) (string, error) {
-	content, err := ioutil.ReadFile(filepath.Join(dir, ".git/HEAD"))
+	content, err := os.ReadFile(filepath.Join(dir, ".git/HEAD"))
 	if err != nil {
 		return "", err
 	}

--- a/cmd/start/main_test.go
+++ b/cmd/start/main_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -194,7 +194,7 @@ func lastTagPayload(t *testing.T, srv *testserver.TestServer) bitbucket.TagCreat
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/directory/copy.go
+++ b/internal/directory/copy.go
@@ -3,14 +3,13 @@ package directory
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
 )
 
 func CopyToTempDir(sourceDir, destinationBaseDir, pattern string) (string, error) {
-	tempDir, err := ioutil.TempDir(destinationBaseDir, pattern)
+	tempDir, err := os.MkdirTemp(destinationBaseDir, pattern)
 	if err != nil {
 		return "", fmt.Errorf("could not create temporary directory: %w", err)
 	}
@@ -22,7 +21,7 @@ func CopyToTempDir(sourceDir, destinationBaseDir, pattern string) (string, error
 }
 
 func Copy(scrDir, dest string) error {
-	entries, err := ioutil.ReadDir(scrDir)
+	entries, err := os.ReadDir(scrDir)
 	if err != nil {
 		return err
 	}
@@ -62,9 +61,13 @@ func Copy(scrDir, dest string) error {
 			return err
 		}
 
-		isSymlink := entry.Mode()&os.ModeSymlink != 0
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		isSymlink := info.Mode()&os.ModeSymlink != 0
 		if !isSymlink {
-			if err := os.Chmod(destPath, entry.Mode()); err != nil {
+			if err := os.Chmod(destPath, info.Mode()); err != nil {
 				return err
 			}
 		}

--- a/internal/directory/files.go
+++ b/internal/directory/files.go
@@ -2,12 +2,12 @@ package directory
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 )
 
 func ListFiles(dir string) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/gittest/repository.go
+++ b/internal/gittest/repository.go
@@ -1,7 +1,6 @@
 package gittest
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -11,7 +10,7 @@ import (
 // The returned function should be deferred to clean up the temp dir.
 func CreateFakeGitRepoDir(url, branch, sha string) (string, func(), error) {
 	cleanupFunc := func() {}
-	dir, err := ioutil.TempDir(".", "test-git-repo-")
+	dir, err := os.MkdirTemp(".", "test-git-repo-")
 	if err != nil {
 		return "", cleanupFunc, err
 	}
@@ -23,7 +22,7 @@ func CreateFakeGitRepoDir(url, branch, sha string) (string, func(), error) {
 	if err != nil {
 		return "", cleanupFunc, err
 	}
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(gitDir, "HEAD"),
 		[]byte("ref: refs/heads/"+branch),
 		0644,
@@ -31,7 +30,7 @@ func CreateFakeGitRepoDir(url, branch, sha string) (string, func(), error) {
 	if err != nil {
 		return "", cleanupFunc, err
 	}
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(gitDir, "config"),
 		[]byte(`[remote "origin"]
 	url = `+url+`
@@ -46,7 +45,7 @@ func CreateFakeGitRepoDir(url, branch, sha string) (string, func(), error) {
 	if err != nil {
 		return "", cleanupFunc, err
 	}
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(gitHeadsDir, branch),
 		[]byte(sha),
 		0644,

--- a/internal/manager/receive.go
+++ b/internal/manager/receive.go
@@ -3,7 +3,7 @@ package manager
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -60,7 +60,7 @@ type PipelineInfo struct {
 // Handle handles Bitbucket requests. It extracts pipeline data from the request
 // body and sends the gained data to the scheduler.
 func (s *BitbucketWebhookReceiver) Handle(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		msg := "could not read body"
 		s.Logger.Errorf("%s: %s", msg, err)

--- a/internal/manager/receive_test.go
+++ b/internal/manager/receive_test.go
@@ -6,7 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -210,7 +210,7 @@ func TestWebhookHandling(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			body, err := ioutil.ReadAll(f)
+			body, err := io.ReadAll(f)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -234,7 +234,7 @@ func TestWebhookHandling(t *testing.T) {
 			if tc.wantStatus != gotStatus {
 				t.Fatalf("Got status: %v, want: %v", gotStatus, tc.wantStatus)
 			}
-			gotBodyBytes, err := ioutil.ReadAll(res.Body)
+			gotBodyBytes, err := io.ReadAll(res.Body)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -267,7 +267,7 @@ func removeSpace(str string) string {
 }
 
 func readTestdataFile(t *testing.T, filename string) []byte {
-	b, err := ioutil.ReadFile(filepath.Join(projectpath.Root, "test/testdata", filename))
+	b, err := os.ReadFile(filepath.Join(projectpath.Root, "test/testdata", filename))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/notification/client.go
+++ b/internal/notification/client.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -84,7 +84,7 @@ func (c Client) CallWebhook(ctxt context.Context, summary PipelineRunResult) err
 	c.logger().Infof("notification webhook response was: %s", response.Status)
 
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		body, err := ioutil.ReadAll(response.Body)
+		body, err := io.ReadAll(response.Body)
 		if err != nil {
 			body = []byte("<could not read body>")
 		}

--- a/internal/notification/client_test.go
+++ b/internal/notification/client_test.go
@@ -2,7 +2,7 @@ package notification
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -17,7 +17,7 @@ func TestWebhookCall(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		want := string(testfile.ReadGolden(t, "notification/teams-notification.json"))
 
-		got, err := ioutil.ReadAll(r.Body)
+		got, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("reading request body failed: %s", err)
 		}

--- a/internal/testfile/testdata.go
+++ b/internal/testfile/testdata.go
@@ -1,7 +1,7 @@
 package testfile
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -19,7 +19,7 @@ func ReadGolden(t *testing.T, filename string) []byte {
 }
 
 func ReadFileOrFatal(t *testing.T, filename string) []byte {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/bitbucket/client.go
+++ b/pkg/bitbucket/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -102,7 +101,7 @@ func (c *Client) doRequest(req *http.Request) (int, []byte, error) {
 	}
 	defer res.Body.Close()
 
-	responseBody, err := ioutil.ReadAll(res.Body)
+	responseBody, err := io.ReadAll(res.Body)
 	return res.StatusCode, responseBody, err
 }
 

--- a/pkg/bitbucket/code_insights_test.go
+++ b/pkg/bitbucket/code_insights_test.go
@@ -2,7 +2,7 @@ package bitbucket
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -83,7 +83,7 @@ func checkLastRequest(t *testing.T, srv *testserver.TestServer, golden string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	gotBody, err := ioutil.ReadAll(req.Body)
+	gotBody, err := io.ReadAll(req.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/config/ods.go
+++ b/pkg/config/ods.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -162,7 +161,7 @@ func Read(body []byte) (*ODS, error) {
 
 // ReadFromFile reads an ods config from given filename or errors.
 func ReadFromFile(filename string) (*ODS, error) {
-	body, err := ioutil.ReadFile(filename)
+	body, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("could not read file %s: %w", filename, err)
 	}

--- a/pkg/nexus/test_client.go
+++ b/pkg/nexus/test_client.go
@@ -2,7 +2,7 @@ package nexus
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
@@ -13,7 +13,7 @@ type TestClient struct {
 
 // Download writes a dummy string into outfile.
 func (c *TestClient) Download(url, outfile string) (int64, error) {
-	return 0, ioutil.WriteFile(outfile, []byte("test"), 0644)
+	return 0, os.WriteFile(outfile, []byte("test"), 0644)
 }
 
 // Search responds with pre-registered URLs for repository.

--- a/pkg/pipelinectxt/artifacts.go
+++ b/pkg/pipelinectxt/artifacts.go
@@ -3,7 +3,6 @@ package pipelinectxt
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -55,7 +54,7 @@ type ArtifactInfo struct {
 
 // ReadArtifactsManifestFromFile reads an artifact manifest from given filename or errors.
 func ReadArtifactsManifestFromFile(filename string) (*ArtifactsManifest, error) {
-	body, err := ioutil.ReadFile(filename)
+	body, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("could not read file %s: %w", filename, err)
 	}
@@ -93,7 +92,7 @@ func WriteJsonArtifact(in interface{}, artifactsPath, filename string) error {
 	if err != nil {
 		return fmt.Errorf("could not create %s: %w", artifactsPath, err)
 	}
-	return ioutil.WriteFile(filepath.Join(artifactsPath, filename), out, 0644)
+	return os.WriteFile(filepath.Join(artifactsPath, filename), out, 0644)
 }
 
 // CopyArtifact copies given "sourceFile" into "artifactsPath".
@@ -114,7 +113,7 @@ func CopyArtifact(sourceFile, artifactsPath string) error {
 func ReadArtifactsDir(artifactsDir string) (map[string][]string, error) {
 	artifactsMap := map[string][]string{}
 
-	items, err := ioutil.ReadDir(artifactsDir)
+	items, err := os.ReadDir(artifactsDir)
 	if err != nil {
 		return artifactsMap, fmt.Errorf("%w", err)
 	}
@@ -122,7 +121,7 @@ func ReadArtifactsDir(artifactsDir string) (map[string][]string, error) {
 	for _, item := range items {
 		if item.IsDir() {
 			// artifact subdir here, e.g. "xunit-reports"
-			subitems, err := ioutil.ReadDir(filepath.Join(artifactsDir, item.Name()))
+			subitems, err := os.ReadDir(filepath.Join(artifactsDir, item.Name()))
 			if err != nil {
 				log.Fatalf("Failed to read dir %s, %s", item.Name(), err.Error())
 			}

--- a/pkg/pipelinectxt/artifacts_test.go
+++ b/pkg/pipelinectxt/artifacts_test.go
@@ -2,7 +2,6 @@ package pipelinectxt
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestReadArtifactsDir(t *testing.T) {
-	artifactsDir, err := ioutil.TempDir(".", "test-artifacts-")
+	artifactsDir, err := os.MkdirTemp(".", "test-artifacts-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,7 +23,7 @@ func TestReadArtifactsDir(t *testing.T) {
 		t.Fatal(err)
 	}
 	artifactsFile := filepath.Join(artifactsSubDir, "foo.txt")
-	err = ioutil.WriteFile(artifactsFile, []byte("test"), 0644)
+	err = os.WriteFile(artifactsFile, []byte("test"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +47,7 @@ func TestDownloadGroup(t *testing.T) {
 	nexusURL := "https://nexus.example.com"
 	permanentBaseURL := fmt.Sprintf("%s/%s%s/%s", nexusURL, nexus.PermanentRepositoryDefault, group, artifactType)
 	temporaryBaseURL := fmt.Sprintf("%s/%s%s/%s", nexusURL, nexus.PermanentRepositoryDefault, group, artifactType)
-	artifactsDir, err := ioutil.TempDir(".", "test-artifacts-")
+	artifactsDir, err := os.MkdirTemp(".", "test-artifacts-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/pipelinectxt/context.go
+++ b/pkg/pipelinectxt/context.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -192,11 +191,11 @@ func readRemoteOriginURL(gitConfigFilename string) (string, error) {
 }
 
 func writeFile(filename, content string) error {
-	return ioutil.WriteFile(filename, []byte(content), 0644)
+	return os.WriteFile(filename, []byte(content), 0644)
 }
 
 func getTrimmedFileContent(filename string) (string, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/sonar/client.go
+++ b/pkg/sonar/client.go
@@ -3,7 +3,7 @@ package sonar
 import (
 	b64 "encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -99,7 +99,7 @@ func (c *Client) get(urlPath string) (int, []byte, error) {
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	return res.StatusCode, body, err
 }
 

--- a/pkg/tasktesting/git.go
+++ b/pkg/tasktesting/git.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
 	"os"
@@ -321,5 +320,5 @@ func trackLfsJpgFileToBitbucketOrFatal(t *testing.T, wsDir, filename string) {
 }
 
 func writeFile(filename, content string) error {
-	return ioutil.WriteFile(filename, []byte(content), 0644)
+	return os.WriteFile(filename, []byte(content), 0644)
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -123,7 +123,7 @@ pipeline:
         - name: source
           workspace: shared-workspace`
 
-	err = ioutil.WriteFile(filepath.Join(wsDir, filename), []byte(fileContent), 0644)
+	err = os.WriteFile(filepath.Join(wsDir, filename), []byte(fileContent), 0644)
 	if err != nil {
 		t.Fatalf("could not write file=%s: %s", filename, err)
 	}

--- a/test/tasks/common_test.go
+++ b/test/tasks/common_test.go
@@ -3,7 +3,6 @@ package tasks
 import (
 	"crypto/sha256"
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,7 +66,7 @@ func checkFilesExist(t *testing.T, wsDir string, wantFiles ...string) {
 
 func checkFileHash(t *testing.T, wsDir string, filename string, hash [32]byte) {
 	filepath := filepath.Join(wsDir, filename)
-	filecontent, err := ioutil.ReadFile(filepath)
+	filecontent, err := os.ReadFile(filepath)
 	if err != nil {
 		t.Fatalf("Want %s, but got nothing", filename)
 	}
@@ -78,7 +77,7 @@ func checkFileHash(t *testing.T, wsDir string, filename string, hash [32]byte) {
 }
 
 func getTrimmedFileContent(filename string) (string, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}
@@ -94,7 +93,7 @@ func trimmedFileContentOrFatal(t *testing.T, filename string) string {
 }
 
 func checkFileContentContains(t *testing.T, wsDir, filename string, wantContains ...string) {
-	content, err := ioutil.ReadFile(filepath.Join(wsDir, filename))
+	content, err := os.ReadFile(filepath.Join(wsDir, filename))
 	got := string(content)
 	if err != nil {
 		t.Fatalf("could not read %s: %s", filename, err)
@@ -117,7 +116,7 @@ func checkFileContentLeanContains(t *testing.T, wsDir, filename string, wantCont
 }
 
 func getFileContentLean(filename string) (string, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}
@@ -202,7 +201,7 @@ func createODSYML(wsDir string, o *config.ODS) error {
 		return err
 	}
 	filename := filepath.Join(wsDir, "ods.yaml")
-	return ioutil.WriteFile(filename, y, 0644)
+	return os.WriteFile(filename, y, 0644)
 }
 
 func checkBuildStatus(t *testing.T, c *bitbucket.Client, gitCommit, wantBuildStatus string) {

--- a/test/tasks/ods-build-python_test.go
+++ b/test/tasks/ods-build-python_test.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -43,7 +43,7 @@ func TestTaskODSBuildPython(t *testing.T) {
 						filepath.Join(pipelinectxt.SonarAnalysisPath, "quality-gate.json"),
 					)
 
-					wantContainsBytes, err := ioutil.ReadFile("../../test/testdata/golden/ods-build-python/excerpt-from-coverage.xml")
+					wantContainsBytes, err := os.ReadFile("../../test/testdata/golden/ods-build-python/excerpt-from-coverage.xml")
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -87,7 +87,7 @@ func TestTaskODSBuildPython(t *testing.T) {
 						filepath.Join(pipelinectxt.SonarAnalysisPath, "quality-gate.json"),
 					)
 
-					wantContainsBytes, err := ioutil.ReadFile("../../test/testdata/golden/ods-build-python/excerpt-from-coverage.xml")
+					wantContainsBytes, err := os.ReadFile("../../test/testdata/golden/ods-build-python/excerpt-from-coverage.xml")
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/test/tasks/ods-deploy-helm_test.go
+++ b/test/tasks/ods-deploy-helm_test.go
@@ -3,7 +3,7 @@ package tasks
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -200,7 +200,7 @@ func createReleaseNamespace(clientset *k8s.Clientset, ctxtNamespace string) (str
 }
 
 func writeContextFile(t *testing.T, wsDir, file, content string) {
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		filepath.Join(wsDir, pipelinectxt.BaseDir, file), []byte(content), 0644,
 	)
 	if err != nil {
@@ -234,7 +234,7 @@ func checkService(clientset *k8s.Clientset, namespace, name string) (*corev1.Ser
 }
 
 func readPrivateKeySecret() (*corev1.Secret, error) {
-	bytes, err := ioutil.ReadFile(filepath.Join(projectpath.Root, "test/testdata/fixtures/tasks/secret.yaml"))
+	bytes, err := os.ReadFile(filepath.Join(projectpath.Root, "test/testdata/fixtures/tasks/secret.yaml"))
 	if err != nil {
 		return nil, err
 	}

--- a/test/testserver/testserver.go
+++ b/test/testserver/testserver.go
@@ -3,9 +3,10 @@ package testserver
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -32,8 +33,8 @@ func cloneRequest(r *http.Request) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	r.Body = ioutil.NopCloser(&b)
-	r2.Body = ioutil.NopCloser(bytes.NewReader(b.Bytes()))
+	r.Body = io.NopCloser(&b)
+	r2.Body = io.NopCloser(bytes.NewReader(b.Bytes()))
 	return &r2, nil
 }
 
@@ -68,7 +69,7 @@ func (ts *TestServer) EnqueueResponse(t *testing.T, path string, statusCode int,
 	body := []byte{}
 	if len(fixture) > 0 {
 		filename := filepath.Join(projectpath.Root, "test/testdata/fixtures", fixture)
-		b, err := ioutil.ReadFile(filename)
+		b, err := os.ReadFile(filename)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
As of Go 1.16, the same functionality is now provided by package io or package
os, and those implementations should be preferred in new code.

See https://pkg.go.dev/io/ioutil.

`golangci-lint` complains about `io/ioutil` usage (e.g. see https://github.com/opendevstack/ods-pipeline/actions/runs/2978230758), even though I cannot replicate the issue locally, even though it looks like the same version and configuration is used.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
