### PR TITLE
Apply correct tag when pushing to external registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ listed in the changelog.
 ### Fixed
 
 - Aqua and helm-diff log output is incomplete ([#593](https://github.com/opendevstack/ods-pipeline/issues/593))
+- Image is tagged with `latest` instead of correct tag when pushed to external registry ([#606](https://github.com/opendevstack/ods-pipeline/issues/606))
 
 ## [0.6.0] - 2022-07-20
 


### PR DESCRIPTION
Fixes #606.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
