### PR TITLE
Normalize K8s manifests to exclude style differences from Helm diff output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ listed in the changelog.
 
 ## [Unreleased]
 
+### Changed
+
+- Normalize K8s manifests to exclude style differences from Helm diff output. The change is applied to both the helm execution in the `ods-deploy-helm` task and in the install script. See [#591](https://github.com/opendevstack/ods-pipeline/issues/591).
+
 ## [0.7.0] - 2022-10-11
 
 ### Changed

--- a/cmd/deploy-with-helm/helm.go
+++ b/cmd/deploy-with-helm/helm.go
@@ -100,6 +100,7 @@ func assembleHelmDiffArgs(
 		"upgrade",
 		"--detailed-exitcode",
 		"--no-color",
+		"--normalize-manifests",
 	}
 	helmDiffFlags, err := shlex.Split(opts.diffFlags)
 	if err != nil {

--- a/cmd/deploy-with-helm/helm_test.go
+++ b/cmd/deploy-with-helm/helm_test.go
@@ -122,7 +122,7 @@ func TestAssembleHelmDiffArgs(t *testing.T) {
 			helmArchive:      "c",
 			opts:             options{diffFlags: "--three-way-merge", upgradeFlags: "--install", debug: true},
 			want: []string{"--namespace=a", "secrets", "diff", "upgrade",
-				"--detailed-exitcode", "--no-color", "--three-way-merge", "--debug", "--install",
+				"--detailed-exitcode", "--no-color", "--normalize-manifests", "--three-way-merge", "--debug", "--install",
 				"b", "c"},
 		},
 		"with no diff flags": {
@@ -131,7 +131,7 @@ func TestAssembleHelmDiffArgs(t *testing.T) {
 			helmArchive:      "c",
 			opts:             options{diffFlags: "", upgradeFlags: "--install"},
 			want: []string{"--namespace=a", "secrets", "diff", "upgrade",
-				"--detailed-exitcode", "--no-color", "--install",
+				"--detailed-exitcode", "--no-color", "--normalize-manifests", "--install",
 				"b", "c"},
 		},
 		"with values file": {
@@ -141,7 +141,7 @@ func TestAssembleHelmDiffArgs(t *testing.T) {
 			opts:             options{diffFlags: "--three-way-merge", upgradeFlags: "--install"},
 			valuesFiles:      []string{"values.dev.yaml"},
 			want: []string{"--namespace=a", "secrets", "diff", "upgrade",
-				"--detailed-exitcode", "--no-color", "--three-way-merge", "--install", "--values=values.dev.yaml",
+				"--detailed-exitcode", "--no-color", "--normalize-manifests", "--three-way-merge", "--install", "--values=values.dev.yaml",
 				"b", "c"},
 		},
 		"with CLI values": {
@@ -151,7 +151,7 @@ func TestAssembleHelmDiffArgs(t *testing.T) {
 			opts:             options{diffFlags: "--three-way-merge", upgradeFlags: "--install"},
 			cliValues:        []string{"--set=image.tag=abcdef"},
 			want: []string{"--namespace=a", "secrets", "diff", "upgrade",
-				"--detailed-exitcode", "--no-color", "--three-way-merge", "--install", "--set=image.tag=abcdef",
+				"--detailed-exitcode", "--no-color", "--normalize-manifests", "--three-way-merge", "--install", "--set=image.tag=abcdef",
 				"b", "c"},
 		},
 		"with multiple args": {
@@ -165,7 +165,7 @@ func TestAssembleHelmDiffArgs(t *testing.T) {
 			valuesFiles: []string{"secrets.yaml", "values.dev.yaml", "secrets.dev.yaml"},
 			cliValues:   []string{"--set=image.tag=abcdef", "--set=x=y"},
 			want: []string{"--namespace=a", "secrets", "diff", "upgrade",
-				"--detailed-exitcode", "--no-color",
+				"--detailed-exitcode", "--no-color", "--normalize-manifests",
 				"--three-way-merge", "--no-hooks", "--include-tests",
 				"--install", "--wait",
 				"--values=secrets.yaml", "--values=values.dev.yaml", "--values=secrets.dev.yaml",

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -77,7 +77,7 @@ fi
 echo "Installing Helm release ${RELEASE_NAME} ..."
 if [ "${DIFF}" == "true" ]; then
     if helm -n "${NAMESPACE}" \
-            "${DIFF_UPGRADE_ARGS[@]}" --install --detailed-exitcode --three-way-merge \
+            "${DIFF_UPGRADE_ARGS[@]}" --install --detailed-exitcode --three-way-merge --normalize-manifests \
             "${VALUES_ARGS[@]}" \
             ${RELEASE_NAME} ${CHART_DIR}; then
         echo "Helm release already up-to-date."


### PR DESCRIPTION
The change is applied to both the helm execution in the `ods-deploy-helm` task and in the install script.

Closes #591.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
