### PR TITLE
Handle scan errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ listed in the changelog.
 
 - Normalize K8s manifests to exclude style differences from Helm diff output. The change is applied to both the helm execution in the `ods-deploy-helm` task and in the install script. See [#591](https://github.com/opendevstack/ods-pipeline/issues/591).
 
+### Fixed
+- Errors during output collection of binaries such as `buildah`, `aqua-scanner` are not handled ([#611](https://github.com/opendevstack/ods-pipeline/issues/611))
+
 ## [0.7.0] - 2022-10-11
 
 ### Changed


### PR DESCRIPTION
Fixes #611.

Tasks: 
- [ ] Updated design documents in `docs/design` directory or not applicable
- [ ] Updated user-facing documentation in `docs` directory or not applicable
- [ ] Ran tests (e.g. `make test`) or not applicable
- [ ] Updated changelog or not applicable
