### PR TITLE
Handle interleaved output, scan errors, and stream more Helm output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ listed in the changelog.
 
 - Normalize K8s manifests to exclude style differences from Helm diff output. The change is applied to both the helm execution in the `ods-deploy-helm` task and in the install script. See [#591](https://github.com/opendevstack/ods-pipeline/issues/591).
 - Update skopeo (1.8 to 1.9) ([#616](https://github.com/opendevstack/ods-pipeline/issues/616))
+- Stream Helm upgrade log output ([#615](https://github.com/opendevstack/ods-pipeline/issues/615))
+
+### Fixed
+- Errors during output collection of binaries such as `buildah`, `aqua-scanner` are not handled ([#611](https://github.com/opendevstack/ods-pipeline/issues/611))
+- STDOUT and STDERR is not interleaved as expected ([#613](https://github.com/opendevstack/ods-pipeline/issues/613))
 
 ## [0.7.0] - 2022-10-11
 

--- a/cmd/build-push-image/aqua.go
+++ b/cmd/build-push-image/aqua.go
@@ -44,7 +44,7 @@ func aquaScanURL(opts options, aquaImage string) (string, error) {
 func aquaScan(exe string, args []string, outWriter, errWriter io.Writer) (bool, error) {
 	// STDERR contains the scan log output, hence we read it before STDOUT.
 	// STDOUT contains the scan summary (incl. ASCII table).
-	return command.RunWithStreamingOutput(
+	return command.RunWithSpecialFailureCode(
 		exe, args, []string{}, outWriter, errWriter, scanComplianceFailureExitCode,
 	)
 }

--- a/cmd/build-push-image/aqua.go
+++ b/cmd/build-push-image/aqua.go
@@ -44,7 +44,7 @@ func aquaScanURL(opts options, aquaImage string) (string, error) {
 func aquaScan(exe string, args []string, outWriter, errWriter io.Writer) (bool, error) {
 	// STDERR contains the scan log output, hence we read it before STDOUT.
 	// STDOUT contains the scan summary (incl. ASCII table).
-	return command.RunWithStreamingOutputReversed(
+	return command.RunWithStreamingOutput(
 		exe, args, []string{}, outWriter, errWriter, scanComplianceFailureExitCode,
 	)
 }

--- a/cmd/build-push-image/buildah.go
+++ b/cmd/build-push-image/buildah.go
@@ -13,6 +13,10 @@ import (
 	"github.com/opendevstack/pipeline/internal/command"
 )
 
+const (
+	buildahBin = "buildah"
+)
+
 // buildahBuild builds a local image using the Dockerfile and context directory
 // given in opts, tagging the resulting image with given tag.
 func buildahBuild(opts options, tag string, outWriter, errWriter io.Writer) error {
@@ -20,11 +24,7 @@ func buildahBuild(opts options, tag string, outWriter, errWriter io.Writer) erro
 	if err != nil {
 		return fmt.Errorf("assemble build args: %w", err)
 	}
-	_, err = command.RunWithStreamingOutput(
-		"buildah", args, []string{}, outWriter, errWriter,
-		-1, // no special exit code handling
-	)
-	return err
+	return command.Run(buildahBin, args, []string{}, outWriter, errWriter)
 }
 
 // buildahPush pushes a local image to the given imageRef.
@@ -44,14 +44,8 @@ func buildahPush(opts options, workingDir, imageRef string, outWriter, errWriter
 	if opts.debug {
 		args = append(args, "--log-level=debug")
 	}
-	_, err = command.RunWithStreamingOutput(
-		"buildah",
-		append(args, imageRef, fmt.Sprintf("docker://%s", imageRef)),
-		[]string{},
-		outWriter, errWriter,
-		-1, // no special exit code handling
-	)
-	return err
+	args = append(args, imageRef, fmt.Sprintf("docker://%s", imageRef))
+	return command.Run(buildahBin, args, []string{}, outWriter, errWriter)
 }
 
 // buildahBuildArgs assembles the args to be passed to buildah based on

--- a/cmd/build-push-image/main.go
+++ b/cmd/build-push-image/main.go
@@ -288,7 +288,7 @@ func getImageDigestFromRegistry(imageRef string, opts options) (string, error) {
 	if opts.debug {
 		args = append(args, "--debug")
 	}
-	stdout, _, err := command.Run("skopeo", append(args, "docker://"+imageRef))
+	stdout, _, err := command.RunBuffered("skopeo", append(args, "docker://"+imageRef))
 	return string(stdout), err
 }
 

--- a/cmd/deploy-with-helm/helm.go
+++ b/cmd/deploy-with-helm/helm.go
@@ -165,8 +165,12 @@ func commonHelmUpgradeArgs(
 }
 
 // helmUpgrade runs given Helm command.
-func helmUpgrade(args []string) (outBytes, errBytes []byte, err error) {
-	return command.RunWithExtraEnvs(helmBin, args, []string{fmt.Sprintf("SOPS_AGE_KEY_FILE=%s", ageKeyFilePath)})
+func helmUpgrade(args []string, stdout, stderr io.Writer) error {
+	_, err := command.RunWithStreamingOutput(
+		helmBin, args, []string{fmt.Sprintf("SOPS_AGE_KEY_FILE=%s", ageKeyFilePath)},
+		stdout, stderr, -1,
+	)
+	return err
 }
 
 // printlnSafeHelmCmd prints all args that do not contain sensitive information.

--- a/cmd/deploy-with-helm/helm.go
+++ b/cmd/deploy-with-helm/helm.go
@@ -39,7 +39,7 @@ type helmChart struct {
 func helmDiff(exe string, args []string, outWriter, errWriter io.Writer) (bool, error) {
 	// STDOUT contains the diff view.
 	// STDERR contains the summary statement.
-	return command.RunWithStreamingOutput(
+	return command.RunWithSpecialFailureCode(
 		exe, args, []string{
 			fmt.Sprintf("SOPS_AGE_KEY_FILE=%s", ageKeyFilePath),
 			"HELM_DIFF_IGNORE_UNKNOWN_FLAGS=true", // https://github.com/databus23/helm-diff/issues/278
@@ -166,11 +166,10 @@ func commonHelmUpgradeArgs(
 
 // helmUpgrade runs given Helm command.
 func helmUpgrade(args []string, stdout, stderr io.Writer) error {
-	_, err := command.RunWithStreamingOutput(
+	return command.Run(
 		helmBin, args, []string{fmt.Sprintf("SOPS_AGE_KEY_FILE=%s", ageKeyFilePath)},
-		stdout, stderr, -1,
+		stdout, stderr,
 	)
-	return err
 }
 
 // printlnSafeHelmCmd prints all args that do not contain sensitive information.
@@ -202,7 +201,7 @@ func packageHelmChart(chartDir, ctxtVersion, gitCommitSHA string, debug bool) (s
 	if debug {
 		helmPackageArgs = append(helmPackageArgs, "--debug")
 	}
-	stdout, stderr, err := command.Run(helmBin, append(helmPackageArgs, chartDir))
+	stdout, stderr, err := command.RunBuffered(helmBin, append(helmPackageArgs, chartDir))
 	if err != nil {
 		return "", fmt.Errorf(
 			"could not package chart %s. stderr: %s, err: %s", chartDir, string(stderr), err,

--- a/cmd/deploy-with-helm/main.go
+++ b/cmd/deploy-with-helm/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"io/fs"
 	"log"
 	"os"
@@ -389,13 +390,14 @@ func main() {
 		log.Fatal("assemble helm upgrade args: ", err)
 	}
 	printlnSafeHelmCmd(helmUpgradeArgs, os.Stdout)
-	stdout, stderr, err = helmUpgrade(helmUpgradeArgs)
+
+	var upgradeStdoutBuf bytes.Buffer
+	upgradeStdoutWriter := io.MultiWriter(os.Stdout, &upgradeStdoutBuf)
+	err = helmUpgrade(helmUpgradeArgs, upgradeStdoutWriter, os.Stderr)
 	if err != nil {
-		fmt.Println(string(stderr))
 		log.Fatal("helm upgrade: ", err)
 	}
-	fmt.Println(string(stdout))
-	err = writeDeploymentArtifact(stdout, "release", opts.chartDir, targetConfig.Name)
+	err = writeDeploymentArtifact(upgradeStdoutBuf.Bytes(), "release", opts.chartDir, targetConfig.Name)
 	if err != nil {
 		log.Fatal("write release artifact: ", err)
 	}

--- a/cmd/deploy-with-helm/main.go
+++ b/cmd/deploy-with-helm/main.go
@@ -216,7 +216,7 @@ func main() {
 			if opts.debug {
 				skopeoCopyArgs = append(skopeoCopyArgs, "--debug")
 			}
-			stdout, stderr, err := command.Run(
+			stdout, stderr, err := command.RunBuffered(
 				"skopeo", append(
 					skopeoCopyArgs,
 					fmt.Sprintf("docker://%s", srcImageURL),
@@ -236,7 +236,7 @@ func main() {
 	if opts.debug {
 		helmPluginArgs = append(helmPluginArgs, "--debug")
 	}
-	stdout, stderr, err := command.Run(helmBin, helmPluginArgs)
+	stdout, stderr, err := command.RunBuffered(helmBin, helmPluginArgs)
 	if err != nil {
 		fmt.Println(string(stderr))
 		log.Fatal(err)

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -380,7 +380,7 @@ func checkoutAndAssembleContext(
 		log.Fatal(err)
 	}
 	logger.Infof("Checking out %s@%s into %s ...", url, gitFullRef, absCheckoutDir)
-	stdout, stderr, err := command.Run("/ko-app/git-init", []string{
+	stdout, stderr, err := command.RunBuffered("/ko-app/git-init", []string{
 		"-url", url,
 		"-revision", gitFullRef,
 		"-refspec", gitRefSpec,
@@ -442,7 +442,7 @@ func getCommitSHA(dir string) (string, error) {
 }
 
 func gitLfsInUse(logger logging.LeveledLoggerInterface, dir string) (lfs bool, err error) {
-	stdout, stderr, err := command.RunInDir("git", []string{"lfs", "ls-files", "--all"}, dir)
+	stdout, stderr, err := command.RunBufferedInDir("git", []string{"lfs", "ls-files", "--all"}, dir)
 	if err != nil {
 		return false, fmt.Errorf("cannot list git lfs files: %s (%w)", stderr, err)
 	}
@@ -450,12 +450,12 @@ func gitLfsInUse(logger logging.LeveledLoggerInterface, dir string) (lfs bool, e
 }
 
 func gitLfsEnableAndPullFiles(logger logging.LeveledLoggerInterface, dir string) (err error) {
-	stdout, stderr, err := command.RunInDir("git", []string{"lfs", "install"}, dir)
+	stdout, stderr, err := command.RunBufferedInDir("git", []string{"lfs", "install"}, dir)
 	if err != nil {
 		return fmt.Errorf("cannot enable git lfs: %s (%w)", stderr, err)
 	}
 	logger.Infof(string(stdout))
-	stdout, stderr, err = command.RunInDir("git", []string{"lfs", "pull"}, dir)
+	stdout, stderr, err = command.RunBufferedInDir("git", []string{"lfs", "pull"}, dir)
 	if err != nil {
 		return fmt.Errorf("cannot git pull lfs files: %s (%w)", stderr, err)
 	}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 )
 
-func Run(executable string, args []string) (outBytes, errBytes []byte, err error) {
+func RunBuffered(executable string, args []string) (outBytes, errBytes []byte, err error) {
 	cmd := exec.Command(executable, args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -22,7 +22,7 @@ func Run(executable string, args []string) (outBytes, errBytes []byte, err error
 	return outBytes, errBytes, err
 }
 
-func RunInDir(executable string, args []string, wsDir string) (outBytes, errBytes []byte, err error) {
+func RunBufferedInDir(executable string, args []string, wsDir string) (outBytes, errBytes []byte, err error) {
 	cmd := exec.Command(executable, args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -34,45 +34,38 @@ func RunInDir(executable string, args []string, wsDir string) (outBytes, errByte
 	return outBytes, errBytes, err
 }
 
-func RunWithExtraEnvs(executable string, args []string, extraEnvs []string) (outBytes, errBytes []byte, err error) {
-	cmd := exec.Command(executable, args...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	newEnv := append(os.Environ(), extraEnvs...)
-	cmd.Env = newEnv
-	err = cmd.Run()
-	outBytes = stdout.Bytes()
-	errBytes = stderr.Bytes()
-	return outBytes, errBytes, err
-}
-
-// RunWithStreamingOutput invokes exe with given args and env. Stdout and stderr
-// are streamed to outWriter and errWriter, respectively. If exe errors with an
-// exit code equal to failureExitCode, no error is returned to the caller,
-// but success is false. If exe does not error, success is true.
-func RunWithStreamingOutput(exe string, args []string, env []string, outWriter, errWriter io.Writer, failureExitCode int) (success bool, err error) {
+// Run invokes exe with given args and env. Stdout and stderr
+// are streamed to outWriter and errWriter, respectively.
+func Run(exe string, args []string, env []string, outWriter, errWriter io.Writer) error {
 	cmd := exec.Command(exe, args...)
 	cmd.Env = append(os.Environ(), env...)
 	cmdStderr, err := cmd.StderrPipe()
 	if err != nil {
-		return false, fmt.Errorf("connect stderr pipe: %w", err)
+		return fmt.Errorf("connect stderr pipe: %w", err)
 	}
 	cmdStdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return false, fmt.Errorf("connect stdout pipe: %w", err)
+		return fmt.Errorf("connect stdout pipe: %w", err)
 	}
 	err = cmd.Start()
 	if err != nil {
-		return false, fmt.Errorf("start cmd: %w", err)
+		return fmt.Errorf("start cmd: %w", err)
 	}
 
 	err = collectOutput(cmdStdout, cmdStderr, outWriter, errWriter)
 	if err != nil {
-		return false, fmt.Errorf("collect output: %w", err)
+		return fmt.Errorf("collect output: %w", err)
 	}
 
-	err = cmd.Wait()
+	return cmd.Wait()
+}
+
+// RunWithSpecialFailureCode invokes exe with given args and env. Stdout and stderr
+// are streamed to outWriter and errWriter, respectively. If exe errors with an
+// exit code equal to failureExitCode, no error is returned to the caller,
+// but success is false. If exe does not error, success is true.
+func RunWithSpecialFailureCode(exe string, args []string, env []string, outWriter, errWriter io.Writer, failureExitCode int) (success bool, err error) {
+	err = Run(exe, args, env, outWriter, errWriter)
 	if err != nil {
 		var ee *exec.ExitError
 		if errors.As(err, &ee) && ee.ExitCode() == failureExitCode {

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -74,3 +74,21 @@ func TestRunWithStreamingOutputError(t *testing.T) {
 		t.Fatal("cmd should not be successful")
 	}
 }
+
+func TestInterleavedStdoutAndStderr(t *testing.T) {
+	var out bytes.Buffer
+	success, err := RunWithStreamingOutput(
+		"../../test/scripts/interleaved-output.sh", []string{}, []string{}, &out, &out, -1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantOut := "some stdout\nsome stderr\nmore stdout\nmore stderr\nstderr after sleep\nstdout after sleep"
+	if diff := cmp.Diff(wantOut+"\n", out.String()); diff != "" {
+		t.Fatalf("stdout mismatch (-want +got):\n%s", diff)
+	}
+	if !success {
+		t.Fatal("cmd should be successful")
+	}
+
+}

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -34,7 +34,7 @@ func TestRunWithStreamingOutput(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
-			driftDetected, err := RunWithStreamingOutput(
+			driftDetected, err := RunWithSpecialFailureCode(
 				"../../test/scripts/exit-with-code.sh",
 				[]string{"value of FOO=${FOO}", "log msg", strconv.Itoa(tc.cmdExitCode)},
 				[]string{"FOO=bar"},
@@ -64,7 +64,7 @@ func TestRunWithStreamingOutput(t *testing.T) {
 
 // TestRunWithStreamingOutputError covers the case when the aqua scanner cannot be invoked at all.
 func TestRunWithStreamingOutputError(t *testing.T) {
-	success, err := RunWithStreamingOutput(
+	success, err := RunWithSpecialFailureCode(
 		"./bogus.sh", []string{}, []string{}, &bytes.Buffer{}, &bytes.Buffer{}, -1,
 	)
 	if err == nil || err.Error() != "start cmd: fork/exec ./bogus.sh: no such file or directory" {
@@ -77,7 +77,7 @@ func TestRunWithStreamingOutputError(t *testing.T) {
 
 func TestInterleavedStdoutAndStderr(t *testing.T) {
 	var out bytes.Buffer
-	success, err := RunWithStreamingOutput(
+	success, err := RunWithSpecialFailureCode(
 		"../../test/scripts/interleaved-output.sh", []string{}, []string{}, &out, &out, -1,
 	)
 	if err != nil {

--- a/internal/docs/tasks.go
+++ b/internal/docs/tasks.go
@@ -78,7 +78,7 @@ func RenderTasks(sourceDir, targetDir string) error {
 	if _, err := os.Stat(sourceDir); os.IsNotExist(err) {
 		return err
 	}
-	stdout, stderr, err := command.RunInDir(
+	stdout, stderr, err := command.RunBufferedInDir(
 		"helm",
 		[]string{"template", "--values=values.docs.yaml", "."},
 		sourceDir,

--- a/pkg/sonar/report.go
+++ b/pkg/sonar/report.go
@@ -21,7 +21,7 @@ func (c *Client) GenerateReports(sonarProject, author, branch, rootPath, artifac
 		"-a", author,
 		branch,
 	}
-	stdout, stderr, err := command.Run("java", reportParams)
+	stdout, stderr, err := command.RunBuffered("java", reportParams)
 	if err != nil {
 		return fmt.Errorf(
 			"report generation failed: %w, stderr: %s, stdout: %s",

--- a/pkg/sonar/scan.go
+++ b/pkg/sonar/scan.go
@@ -67,7 +67,7 @@ func (c *Client) Scan(sonarProject, branch, commit string, pr *PullRequest) (str
 	// permission on the project is passed as "sonar.login" for authentication,
 	// see https://docs.sonarqube.org/latest/analysis/analysis-parameters/.
 	scannerParams = append(scannerParams, fmt.Sprintf("-Dsonar.login=%s", c.clientConfig.APIToken))
-	stdout, stderr, err := command.Run("sonar-scanner", scannerParams)
+	stdout, stderr, err := command.RunBuffered("sonar-scanner", scannerParams)
 	if err != nil {
 		return string(stdout), fmt.Errorf("scanning failed: %w, stderr: %s", err, string(stderr))
 	}

--- a/pkg/tasktesting/check.go
+++ b/pkg/tasktesting/check.go
@@ -26,7 +26,7 @@ var serviceMapping = map[Service]string{
 // Safeguard against running outside KinD
 func CheckCluster(t *testing.T, outsideKindAllowed bool) {
 	if !outsideKindAllowed {
-		stdout, stderr, err := command.Run("kubectl", []string{"config", "current-context"})
+		stdout, stderr, err := command.RunBuffered("kubectl", []string{"config", "current-context"})
 		if err != nil {
 			t.Fatalf("could not check current Kube context: %s, err: %s", string(stderr), err)
 		}

--- a/pkg/tasktesting/git.go
+++ b/pkg/tasktesting/git.go
@@ -103,38 +103,38 @@ func initAndCommitOrFatal(t *testing.T, wsDir string) {
 	if err := pipelinectxt.WriteGitIgnore(filepath.Join(wsDir, ".gitignore")); err != nil {
 		t.Fatalf("could not write .gitignore: %s", err)
 	}
-	stdout, stderr, err := command.RunInDir("git", []string{"init"}, wsDir)
+	stdout, stderr, err := command.RunBufferedInDir("git", []string{"init"}, wsDir)
 	if err != nil {
 		t.Fatalf("error running git init: %s, stdout: %s, stderr: %s", err, stdout, stderr)
 	}
-	stdout, stderr, err = command.RunInDir("git", []string{"config", "user.email", "testing@opendevstack.org"}, wsDir)
+	stdout, stderr, err = command.RunBufferedInDir("git", []string{"config", "user.email", "testing@opendevstack.org"}, wsDir)
 	if err != nil {
 		t.Fatalf("error running git config.user.email: %s, stdout: %s, stderr: %s", err, stdout, stderr)
 	}
-	stdout, stderr, err = command.RunInDir("git", []string{"config", "user.name", "testing"}, wsDir)
+	stdout, stderr, err = command.RunBufferedInDir("git", []string{"config", "user.name", "testing"}, wsDir)
 	if err != nil {
 		t.Fatalf("error running git config.user.name: %s, stdout: %s, stderr: %s", err, stdout, stderr)
 	}
-	stdout, stderr, err = command.RunInDir("git", []string{"add", "."}, wsDir)
+	stdout, stderr, err = command.RunBufferedInDir("git", []string{"add", "."}, wsDir)
 	if err != nil {
 		t.Fatalf("error running git add: %s, stdout: %s, stderr: %s", err, stdout, stderr)
 	}
-	stdout, stderr, err = command.RunInDir("git", []string{"commit", "-m", "initial commit"}, wsDir)
+	stdout, stderr, err = command.RunBufferedInDir("git", []string{"commit", "-m", "initial commit"}, wsDir)
 	if err != nil {
 		t.Fatalf("error running git commit: %s, stdout: %s, stderr: %s", err, stdout, stderr)
 	}
 }
 
 func PushFileToBitbucketOrFatal(t *testing.T, c *kclient.Clientset, ns, wsDir, branch, filename string) {
-	stdout, stderr, err := command.RunInDir("git", []string{"add", filename}, wsDir)
+	stdout, stderr, err := command.RunBufferedInDir("git", []string{"add", filename}, wsDir)
 	if err != nil {
 		t.Fatalf("failed to add file=%s: %s, stdout: %s, stderr: %s", filename, err, stdout, stderr)
 	}
-	stdout, stderr, err = command.RunInDir("git", []string{"commit", "-m", "update " + filename}, wsDir)
+	stdout, stderr, err = command.RunBufferedInDir("git", []string{"commit", "-m", "update " + filename}, wsDir)
 	if err != nil {
 		t.Fatalf("error running git commit: %s, stdout: %s, stderr: %s", err, stdout, stderr)
 	}
-	stdout, stderr, err = command.RunInDir("git", []string{"push", "origin", branch}, wsDir)
+	stdout, stderr, err = command.RunBufferedInDir("git", []string{"push", "origin", branch}, wsDir)
 	if err != nil {
 		t.Fatalf("failed to push to remote: %s, stdout: %s, stderr: %s", err, stdout, stderr)
 	}
@@ -169,11 +169,11 @@ func pushToBitbucketOrFatal(t *testing.T, c *kclient.Clientset, ns, wsDir, proje
 		fmt.Sprintf("http://%s:%s@", "admin", bbToken),
 		-1,
 	)
-	_, stderr, err := command.RunInDir("git", []string{"remote", "add", "origin", originURLWithCredentials}, wsDir)
+	_, stderr, err := command.RunBufferedInDir("git", []string{"remote", "add", "origin", originURLWithCredentials}, wsDir)
 	if err != nil {
 		t.Fatalf("failed to add remote origin=%s: %s, stderr: %s", originURL, err, stderr)
 	}
-	_, stderr, err = command.RunInDir("git", []string{"push", "-u", "origin", "master"}, wsDir)
+	_, stderr, err = command.RunBufferedInDir("git", []string{"push", "-u", "origin", "master"}, wsDir)
 	if err != nil {
 		t.Fatalf("failed to push to remote: %s, stderr: %s", err, stderr)
 	}
@@ -301,19 +301,19 @@ func createJpgRandomFileOrFatal(t *testing.T, wsDir, filename string) [32]byte {
 }
 
 func trackLfsJpgFileToBitbucketOrFatal(t *testing.T, wsDir, filename string) {
-	stdout, stderr, err := command.RunInDir("git", []string{"lfs", "track", "*.jpg"}, wsDir)
+	stdout, stderr, err := command.RunBufferedInDir("git", []string{"lfs", "track", "*.jpg"}, wsDir)
 	if err != nil {
 		t.Fatalf("failed to track %s as LFS file: %s, stdout: %s, stderr: %s", filename, err, stdout, stderr)
 	}
-	stdout, stderr, err = command.RunInDir("git", []string{"add", ".gitattributes", filename}, wsDir)
+	stdout, stderr, err = command.RunBufferedInDir("git", []string{"add", ".gitattributes", filename}, wsDir)
 	if err != nil {
 		t.Fatalf("error running git add: %s, stdout: %s, stderr: %s", err, stdout, stderr)
 	}
-	stdout, stderr, err = command.RunInDir("git", []string{"commit", "-m", "track as LFS file " + filename}, wsDir)
+	stdout, stderr, err = command.RunBufferedInDir("git", []string{"commit", "-m", "track as LFS file " + filename}, wsDir)
 	if err != nil {
 		t.Fatalf("error running git commit: %s, stdout: %s, stderr: %s", err, stdout, stderr)
 	}
-	stdout, stderr, err = command.RunInDir("git", []string{"push", "origin", "master"}, wsDir)
+	stdout, stderr, err = command.RunBufferedInDir("git", []string{"push", "origin", "master"}, wsDir)
 	if err != nil {
 		t.Fatalf("failed to push to remote: %s, stdout: %s, stderr: %s", err, stdout, stderr)
 	}

--- a/pkg/tasktesting/helper.go
+++ b/pkg/tasktesting/helper.go
@@ -60,7 +60,7 @@ func installCDNamespaceResources(t *testing.T, ns, serviceaccount string) {
 		scriptArgs = append(scriptArgs, "-v")
 	}
 
-	stdout, stderr, err := command.Run(
+	stdout, stderr, err := command.RunBuffered(
 		filepath.Join(projectpath.Root, "scripts/install-inside-kind.sh"),
 		scriptArgs,
 	)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -237,7 +237,7 @@ func waitForPipelineRunToBeDone(clientset *tekton.Clientset, ns, pr string, time
 }
 
 func kindControlPlaneIP() (string, error) {
-	stdout, stderr, err := command.Run(
+	stdout, stderr, err := command.RunBuffered(
 		"docker",
 		[]string{"inspect", "-f", "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}", "kind-control-plane"},
 	)
@@ -251,7 +251,7 @@ func pipelineRunLogs(namespace, name string) (string, error) {
 	if !tknInstalled() {
 		return "", errors.New("tkn is not installed, cannot show logs")
 	}
-	stdout, stderr, err := command.Run(
+	stdout, stderr, err := command.RunBuffered(
 		"tkn",
 		[]string{"pr", "logs", "-n", namespace, name},
 	)

--- a/test/scripts/interleaved-output.sh
+++ b/test/scripts/interleaved-output.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -ue
+
+bash -c 'sleep 1; >&2 echo stderr after sleep' &
+bash -c 'sleep 2; echo stdout after sleep' &
+
+echo "some stdout"
+sleep 0.1
+>&2 echo "some stderr"
+sleep 0.1
+echo "more stdout"
+sleep 0.1
+>&2 echo "more stderr"
+
+exit 0

--- a/test/tasks/ods-package-image_test.go
+++ b/test/tasks/ods-package-image_test.go
@@ -89,13 +89,13 @@ func TestTaskODSPackageImage(t *testing.T) {
 // verify that the image has not been rebuild in the task.
 func buildAndPushImageWithLabel(t *testing.T, ctxt *tasktesting.TaskRunContext, tag, wsDir string) {
 	t.Logf("Build image %s ahead of taskrun", tag)
-	_, stderr, err := command.Run("docker", []string{
+	_, stderr, err := command.RunBuffered("docker", []string{
 		"build", "--label", "tasktestrun=true", "-t", tag, filepath.Join(wsDir, "docker"),
 	})
 	if err != nil {
 		t.Fatalf("could not build image: %s, stderr: %s", err, string(stderr))
 	}
-	_, stderr, err = command.Run("docker", []string{
+	_, stderr, err = command.RunBuffered("docker", []string{
 		"push", tag,
 	})
 	if err != nil {
@@ -115,7 +115,7 @@ func checkResultingFiles(t *testing.T, ctxt *tasktesting.TaskRunContext, wsDir s
 }
 
 func checkLabelOnImage(t *testing.T, ctxt *tasktesting.TaskRunContext, wsDir, wantLabelKey, wantLabelValue string) {
-	stdout, stderr, err := command.Run("docker", []string{
+	stdout, stderr, err := command.RunBuffered("docker", []string{
 		"image", "inspect", "--format", "{{ index .Config.Labels \"" + wantLabelKey + "\"}}",
 		getDockerImageTag(t, ctxt, wsDir),
 	})
@@ -129,7 +129,7 @@ func checkLabelOnImage(t *testing.T, ctxt *tasktesting.TaskRunContext, wsDir, wa
 }
 
 func runResultingImage(t *testing.T, ctxt *tasktesting.TaskRunContext, wsDir string) string {
-	stdout, stderr, err := command.Run("docker", []string{
+	stdout, stderr, err := command.RunBuffered("docker", []string{
 		"run", "--rm",
 		getDockerImageTag(t, ctxt, wsDir),
 	})


### PR DESCRIPTION
Fixes #611.
Fixes #613.
Closes #615.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
