### PR TITLE
Update buildah from 1.26 to 1.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ listed in the changelog.
 
 - Normalize K8s manifests to exclude style differences from Helm diff output. The change is applied to both the helm execution in the `ods-deploy-helm` task and in the install script. See [#591](https://github.com/opendevstack/ods-pipeline/issues/591).
 - Update skopeo (1.8 to 1.9) ([#616](https://github.com/opendevstack/ods-pipeline/issues/616))
+- Update buildah (1.26 to 1.27) ([#626](https://github.com/opendevstack/ods-pipeline/issues/626))
 - Stream Helm upgrade log output ([#615](https://github.com/opendevstack/ods-pipeline/issues/615))
 
 ### Fixed

--- a/build/package/Dockerfile.buildah
+++ b/build/package/Dockerfile.buildah
@@ -17,7 +17,7 @@ RUN cd cmd/build-push-image && CGO_ENABLED=0 go build -o /usr/local/bin/ods-buil
 # and https://github.com/containers/buildah/blob/main/contrib/buildahimage/stable/Dockerfile.
 FROM registry.access.redhat.com/ubi8:8.4
 
-ENV BUILDAH_VERSION=1.26 \
+ENV BUILDAH_VERSION=1.27 \
     SKOPEO_VERSION=1.9
 
 COPY --from=builder /usr/local/bin/ods-build-push-image /usr/local/bin/ods-build-push-image

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -575,7 +575,7 @@ a| The script is supposed to be downloaded and piped into bash. The script insta
 
 | SDS-EXT-18
 | Buildah
-| 1.26
+| 1.27
 | Tool that facilitates building OCI images.
 | https://github.com/containers/buildah
 


### PR DESCRIPTION
Fixes #626.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
