### PR TITLE
Enable build task caching by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ listed in the changelog.
 - Update buildah (1.26 to 1.27) ([#626](https://github.com/opendevstack/ods-pipeline/issues/626))
 - Stream Helm upgrade log output ([#615](https://github.com/opendevstack/ods-pipeline/issues/615))
 - Update Go to 1.18 ([#623](https://github.com/opendevstack/ods-pipeline/issues/623))
+- Enable build skipping by default ([#642](https://github.com/opendevstack/ods-pipeline/issues/642))
 
 ### Fixed
 - Errors during output collection of binaries such as `buildah`, `aqua-scanner` are not handled ([#611](https://github.com/opendevstack/ods-pipeline/issues/611))

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-go.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-go.yaml
@@ -85,7 +85,7 @@ spec:
         a build can be skipped if the `working-dir` contents did not change.
         For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
       type: string
-      default: "false"
+      default: "true"
     - name: build-script
       description: >-
         Build script to execute. The

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-go.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-go.yaml
@@ -83,7 +83,7 @@ spec:
       description: >-
         If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that
         a build can be skipped if the `working-dir` contents did not change.
-        For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
+        You must set this to `"false"` if the build can be affected by files outside `working-dir`. See ADR caching-build-tasks for more details and workarounds.
       type: string
       default: "true"
     - name: build-script

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
@@ -148,7 +148,7 @@ spec:
         a build can be skipped if the `working-dir` contents did not change.
         For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
       type: string
-      default: "false"
+      default: "true"
     - name: build-script
       description: >-
         Build script to execute. The

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
@@ -146,7 +146,7 @@ spec:
       description: >-
         If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that
         a build can be skipped if the `working-dir` contents did not change.
-        For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
+        You must set this to `"false"` if the build can be affected by files outside `working-dir`. See ADR caching-build-tasks for more details and workarounds.
       type: string
       default: "true"
     - name: build-script

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-npm.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-npm.yaml
@@ -86,7 +86,7 @@ spec:
         a build can be skipped if the `working-dir` contents did not change.
         For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
       type: string
-      default: "false"
+      default: "true"
     - name: build-script
       description: >-
         Build script to execute. The

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-npm.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-npm.yaml
@@ -84,7 +84,7 @@ spec:
       description: >-
         If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that
         a build can be skipped if the `working-dir` contents did not change.
-        For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
+        You must set this to `"false"` if the build can be affected by files outside `working-dir`. See ADR caching-build-tasks for more details and workarounds.
       type: string
       default: "true"
     - name: build-script

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-python.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-python.yaml
@@ -60,7 +60,7 @@ spec:
         a build can be skipped if the `working-dir` contents did not change.
         For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
       type: string
-      default: "false"
+      default: "true"
     - name: max-line-length
       description: Maximum line length.
       type: string

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-python.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-python.yaml
@@ -58,7 +58,7 @@ spec:
       description: >-
         If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that
         a build can be skipped if the `working-dir` contents did not change.
-        For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
+        You must set this to `"false"` if the build can be affected by files outside `working-dir`. See ADR caching-build-tasks for more details and workarounds.
       type: string
       default: "true"
     - name: max-line-length

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -49,7 +49,7 @@ If the server edition supports it, the branch parameter shall be set, unless the
 
 | SDS-SHARED-4
 | `cache-build.sh` shell script
-a| Caches a build's outputs and ods artigacts to the `build-task` cache area.
+a| Caches a build's outputs and ods artifacts to the `build-task` cache area.
 
 Determines cache location at `$ROOT_DIR/.ods-cache/build-task/$CACHE_BUILD_KEY/$git_sha_working_dir`  where
 

--- a/docs/tasks/ods-build-go.adoc
+++ b/docs/tasks/ods-build-go.adoc
@@ -85,7 +85,7 @@ without leading `./` and trailing `/`.
 
 
 | cache-build
-| false
+| true
 | If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that a build can be skipped if the `working-dir` contents did not change. For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
 
 

--- a/docs/tasks/ods-build-go.adoc
+++ b/docs/tasks/ods-build-go.adoc
@@ -86,7 +86,7 @@ without leading `./` and trailing `/`.
 
 | cache-build
 | true
-| If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that a build can be skipped if the `working-dir` contents did not change. For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
+| If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that a build can be skipped if the `working-dir` contents did not change. You must set this to `"false"` if the build can be affected by files outside `working-dir`. See ADR caching-build-tasks for more details and workarounds.
 
 
 | build-script

--- a/docs/tasks/ods-build-gradle.adoc
+++ b/docs/tasks/ods-build-gradle.adoc
@@ -141,7 +141,7 @@ without leading `./` and trailing `/`.
 
 | cache-build
 | true
-| If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that a build can be skipped if the `working-dir` contents did not change. For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
+| If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that a build can be skipped if the `working-dir` contents did not change. You must set this to `"false"` if the build can be affected by files outside `working-dir`. See ADR caching-build-tasks for more details and workarounds.
 
 
 | build-script

--- a/docs/tasks/ods-build-gradle.adoc
+++ b/docs/tasks/ods-build-gradle.adoc
@@ -140,7 +140,7 @@ without leading `./` and trailing `/`.
 
 
 | cache-build
-| false
+| true
 | If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that a build can be skipped if the `working-dir` contents did not change. For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
 
 

--- a/docs/tasks/ods-build-npm.adoc
+++ b/docs/tasks/ods-build-npm.adoc
@@ -83,7 +83,7 @@ without leading `./` and trailing `/`.
 
 
 | cache-build
-| false
+| true
 | If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that a build can be skipped if the `working-dir` contents did not change. For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
 
 

--- a/docs/tasks/ods-build-npm.adoc
+++ b/docs/tasks/ods-build-npm.adoc
@@ -84,7 +84,7 @@ without leading `./` and trailing `/`.
 
 | cache-build
 | true
-| If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that a build can be skipped if the `working-dir` contents did not change. For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
+| If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that a build can be skipped if the `working-dir` contents did not change. You must set this to `"false"` if the build can be affected by files outside `working-dir`. See ADR caching-build-tasks for more details and workarounds.
 
 
 | build-script

--- a/docs/tasks/ods-build-python.adoc
+++ b/docs/tasks/ods-build-python.adoc
@@ -57,7 +57,7 @@ without leading `./` and trailing `/`.
 
 
 | cache-build
-| false
+| true
 | If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that a build can be skipped if the `working-dir` contents did not change. For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
 
 

--- a/docs/tasks/ods-build-python.adoc
+++ b/docs/tasks/ods-build-python.adoc
@@ -58,7 +58,7 @@ without leading `./` and trailing `/`.
 
 | cache-build
 | true
-| If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that a build can be skipped if the `working-dir` contents did not change. For single build repos enabling build caching has limited benefits. For multi build repos enabling this is recommended unless the build is dependant on files outside of the working directory. See ADR caching-build-tasks for more details and workarounds.
+| If enabled tasks uses or populates cache with the output dir contents (and artifacts) so that a build can be skipped if the `working-dir` contents did not change. You must set this to `"false"` if the build can be affected by files outside `working-dir`. See ADR caching-build-tasks for more details and workarounds.
 
 
 | max-line-length

--- a/test/tasks/ods-build-go_test.go
+++ b/test/tasks/ods-build-go_test.go
@@ -32,6 +32,7 @@ func TestTaskODSBuildGo(t *testing.T) {
 						"go-os":              runtime.GOOS,
 						"go-arch":            runtime.GOARCH,
 						"sonar-quality-gate": "true",
+						"cache-build":        "false",
 					}
 				},
 				WantRunSuccess: true,
@@ -79,7 +80,7 @@ func TestTaskODSBuildGo(t *testing.T) {
 						"go-os":              runtime.GOOS,
 						"go-arch":            runtime.GOARCH,
 						"sonar-quality-gate": "true",
-						"cache-build":        "true",
+						// "cache-build":        "true", expected to be default
 					}
 				},
 				WantRunSuccess: true,

--- a/test/tasks/ods-build-gradle_test.go
+++ b/test/tasks/ods-build-gradle_test.go
@@ -25,6 +25,7 @@ func TestTaskODSBuildGradle(t *testing.T) {
 					ctxt.ODS = tasktesting.SetupGitRepo(t, ctxt.Namespace, wsDir)
 					ctxt.Params = map[string]string{
 						"sonar-quality-gate": "true",
+						"cache-build":        "false",
 					}
 				},
 				WantRunSuccess: true,
@@ -61,7 +62,7 @@ func TestTaskODSBuildGradle(t *testing.T) {
 					ctxt.ODS = tasktesting.SetupGitRepo(t, ctxt.Namespace, wsDir)
 					ctxt.Params = map[string]string{
 						"sonar-quality-gate": "true",
-						"cache-build":        "true",
+						// "cache-build":        "true", is expected to be default
 					}
 				},
 				WantRunSuccess: true,

--- a/test/tasks/ods-build-npm_test.go
+++ b/test/tasks/ods-build-npm_test.go
@@ -27,6 +27,7 @@ func TestTaskODSBuildNPM(t *testing.T) {
 					ctxt.ODS = tasktesting.SetupGitRepo(t, ctxt.Namespace, wsDir)
 					ctxt.Params = map[string]string{
 						"sonar-quality-gate": "true",
+						"cache-build":        "false",
 					}
 				},
 				WantRunSuccess: true,
@@ -69,7 +70,7 @@ func TestTaskODSBuildNPM(t *testing.T) {
 						"sonar-skip":  "true",
 						"working-dir": subdir,
 						"output-dir":  "../docker",
-						"cache-build": "true",
+						// "cache-build": "true", expected to be default now
 					}
 				},
 				WantRunSuccess: true,

--- a/test/tasks/ods-build-python_test.go
+++ b/test/tasks/ods-build-python_test.go
@@ -27,6 +27,7 @@ func TestTaskODSBuildPython(t *testing.T) {
 					ctxt.ODS = tasktesting.SetupGitRepo(t, ctxt.Namespace, wsDir)
 					ctxt.Params = map[string]string{
 						"sonar-quality-gate": "true",
+						"cache-build":        "false",
 					}
 				},
 				WantRunSuccess: true,
@@ -70,7 +71,7 @@ func TestTaskODSBuildPython(t *testing.T) {
 					ctxt.ODS = tasktesting.SetupGitRepo(t, ctxt.Namespace, wsDir)
 					ctxt.Params = map[string]string{
 						"sonar-quality-gate": "true",
-						"cache-build":        "true",
+						// "cache-build": "true", expected to be default now
 					}
 				},
 				WantRunSuccess: true,
@@ -130,6 +131,7 @@ func TestTaskODSBuildPython(t *testing.T) {
 					ctxt.Params = map[string]string{
 						"sonar-quality-gate": "true",
 						"working-dir":        subdir,
+						"cache-build":        "true",
 					}
 				},
 				WantRunSuccess: true,


### PR DESCRIPTION
This build is meant to see which tests may need adjustment here.

Closes #642

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
