### PR TITLE
Update go-junit-report to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ listed in the changelog.
 - Update buildah (1.26 to 1.27) ([#626](https://github.com/opendevstack/ods-pipeline/issues/626))
 - Stream Helm upgrade log output ([#615](https://github.com/opendevstack/ods-pipeline/issues/615))
 - Update Go to 1.18 ([#623](https://github.com/opendevstack/ods-pipeline/issues/623))
+- Update go-junit-report to 2.0.0 ([#625](https://github.com/opendevstack/ods-pipeline/issues/625))
 - Enable build skipping by default ([#642](https://github.com/opendevstack/ods-pipeline/issues/642))
 
 ### Fixed

--- a/build/package/Dockerfile.go-toolset
+++ b/build/package/Dockerfile.go-toolset
@@ -4,12 +4,12 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
 
 ENV GOLANGCI_LINT_VERSION=v1.45.2 \
-    GO_JUNIT_REPORT_VERSION=v0.9.1 \
+    GO_JUNIT_REPORT_VERSION=v2.0.0 \
     GOBIN=/usr/local/bin
 
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$GOLANGCI_LINT_VERSION/install.sh | sh -s -- -b /usr/local/bin $GOLANGCI_LINT_VERSION
 
-RUN go install github.com/jstemmer/go-junit-report@$GO_JUNIT_REPORT_VERSION
+RUN go install github.com/jstemmer/go-junit-report/v2@$GO_JUNIT_REPORT_VERSION
 
 # Add scripts
 COPY build/package/scripts/cache-build.sh /usr/local/bin/cache-build

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -515,7 +515,7 @@ a| The script is supposed to be downloaded and piped into bash. The script insta
 
 | SDS-EXT-5
 | junit-report
-| 0.9
+| 2.0
 | Converts go test output to an xml report, suitable for applications that expect junit xml reports.
 | https://github.com/jstemmer/go-junit-report
 


### PR DESCRIPTION
Closes #625

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
