### PR TITLE
Ask for Bitbucket username during installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ listed in the changelog.
 
 ## [Unreleased]
 
+### Fixed
+
+- Installation does not ask for Bitbucket username ([#652](https://github.com/opendevstack/ods-pipeline/issues/652))
+
 ### Added
 
 - Add new default npm toolset with Node.js 18 ([#585](https://github.com/opendevstack/ods-pipeline/issues/585))

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -199,8 +199,8 @@ else
     installSecret "ods-bitbucket-auth" \
         "basic-auth-secret.yaml.tmpl" \
         "${BITBUCKET_AUTH}" \
-        "" \
-        "Please enter a personal access token of a Bitbucket user with project admin permission (input will be hidden):"
+        "Please enter the username of Bitbucket user with write permission." \
+        "Please enter a personal access token of this Bitbucket user (input will be hidden):"
 
     # Webhook secret is a special case, as we do not want the user to set it.
     # No prompts -> password will be auto-generated if not given.


### PR DESCRIPTION
Fixes #652.

Also, the Bitbucket user actually does not need admin permissions, write is enough.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
