### PR TITLE
Fix private cert issues discovered in manual testing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -125,7 +125,7 @@ jobs:
           go test -v ./cmd/... | sed ''/PASS/s//$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/''
           go test -v ./internal/... | sed ''/PASS/s//$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/''
           go test -v ./pkg/... | sed ''/PASS/s//$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/''
-          go test -timeout 30m -v ./test/tasks/... -always-keep-tmp-workspaces | sed ''/PASS/s//$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/''
+          go test -timeout 45m -v ./test/tasks/... -always-keep-tmp-workspaces | sed ''/PASS/s//$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/''
           go test -timeout 10m -v ./test/e2e/... | sed ''/PASS/s//$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/''
       -
         name: Log into ghcr.io

--- a/build/package/Dockerfile.start
+++ b/build/package/Dockerfile.start
@@ -4,11 +4,7 @@ ARG TARGETARCH
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
 
-ENV TEKTON_VERSION=0.24.0 \
-    TEKTONCD_PATH=/opt/app-root/src/go/src/github.com/tektoncd \
-    BINARY=git-init.orig \
-    KO_APP=/ko-app \
-    GIT_LFS_VERSION=3.0.2
+ENV GIT_LFS_VERSION=3.0.2
 
 # Build Go binary.
 RUN mkdir -p /etc/go
@@ -20,24 +16,13 @@ COPY internal /etc/go/internal
 COPY pkg /etc/go/pkg
 RUN cd /etc/go/cmd/start && CGO_ENABLED=0 go build -o /usr/local/bin/ods-start
 
-RUN mkdir -p $TEKTONCD_PATH && \
-    cd /tmp && \
-    curl -LO https://github.com/tektoncd/pipeline/archive/refs/tags/v$TEKTON_VERSION.tar.gz && \
-    tar -C $TEKTONCD_PATH -xzf v$TEKTON_VERSION.tar.gz && \
-    ln -s $TEKTONCD_PATH/pipeline-$TEKTON_VERSION $TEKTONCD_PATH/pipeline && \
-    cd -
-
-WORKDIR $TEKTONCD_PATH/pipeline
-
+# Install Git LFS.
 RUN cd /tmp \
     && mkdir -p /tmp/git-lfs \
     && curl -LO https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${TARGETARCH}-v${GIT_LFS_VERSION}.tar.gz \
     && tar -zxvf git-lfs-linux-${TARGETARCH}-v${GIT_LFS_VERSION}.tar.gz -C /tmp/git-lfs \
     && bash /tmp/git-lfs/install.sh \
     && git lfs version
-
-RUN CGO_ENABLED=0 go build -o /tmp/openshift-pipelines-git-init ./cmd/git-init && \
-    mkdir ${KO_APP} && cp /tmp/openshift-pipelines-git-init ${KO_APP}/${BINARY}
 
 # Final image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
@@ -53,14 +38,4 @@ COPY --from=builder /usr/local/bin/ods-start /usr/local/bin/ods-start
 COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
 RUN git lfs version
 
-RUN mkdir /ko-app
-COPY --from=builder /ko-app/git-init.orig /ko-app/git-init.orig
-COPY build/package/scripts/uidwrapper /ko-app/git-init
-
-USER root
-RUN chgrp -R 0 /ko-app && \
-    chmod -R g=u /ko-app /etc/passwd
-
 USER 1001
-
-ENTRYPOINT ["/ko-app/git-init"]

--- a/build/package/scripts/configure-gradle.sh
+++ b/build/package/scripts/configure-gradle.sh
@@ -4,15 +4,17 @@
 CONTENT=""
 
 if [ -f /etc/ssl/certs/private-cert.pem ]; then
-  echo "Configuring Gradle to trust private cert ..."
-  configure-truststore --dest-store ".ods-cache/truststore/cacerts"
-  # shellcheck disable=SC2181
-  if [ $? -ne 0 ]; then
-    exit 1
-  fi
-  # Configure Gradle to use the modified trust store.
-  CONTENT+="systemProp.javax.net.ssl.trustStore=.ods-cache/keystore/cacerts\n"
-  CONTENT+="systemProp.javax.net.ssl.trustStorePassword=password\n"
+	truststore_location="$(pwd)/.ods-cache/truststore/cacerts"
+	truststore_pass="changeit"
+	echo "Configuring Gradle to trust private cert ..."
+	configure-truststore --dest-store="${truststore_location}" --dest-storepass="${truststore_pass}"
+	# shellcheck disable=SC2181
+	if [ $? -ne 0 ]; then
+		exit 1
+	fi
+	# Configure Gradle to use the modified trust store.
+	CONTENT+="systemProp.javax.net.ssl.trustStore=${truststore_location}\n"
+	CONTENT+="systemProp.javax.net.ssl.trustStorePassword=${truststore_pass}\n"
 fi
 
 if [ "${HTTP_PROXY}" != "" ]; then

--- a/build/package/scripts/configure-truststore.sh
+++ b/build/package/scripts/configure-truststore.sh
@@ -53,4 +53,6 @@ if [ ! -f "${dest_truststore}" ] || [ "${md5_private_cert}" != "$(cat "${md5_pri
         cat keytool-output.txt; exit 1
     fi
     echo "${md5_private_cert}" > "${md5_private_cert_path}"
+else
+    echo "Trustore with private cert exists already and is up-to-date."
 fi

--- a/build/package/scripts/configure-truststore.sh
+++ b/build/package/scripts/configure-truststore.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -u
 
-md5_bin="${MD5_BIN:-"md5sum --tag"}"
+md5_bin="${MD5_BIN:-"md5sum"}"
 private_cert="/etc/ssl/certs/private-cert.pem"
 src_truststore="${JAVA_HOME}/lib/security/cacerts"
 src_pass="changeit"
@@ -30,7 +30,7 @@ esac; shift; done
 dest_truststore_dir="${dest_truststore%/*}"
 mkdir -p "${dest_truststore_dir}"
 md5_private_cert_path="${dest_truststore_dir}/.md5-private-cert"
-md5_private_cert=$(${md5_bin} "${private_cert}")
+md5_private_cert=$(${md5_bin} < "${private_cert}" | cut -d- -f1)
 
 if [ ! -f "${dest_truststore}" ] || [ "${md5_private_cert}" != "$(cat "${md5_private_cert_path}")" ]; then
     echo "Creating truststore with private cert ..."
@@ -40,6 +40,7 @@ if [ ! -f "${dest_truststore}" ] || [ "${md5_private_cert}" != "$(cat "${md5_pri
         -deststorepass "${dest_pass}" -srcstorepass "${src_pass}" &> keytool-output.txt
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then
+        echo "error importing keystore:"
         cat keytool-output.txt; exit 1
     fi
     # Trust private cert (hide output containing warnings).
@@ -48,6 +49,7 @@ if [ ! -f "${dest_truststore}" ] || [ "${md5_private_cert}" != "$(cat "${md5_pri
         -keystore "${dest_truststore}" -storepass "${dest_pass}" &> keytool-output.txt
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then
+        echo "error importing cert:"
         cat keytool-output.txt; exit 1
     fi
     echo "${md5_private_cert}" > "${md5_private_cert_path}"

--- a/build/package/scripts/configure-truststore.sh
+++ b/build/package/scripts/configure-truststore.sh
@@ -35,6 +35,9 @@ md5_private_cert=$(${md5_bin} < "${private_cert}" | cut -d- -f1)
 if [ ! -f "${dest_truststore}" ] || [ "${md5_private_cert}" != "$(cat "${md5_private_cert_path}")" ]; then
     echo "Creating truststore with private cert ..."
     # Copy global keystone to location where we can write to (hide output containing warnings).
+    if [ -f "${dest_truststore}" ]; then
+        rm "${dest_truststore}"
+    fi
     keytool -importkeystore \
         -srckeystore "${src_truststore}" -destkeystore "${dest_truststore}" \
         -deststorepass "${dest_pass}" -srcstorepass "${src_pass}" &> keytool-output.txt

--- a/build/package/scripts/download-aqua-scanner.sh
+++ b/build/package/scripts/download-aqua-scanner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-md5_bin="${MD5_BIN:-"md5sum --tag"}"
+md5_bin="${MD5_BIN:-"md5sum"}"
 aqua_scanner_url=""
 bin_dir=".ods-cache/bin"
 
@@ -26,7 +26,7 @@ md5_aqua_scanner_url_path="${bin_dir}/.md5-aquasec"
 # If the binary already exists and was downloaded from the
 # URL given by aqua_scanner_url, skip download.
 if [ -n "${aqua_scanner_url}" ] && [ "${aqua_scanner_url}" != "none" ]; then
-    md5_aqua_scanner_url=$(${md5_bin} -s "${aqua_scanner_url}")
+    md5_aqua_scanner_url=$(printf "%s" "${aqua_scanner_url}" | ${md5_bin} | cut -d- -f1)
     if [ ! -f "${md5_aqua_scanner_url_path}" ] || [ "${md5_aqua_scanner_url}" != "$(cat "${md5_aqua_scanner_url_path}")" ]; then
         echo 'Installing Aqua scanner...'
         curl -v -sSf -L "${aqua_scanner_url}" -o aquasec

--- a/build/package/scripts/download-aqua-scanner.sh
+++ b/build/package/scripts/download-aqua-scanner.sh
@@ -21,6 +21,7 @@ esac; shift; done
 
 aqua_scanner_path="${bin_dir}/aquasec"
 md5_aqua_scanner_url_path="${bin_dir}/.md5-aquasec"
+mkdir -p "${bin_dir}"
 
 # Optionally install Aqua scanner.
 # If the binary already exists and was downloaded from the
@@ -29,7 +30,7 @@ if [ -n "${aqua_scanner_url}" ] && [ "${aqua_scanner_url}" != "none" ]; then
     md5_aqua_scanner_url=$(printf "%s" "${aqua_scanner_url}" | ${md5_bin} | cut -d- -f1)
     if [ ! -f "${md5_aqua_scanner_url_path}" ] || [ "${md5_aqua_scanner_url}" != "$(cat "${md5_aqua_scanner_url_path}")" ]; then
         echo 'Installing Aqua scanner...'
-        curl -v -sSf -L "${aqua_scanner_url}" -o aquasec
+        curl -sSf -L "${aqua_scanner_url}" -o aquasec
         mv aquasec "${aqua_scanner_path}"
         chmod +x "${aqua_scanner_path}"
         echo "${md5_aqua_scanner_url}" > "${md5_aqua_scanner_url_path}"

--- a/deploy/ods-pipeline/charts/tasks/templates/_sonar-step.tpl
+++ b/deploy/ods-pipeline/charts/tasks/templates/_sonar-step.tpl
@@ -34,9 +34,9 @@
 
       truststore="${JAVA_HOME}/lib/security/cacerts"
       if [ -f /etc/ssl/certs/private-cert.pem ]; then
-        truststore=".ods-cache/truststore/cacerts"
+        truststore="$(pwd)/.ods-cache/truststore/cacerts"
+        configure-truststore --dest-store "${truststore}"
       fi
-      configure-truststore --dest-store "${truststore}"
       # sonar is built from cmd/sonar/main.go.
       sonar \
         -working-dir=$(params.working-dir) \

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-start.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-start.yaml
@@ -175,9 +175,9 @@ spec:
               name: ods-pipeline
       resources: {}
       script: |
-
         if [ -f /etc/ssl/certs/private-cert.pem ]; then
-          git config --global http.sslCAInfo /etc/ssl/certs/private-cert.pem
+          cat /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/private-cert.pem > /tekton/home/git-cert.pem
+          git config --global http.sslCAInfo /tekton/home/git-cert.pem
         fi
 
         # ods-start is built from cmd/start/main.go.

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -207,7 +207,7 @@ Input parameters: TODO
 
 | SDS-TASK-8
 | `ods-start` container image
-| Container image to start a pipeline. Based on `ubi8/ubi-minimal` (SDS-EXT-2), includes SDS-EXT-9, SDS-EXT-13, SDS-EXT-22, SDS-EXT-27, SDS-EXT-30 and SDS-TASK-9.
+| Container image to start a pipeline. Based on `ubi8/ubi-minimal` (SDS-EXT-2), includes SDS-EXT-9, SDS-EXT-13, SDS-EXT-27, SDS-EXT-30 and SDS-TASK-9.
 
 | SDS-TASK-9
 | `start` binary
@@ -615,12 +615,6 @@ a| The script installs the Helm chart located in `deploy/ods-pipeline`. Further,
 | 3.10
 | Manages secrets with Git workflow.
 | https://github.com/jkroepke/helm-secrets
-
-| SDS-EXT-22
-| Tekton
-| 0.24
-| Cloud-native Pipeline resource.
-| https://github.com/tektoncd/pipeline
 
 | SDS-EXT-23
 | Sops


### PR DESCRIPTION
This is a follow-up from #648. To make it easier to test #648 manually, we merged that before doing manual testing.

The issues addressed in this PR were not picked up in automated tests because:

* when `-private-cert` is given, the tests clone from a server using the test private cert, but in manual testing the server was using a public cert (and only Nexus/SQ were using private certs). While debugging this issue I replaced the usage of Tekton's `git-init` with plain git, making it easier to debug what is going on and removing a dependency in the container image that is not really needed.
* The md5 logic tests used the `md5` binary, and the `md5sum` binary in the UBI images behaves differently than expected, I got that mixed up when I tried `md5sum` locally in an UBI image earlier.
* The Gradle configure script was using some old paths, I assume I updated them after running the tests locally, and the GH tests do not actually execute the private cert path right now. Long-term we should enable this somehow.



Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
