### PR TITLE
Remove PVC use protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ listed in the changelog.
 
 - Node.js 18 is now the default for `ods-build-npm` task ([#585](https://github.com/opendevstack/ods-pipeline/issues/585))
 - Images used in tasks are now pulled directly from the GitHub registry. "Wrapping" the images in the OpenShift/K8s cluster is not required anymore. If tasks need to trust a private certificate, it needs to be present as a K8s secret, which will then be mounted as a file in the pods. To add the secret to an existing installation, pass `--private-cert <host>` to `./install.sh`. For more details, see [#621](https://github.com/opendevstack/ods-pipeline/issues/621).
+- Remove PVC use protection ([#647](https://github.com/opendevstack/ods-pipeline/issues/647))
 
 ### Fixed
 

--- a/internal/manager/pvc.go
+++ b/internal/manager/pvc.go
@@ -11,12 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	// Annotation to set the storage provisioner for a PVC.
-	storageProvisionerAnnotation = "volume.beta.kubernetes.io/storage-provisioner"
-	// PVC finalizer.
-	pvcProtectionFinalizer = "kubernetes.io/pvc-protection"
-)
+// Annotation to set the storage provisioner for a PVC.
+const storageProvisionerAnnotation = "volume.beta.kubernetes.io/storage-provisioner"
 
 // createPVCIfRequired if it does not exist yet
 func (s *Scheduler) createPVCIfRequired(ctxt context.Context, pData PipelineConfig) error {
@@ -30,7 +26,7 @@ func (s *Scheduler) createPVCIfRequired(ctxt context.Context, pData PipelineConf
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        pData.PVC,
 				Labels:      map[string]string{repositoryLabel: pData.Repository},
-				Finalizers:  []string{pvcProtectionFinalizer},
+				Finalizers:  []string{},
 				Annotations: map[string]string{},
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{


### PR DESCRIPTION
It often gets in the way of cleaning up, and does not provide value for us as the PVC should not contain any data that isn't safe to throw away.

Closes #647.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
