### PR TITLE
Drop OpenSSL

### DIFF
--- a/build/package/Dockerfile.finish
+++ b/build/package/Dockerfile.finish
@@ -15,8 +15,5 @@ RUN cd cmd/finish && CGO_ENABLED=0 go build -o /usr/local/bin/ods-finish
 # Final image
 # ubi-micro cannot be used as it misses the ca-certificates package.
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
-ENV OPENSSL_VERSION=1.1
 COPY --from=builder /usr/local/bin/ods-finish /usr/local/bin/ods-finish
-RUN microdnf install --nodocs openssl-${OPENSSL_VERSION}* && microdnf clean all
-
 USER 1001

--- a/build/package/Dockerfile.gradle-toolset
+++ b/build/package/Dockerfile.gradle-toolset
@@ -3,7 +3,6 @@ FROM registry.access.redhat.com/ubi8/openjdk-17:1.13
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV GIT_VERSION=2.31 \
-    OPENSSL_VERSION=1.1 \
     GRADLE_VERSION=7.4.2 \
     GRADLE_USER_HOME=/workspace/source/.ods-cache/deps/gradle
 
@@ -12,7 +11,7 @@ ARG GRADLE_WRAPPER_DOWNLOAD_SHA256=29e49b10984e585d8118b7d0bc452f944e386458df273
 
 USER root
 
-RUN microdnf install --nodocs openssl-${OPENSSL_VERSION}* git-${GIT_VERSION}* && microdnf clean all
+RUN microdnf install --nodocs git-${GIT_VERSION}* && microdnf clean all
 
 # Install Gradle
 RUN cd /opt && \

--- a/build/package/Dockerfile.helm
+++ b/build/package/Dockerfile.helm
@@ -46,12 +46,11 @@ ENV HELM_PLUGIN_DIFF_VERSION=3.3.2 \
     SKOPEO_VERSION=1.9 \
     TAR_VERSION=1.30 \
     GIT_VERSION=2.31 \
-    FINDUTILS_VERSION=4.6 \
-    OPENSSL_VERSION=1.1
+    FINDUTILS_VERSION=4.6
 
 # helm-secrets depends on xargs (from GNU findutils) in it's signal handlers,
 # c.f. https://github.com/jkroepke/helm-secrets/blob/main/scripts/commands/helm.sh#L34-L36
-RUN microdnf install --nodocs openssl-${OPENSSL_VERSION}* skopeo-${SKOPEO_VERSION}* git-${GIT_VERSION}* tar-${TAR_VERSION}* findutils-${FINDUTILS_VERSION}* && microdnf clean all
+RUN microdnf install --nodocs skopeo-${SKOPEO_VERSION}* git-${GIT_VERSION}* tar-${TAR_VERSION}* findutils-${FINDUTILS_VERSION}* && microdnf clean all
 
 COPY --from=builder /usr/local/bin/deploy-helm /usr/local/bin/deploy-helm
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm

--- a/build/package/Dockerfile.pipeline-manager
+++ b/build/package/Dockerfile.pipeline-manager
@@ -15,10 +15,7 @@ RUN cd cmd/pipeline-manager && CGO_ENABLED=0 go build -o /usr/local/bin/pipeline
 # Final image
 # ubi-micro cannot be used as it misses the ca-certificates package.
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
-ENV OPENSSL_VERSION=1.1
-RUN microdnf install --nodocs openssl-${OPENSSL_VERSION}* && microdnf clean all
 COPY --from=builder /usr/local/bin/pipeline-manager /usr/local/bin/pipeline-manager
-
 EXPOSE 8080
 CMD pipeline-manager
 USER 1001

--- a/build/package/Dockerfile.sonar
+++ b/build/package/Dockerfile.sonar
@@ -32,10 +32,9 @@ RUN cd /tmp \
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ENV SONAR_EDITION="community" \
-    OPENSSL_VERSION=1.1 \
     JAVA_HOME=/usr/lib/jvm/jre-11
 
-RUN microdnf install --nodocs openssl-${OPENSSL_VERSION}* java-11-openjdk-headless which && microdnf clean all
+RUN microdnf install --nodocs java-11-openjdk-headless which && microdnf clean all
 
 COPY --from=builder /usr/local/bin/sonar /usr/local/bin/sonar
 COPY --from=builder /usr/local/sonar-scanner-cli /usr/local/sonar-scanner-cli

--- a/build/package/Dockerfile.start
+++ b/build/package/Dockerfile.start
@@ -28,10 +28,9 @@ RUN cd /tmp \
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ENV GIT_VERSION=2.31 \
-    OPENSSH_CLIENTS_VERSION=8.0 \
-    OPENSSL_VERSION=1.1
+    OPENSSH_CLIENTS_VERSION=8.0
 
-RUN microdnf install --nodocs openssl-${OPENSSL_VERSION}* git-${GIT_VERSION}* openssh-clients-${OPENSSH_CLIENTS_VERSION}* && microdnf clean all
+RUN microdnf install --nodocs git-${GIT_VERSION}* openssh-clients-${OPENSSH_CLIENTS_VERSION}* && microdnf clean all
 
 COPY --from=builder /usr/local/bin/ods-start /usr/local/bin/ods-start
 

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -665,12 +665,6 @@ a| The script installs the Helm chart located in `deploy/ods-pipeline`. Further,
 | Basic directory searching utilities, included due to the dependency of `helm-secrets` on `xargs`
 | https://www.gnu.org/software/findutils/
 
-| SDS-EXT-30
-| OpenSSL
-| 1.1
-| Toolkit for general-purpose cryptography and secure communication.
-| https://www.openssl.org
-
 | SDS-EXT-31
 | Trivy
 | 0.36.0


### PR DESCRIPTION
No longer needed - it was installed to download the private cert in the wrapper images.

Follow up from #648.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
