### PR TITLE
relax patterns for environment name but also cover namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ listed in the changelog.
 
 - npm-toolset tests fail with new release of ubi8 Node.js image ([#650](https://github.com/opendevstack/ods-pipeline/issues/650))
 - Installation does not ask for Bitbucket username ([#652](https://github.com/opendevstack/ods-pipeline/issues/652))
+- e2e environment name not allowed ([#634](https://github.com/opendevstack/ods-pipeline/issues/634))
 
 ## [0.8.0] - 2023-01-06
 

--- a/cmd/deploy-helm/steps.go
+++ b/cmd/deploy-helm/steps.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/opendevstack/pipeline/internal/command"
@@ -114,6 +115,11 @@ func setReleaseTarget() DeployStep {
 		d.releaseNamespace = targetConfig.Namespace
 		if d.releaseNamespace == "" {
 			d.releaseNamespace = fmt.Sprintf("%s-%s", d.ctxt.Project, targetConfig.Name)
+		}
+		pattern := "^[a-z][a-z0-9-]{0,61}[a-z]$"
+		matched, err := regexp.MatchString(pattern, d.releaseNamespace)
+		if err != nil || !matched {
+			return d, fmt.Errorf("release namespace: %s must match %s", d.releaseNamespace, pattern)
 		}
 		d.logger.Infof("Release namespace: %s", d.releaseNamespace)
 

--- a/docs/ods-configuration.adoc
+++ b/docs/ods-configuration.adoc
@@ -116,7 +116,7 @@ environments:
   stage: dev
 ----
 
-The value of `name` may freely be chosen, but must only contain lowercase `a-z` and dashes (`-`). The `stage` must be one of `dev`, `qa` or `prod`. Each environment corresponds to one namespace in an OpenShift/Kubernetes cluster. The namespace may either be specified explicitly (via `namespace`), or it will be computed based on the project and the environment name (`<PROJECT>-<ENV-NAME>`). In the example above, `namespace` is not configured, therefore the target namespace will be resolved to `foo-development` (if the project is named `foo`).
+The value of `name` may freely be chosen, but must begin and end with a lowercase `a-z` and can use `a-z0-9` and (`-`) in between. The `stage` must be one of `dev`, `qa` or `prod`. Each environment corresponds to one namespace in an OpenShift/Kubernetes cluster. The namespace may either be specified explicitly (via `namespace`), or it will be computed based on the project and the environment name (`<PROJECT>-<ENV-NAME>`). In the example above, `namespace` is not configured, therefore the target namespace will be resolved to `foo-development` (if the project is named `foo`). If `namespace` is specified it must follow the same rules as the `name` described above.
 
 Environments may also be located external to the cluster in which the pipeline runs. In this case, an environment may specify further fields:
 

--- a/pkg/config/ods.go
+++ b/pkg/config/ods.go
@@ -139,10 +139,16 @@ func (e Environment) Validate() error {
 	if len(e.Name) == 0 {
 		return errors.New("name of environment must not be blank")
 	}
-	pattern := "^[a-z-]*$"
+	pattern := "^[a-z][a-z0-9-]*[a-z]$"
 	matched, err := regexp.MatchString(pattern, e.Name)
 	if err != nil || !matched {
 		return fmt.Errorf("name of environment must match %s", pattern)
+	}
+	if len(e.Namespace) != 0 {
+		matched, err = regexp.MatchString(pattern, e.Namespace)
+		if err != nil || !matched {
+			return fmt.Errorf("namespace of environment must match %s", pattern)
+		}
 	}
 	switch e.Stage {
 	case DevStage, QAStage, ProdStage:

--- a/pkg/config/ods_test.go
+++ b/pkg/config/ods_test.go
@@ -27,6 +27,10 @@ func TestReadFromFile(t *testing.T) {
 	if gotStage != ProdStage {
 		t.Fatalf("Got %s, want prod", gotStage)
 	}
+	gotName := ods.Environments[0].Name
+	if gotName != "e2e" {
+		t.Fatalf("Got %s, want e2e", gotName)
+	}
 }
 
 func TestReadFromSimplifiedFormatFile(t *testing.T) {
@@ -97,17 +101,36 @@ environments:
 			Fixture: []byte(`environments:
 - name: "Hello World!"
   stage: dev`),
-			WantError: "name of environment must match ^[a-z-]*$",
+			WantError: "name of environment must match ^[a-z][a-z0-9-]*[a-z]$",
 		},
 		"invalid name - uppercase": {
 			Fixture: []byte(`environments:
 - name: "DEVenv"
   stage: dev`),
-			WantError: "name of environment must match ^[a-z-]*$",
+			WantError: "name of environment must match ^[a-z][a-z0-9-]*[a-z]$",
+		},
+		"invalid name - starts with number": {
+			Fixture: []byte(`environments:
+- name: "2to"
+  stage: dev`),
+			WantError: "name of environment must match ^[a-z][a-z0-9-]*[a-z]$",
+		},
+		"invalid namespace - starts with number": {
+			Fixture: []byte(`environments:
+- name: "e2e"
+  namespace: "2to"
+  stage: dev`),
+			WantError: "namespace of environment must match ^[a-z][a-z0-9-]*[a-z]$",
 		},
 		"valid": {
 			Fixture: []byte(`environments:
 - name: foo-qa
+  stage: qa`),
+			WantError: "",
+		},
+		"valid2": {
+			Fixture: []byte(`environments:
+- name: e2e-q
   stage: qa`),
 			WantError: "",
 		},

--- a/test/testdata/fixtures/config/ods.yaml
+++ b/test/testdata/fixtures/config/ods.yaml
@@ -1,3 +1,3 @@
 environments:
-- name: foo
+- name: e2e
   stage: prod


### PR DESCRIPTION
Relaxes environment name enforcements.

This also introduces a check of an environment namespace if specified in `ods.yaml` and another check that the overall name is not too long and fits the expected patterns

Fixes #634

Tasks: 
- [NA] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
