### PR TITLE
Use Go 1.19 for building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ listed in the changelog.
 - Node.js 18 is now the default for `ods-build-npm` task ([#585](https://github.com/opendevstack/ods-pipeline/issues/585))
 - Images used in tasks are now pulled directly from the GitHub registry. "Wrapping" the images in the OpenShift/K8s cluster is not required anymore. If tasks need to trust a private certificate, it needs to be present as a K8s secret, which will then be mounted as a file in the pods. To add the secret to an existing installation, pass `--private-cert <host>` to `./install.sh`. For more details, see [#621](https://github.com/opendevstack/ods-pipeline/issues/621).
 - Remove PVC use protection ([#647](https://github.com/opendevstack/ods-pipeline/issues/647))
+- Use Go 1.19 for building ([#659](https://github.com/opendevstack/ods-pipeline/issues/659))
 
 ### Fixed
 

--- a/build/package/Dockerfile.finish
+++ b/build/package/Dockerfile.finish
@@ -1,7 +1,8 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18 AS builder
+FROM golang:1.19 as builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
+WORKDIR /usr/src/app
 
 # Build Go binary.
 COPY go.mod .

--- a/build/package/Dockerfile.helm
+++ b/build/package/Dockerfile.helm
@@ -1,9 +1,10 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18 AS builder
+FROM golang:1.19 as builder
 
 ARG TARGETARCH
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
+WORKDIR /usr/src/app
 
 ENV HELM_VERSION=3.5.2 \
     SOPS_VERSION=3.7.1 \

--- a/build/package/Dockerfile.package-image
+++ b/build/package/Dockerfile.package-image
@@ -1,7 +1,8 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18 AS builder
+FROM golang:1.19 as builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
+WORKDIR /usr/src/app
 
 # Build Go binary.
 COPY go.mod .

--- a/build/package/Dockerfile.pipeline-manager
+++ b/build/package/Dockerfile.pipeline-manager
@@ -1,7 +1,8 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18 AS builder
+FROM golang:1.19 as builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
+WORKDIR /usr/src/app
 
 # Build Go binary.
 COPY go.mod .

--- a/build/package/Dockerfile.sonar
+++ b/build/package/Dockerfile.sonar
@@ -1,7 +1,8 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18 AS builder
+FROM golang:1.19 as builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
+WORKDIR /usr/src/app
 
 ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     CNES_REPORT_VERSION=3.2.2
@@ -16,7 +17,8 @@ COPY pkg pkg
 RUN cd cmd/sonar && CGO_ENABLED=0 go build -o /usr/local/bin/sonar
 
 # Install Sonar Scanner.
-RUN cd /tmp \
+RUN apt-get update && apt-get install -y unzip \
+    && cd /tmp \
     && curl -LO https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/${SONAR_SCANNER_VERSION}/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
     && unzip sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
     && mv sonar-scanner-${SONAR_SCANNER_VERSION} /usr/local/sonar-scanner-cli

--- a/build/package/Dockerfile.start
+++ b/build/package/Dockerfile.start
@@ -1,8 +1,10 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18 AS builder
+FROM golang:1.19 as builder
 
 ARG TARGETARCH
+
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
+WORKDIR /usr/src/app
 
 ENV GIT_LFS_VERSION=3.0.2
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendevstack/pipeline
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/go-cmp v0.5.8

--- a/test/tasks/ods-package-image_test.go
+++ b/test/tasks/ods-package-image_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/opendevstack/pipeline/pkg/logging"
 	"github.com/opendevstack/pipeline/pkg/pipelinectxt"
 	"github.com/opendevstack/pipeline/pkg/tasktesting"
-	"k8s.io/utils/strings/slices"
+	"golang.org/x/exp/slices"
 )
 
 func TestTaskODSPackageImage(t *testing.T) {


### PR DESCRIPTION
Triggered by experimenting with `log/slog`, which requires `atomic.Int64`, which was added in Go 1.19. I would have used Go 1.20 but it is not available via homebrew yet.

This will be handy in #656. I wanted to extract it into its own PR to isolate potential issues arising from the changed builder image.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
