### PR TITLE
Simplify HTTP JSON handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ listed in the changelog.
 - Images used in tasks are now pulled directly from the GitHub registry. "Wrapping" the images in the OpenShift/K8s cluster is not required anymore. If tasks need to trust a private certificate, it needs to be present as a K8s secret, which will then be mounted as a file in the pods. To add the secret to an existing installation, pass `--private-cert <host>` to `./install.sh`. For more details, see [#621](https://github.com/opendevstack/ods-pipeline/issues/621).
 - Remove PVC use protection ([#647](https://github.com/opendevstack/ods-pipeline/issues/647))
 - Use Go 1.19 for building ([#659](https://github.com/opendevstack/ods-pipeline/issues/659))
+- Pipeline manager now returns `application/problem+json` when it encounters an error. Further, it now returns different, better fitting error status codes for some responses. See ([#661](https://github.com/opendevstack/ods-pipeline/issues/661)) for details.
 
 ### Fixed
 

--- a/cmd/pipeline-manager/main.go
+++ b/cmd/pipeline-manager/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/opendevstack/pipeline/internal/httpjson"
 	kubernetesClient "github.com/opendevstack/pipeline/internal/kubernetes"
 	"github.com/opendevstack/pipeline/internal/manager"
 	tektonClient "github.com/opendevstack/pipeline/internal/tekton"
@@ -202,7 +203,7 @@ func serve() error {
 
 	mux := http.NewServeMux()
 	mux.Handle("/health", http.HandlerFunc(health))
-	mux.Handle("/bitbucket", http.HandlerFunc(r.Handle))
+	mux.Handle("/bitbucket", httpjson.Handler(r.Handle))
 	logger.Infof("Ready to accept requests!")
 	return http.ListenAndServe(":8080", mux)
 }

--- a/internal/httpjson/handler.go
+++ b/internal/httpjson/handler.go
@@ -1,0 +1,42 @@
+package httpjson
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+// Handler is an HTTP handler implementing http.Handler.
+type Handler func(w http.ResponseWriter, r *http.Request) (any, error)
+
+// ServeHTTP implements http.Handler.
+// If an error is returned from h, it is converted to a JSON error.
+// Otherwise, the returned value is JSON encoded.
+func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	res, err := h(w, r)
+	if err != nil {
+		var pd ProblemDetailer
+		if pe, ok := err.(ProblemDetailer); ok {
+			pd = pe
+		} else {
+			pd = &StatusProblem{Status: http.StatusInternalServerError, Err: err}
+		}
+		log.Println(pd)
+		JSONError(w, pd.ProblemDetail(), pd.Code())
+		return
+	}
+	if err := json.NewEncoder(w).Encode(res); err != nil {
+		log.Println(err)
+		JSONError(w, "internal server error", http.StatusInternalServerError)
+	}
+}
+
+// JSONError is https://pkg.go.dev/net/http#Error, but for JSON.
+func JSONError(w http.ResponseWriter, err interface{}, code int) {
+	w.Header().Set("Content-Type", "application/problem+json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(code)
+	if e := json.NewEncoder(w).Encode(err); e != nil {
+		log.Println(e)
+	}
+}

--- a/internal/httpjson/handler_test.go
+++ b/internal/httpjson/handler_test.go
@@ -1,0 +1,31 @@
+package httpjson
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandler(t *testing.T) {
+	ts := httptest.NewServer(Handler(func(w http.ResponseWriter, r *http.Request) (any, error) {
+		return nil, NewInternalProblem("foo", nil)
+	}))
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	greeting, err := io.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := `{"title":"Internal Server Error","detail":"foo"}`
+	if strings.TrimSpace(string(greeting)) != want {
+		t.Fatal("not euqal, got", string(greeting))
+	}
+}

--- a/internal/httpjson/problem.go
+++ b/internal/httpjson/problem.go
@@ -1,0 +1,68 @@
+package httpjson
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// ProblemDetailer should be implemented by any error that has should
+// be encoded as a specific RFC 7807 problem detail.
+type ProblemDetailer interface {
+	ProblemDetail() any
+	Code() int
+}
+
+// StatusProblem is basically an error with an HTTP status code.
+type StatusProblem struct {
+	Status int    `json:"-"`
+	Detail string `json:"detail,omitempty"`
+	Err    error
+}
+
+// NewInternalProblem returns a StatusProblem with code 500.
+func NewInternalProblem(detail string, err error) *StatusProblem {
+	return NewStatusProblem(http.StatusInternalServerError, detail, err)
+}
+
+// NewStatusProblem is a helper to create a StatusProblem.
+func NewStatusProblem(code int, detail string, err error) *StatusProblem {
+	return &StatusProblem{Status: code, Detail: detail, Err: err}
+}
+
+// ProblemDetail turns p into a RFC 7807 problem detail.
+func (p *StatusProblem) ProblemDetail() any {
+	return &defaultProblem{
+		Title:  p.title(),
+		Detail: p.Detail,
+		Status: p.Status,
+		err:    p.Err,
+	}
+}
+
+// Code returns the HTTP status code of p.
+func (p *StatusProblem) Code() int {
+	return p.Status
+}
+
+func (p *StatusProblem) String() string {
+	return fmt.Sprintf("%s: %s: %s", p.title(), p.Detail, p.Err.Error())
+}
+
+func (p *StatusProblem) Error() string {
+	return p.String()
+}
+
+func (p *StatusProblem) title() string {
+	return http.StatusText(p.Status)
+}
+
+// defaultProblem is a basic RFC 7807 problem detail.
+// It wraps an error as that is the typical source of a problem.
+type defaultProblem struct {
+	Type     string `json:"type,omitempty"`
+	Title    string `json:"title,omitempty"`
+	Status   int    `json:"-"`
+	Detail   string `json:"detail,omitempty"`
+	Instance string `json:"instance,omitempty"`
+	err      error
+}


### PR DESCRIPTION
* Implement a small type to handle returning and logging errors centrally
* Change some status codes
* Return JSON, not plain text

Tasks: 
- [ ] Updated design documents in `docs/design` directory or not applicable
- [ ] Updated user-facing documentation in `docs` directory or not applicable
- [ ] Ran tests (e.g. `make test`) or not applicable
- [ ] Updated changelog or not applicable
