### PR TITLE
Set dependency on start task for all parallel tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ listed in the changelog.
 ### Fixed
 
 - `ods-start` is unable to cleanup workspace for some storage configurations due to changes in `ods-package-image` ([#672](https://github.com/opendevstack/ods-pipeline/issues/672))
+- `runAfter: [start]` not set for all parallel tasks ([#671](https://github.com/opendevstack/ods-pipeline/issues/671))
 
 ## [0.10.0] - 2023-02-27
 

--- a/internal/manager/pipeline.go
+++ b/internal/manager/pipeline.go
@@ -143,8 +143,16 @@ func assemblePipelineSpec(cfg PipelineConfig, taskKind tekton.TaskKind, taskSuff
 			tektonStringParam("version", "$(params.version)"),
 		},
 	})
+
 	if len(cfg.Tasks) > 0 {
-		cfg.Tasks[0].RunAfter = append(cfg.Tasks[0].RunAfter, "start")
+		// Add "start" to runAfter of the first configured task, and to each further task
+		// that does not set runAfter until we hit a task that does.
+		for i := range cfg.Tasks {
+			if i > 0 && len(cfg.Tasks[i].RunAfter) > 0 {
+				break
+			}
+			cfg.Tasks[i].RunAfter = append(cfg.Tasks[i].RunAfter, "start")
+		}
 		tasks = append(tasks, cfg.Tasks...)
 	}
 


### PR DESCRIPTION
Fixes #671

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
