### PR TITLE
Escape slashes before passing the strings on to sed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ listed in the changelog.
 
 ### Fixed
 
+- Setup of secrets during `install.sh` does not work if secret contains `/` ([#670](https://github.com/opendevstack/ods-pipeline/issues/670))
 - `ods-start` is unable to cleanup workspace for some storage configurations due to changes in `ods-package-image` ([#672](https://github.com/opendevstack/ods-pipeline/issues/672))
 
 ## [0.10.0] - 2023-02-27

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -133,8 +133,11 @@ kubectlApplySecret () {
     local secretTemplate="$2"
     local username="$3"
     local password="$4"
+    # Render variables into template, then apply.
+    # To avoid forward slashes messing up sed, escape forward slashes first.
+    # See https://tldp.org/LDP/abs/html/string-manipulation.html.
     # shellcheck disable=SC2002
-    cat "${secretTemplate}" | sed "s/{{name}}/${secretName}/" | sed "s/{{username}}/${username}/" | sed "s/{{password}}/${password}/" | "${KUBECTL_BIN}" -n "${NAMESPACE}" apply -f -
+    cat "${secretTemplate}" | sed "s/{{name}}/${secretName}/" | sed "s/{{username}}/${username//\//\\/}/" | sed "s/{{password}}/${password//\//\\/}/" | "${KUBECTL_BIN}" -n "${NAMESPACE}" apply -f -
 }
 
 installSecret () {


### PR DESCRIPTION
Fixes #670

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
