### PR TITLE
Task/remove local skopeo dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ listed in the changelog.
 
 ## [Unreleased]
 
+### Fixed
+
+- make create-kind-with-registry failed locally on mac ([#679](https://github.com/opendevstack/ods-pipeline/issues/679))
+
 ## [0.11.0] - 2023-03-14
 
 ### Changed

--- a/scripts/kind-with-registry.sh
+++ b/scripts/kind-with-registry.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
-#	
-# Adapted from:	
-# https://github.com/kubernetes-sigs/kind/commits/master/site/static/examples/kind-with-registry.sh	
-#	
-# Copyright 2020 The Kubernetes Project	
-#	
-# Licensed under the Apache License, Version 2.0 (the "License");	
-# you may not use this file except in compliance with the License.	
-# You may obtain a copy of the License at	
-#	
-#     http://www.apache.org/licenses/LICENSE-2.0	
-#	
-# Unless required by applicable law or agreed to in writing, software	
-# distributed under the License is distributed on an "AS IS" BASIS,	
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.	
-# See the License for the specific language governing permissions and	
+#
+# Adapted from:
+# https://github.com/kubernetes-sigs/kind/commits/master/site/static/examples/kind-with-registry.sh
+#
+# Copyright 2020 The Kubernetes Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 set -o errexit
@@ -76,7 +76,7 @@ if [ "${running}" != 'true' ]; then
   if [ "${reg_network}" != "bridge" ]; then
     docker network create "${reg_network}" || true
   fi
-  
+
   docker run \
     -d --restart=always -p "${REGISTRY_PORT}:5000" --name "${REGISTRY_NAME}" --net "${reg_network}" \
     registry:2
@@ -103,7 +103,11 @@ nodes:
   extraMounts:
   - hostPath: ${ODS_PIPELINE_DIR}/test
     containerPath: /files
-containerdConfigPatches: 
+  kubeadmConfigPatches:
+  - |
+    kind: KubeletConfiguration
+    cgroupDriver: systemd
+containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${REGISTRY_PORT}"]
     endpoint = ["http://${reg_ip}:${REGISTRY_PORT}"]

--- a/test/tasks/ods-package-image_test.go
+++ b/test/tasks/ods-package-image_test.go
@@ -130,21 +130,19 @@ func checkTagFiles(t *testing.T, ctxt *tasktesting.TaskRunContext, wsDir string,
 func checkTags(t *testing.T, ctxt *tasktesting.TaskRunContext, wsDir string, expectedTags []string) {
 	// registry := "kind-registry.kind:5000"
 	registry := "localhost:5000"
-	tlsVerify := false
 	args := []string{
 		"inspect",
 		`--format={{.RepoTags}}`,
-		fmt.Sprintf("--tls-verify=%v", tlsVerify),
 	}
 	imageNsStreamSha := fmt.Sprintf("%s/%s:%s", ctxt.Namespace, ctxt.ODS.Component, ctxt.ODS.GitCommitSHA)
-	imageRef := fmt.Sprintf("docker://%s/%s", registry, imageNsStreamSha)
+	imageRef := fmt.Sprintf("%s/%s", registry, imageNsStreamSha)
 	args = append(args, imageRef)
 
-	stdout, _, err := command.RunBuffered("skopeo", args)
+	stdout, _, err := command.RunBuffered("docker", args)
 	if err != nil {
-		t.Fatalf("skopeo inspect %s: %s", fmt.Sprint(args), err)
+		t.Fatalf("docker %s: %s", fmt.Sprint(args), err)
 	}
-	tags, err := parseSkopeoInspectDigestTags(string(stdout))
+	tags, err := parseDockerInspectDigestTags(string(stdout))
 	if err != nil {
 		t.Fatalf("parse tags failed: %s", err)
 	}
@@ -155,10 +153,10 @@ func checkTags(t *testing.T, ctxt *tasktesting.TaskRunContext, wsDir string, exp
 	}
 }
 
-func parseSkopeoInspectDigestTags(out string) ([]string, error) {
+func parseDockerInspectDigestTags(out string) ([]string, error) {
 	t := strings.TrimSpace(out)
 	if !(strings.HasPrefix(t, "[") && strings.HasSuffix(t, "]")) {
-		return nil, fmt.Errorf("skopeo inspect: unexpected tag response expecting tags to be in brackets %s", t)
+		return nil, fmt.Errorf("docker inspect: unexpected tag response expecting tags to be in brackets %s", t)
 	}
 	t = t[1 : len(t)-1]
 	// expecting t to have space separated tags.


### PR DESCRIPTION
At the moment this does not work, but I am not sure why. 
Tag related commands from log excerpt [gh-issue-662-docker-tags-not-working.log](https://github.com/opendevstack/ods-pipeline/files/11002953/gh-issue-662-docker-tags-not-working.log):

```
INFO  | skopeo copy docker://kind-registry.kind:5000/npjhnsyo/workspace-280637196:3cd3a01e4f8924ae17e4273543b5d6739ce3dc32 docker://kind-registry.kind:5000/npjhnsyo/workspace-280637196:latest

INFO  | skopeo copy docker://kind-registry.kind:5000/npjhnsyo/workspace-280637196:3cd3a01e4f8924ae17e4273543b5d6739ce3dc32 docker://kind-registry.kind:5000/npjhnsyo/workspace-280637196:cool

```
And then the local test command:

```
ods-package-image_test.go:143: docker [inspect --format={{.RepoTags}} localhost:5000/npjhnsyo/workspace-280637196:3cd3a01e4f8924ae17e4273543b5d6739ce3dc32]: exit status 1
```

exit status 1 means that the image is not found.

Now when I comment out the checkTags invocation, run the test and then locally issue the command it does find the image and associated manifest:

```bash
$docker inspect --format={{.RepoTags}} localhost:5000/lmxlhpwy/workspace-2456216427:3507037f00154c62410142e770df87fbed35db20
[localhost:5000/lmxlhpwy/workspace-2456216427:3507037f00154c62410142e770df87fbed35db20 localhost:5000/lmxlhpwy/workspace-2456216427:cool localhost:5000/lmxlhpwy/workspace-2456216427:latest]
```



Closes opendevstack/ods-pipeline-image#4


Tasks: 
- [ ] Updated design documents in `docs/design` directory or not applicable
- [ ] Updated user-facing documentation in `docs` directory or not applicable
- [ ] Ran tests (e.g. `make test`) or not applicable
- [ ] Updated changelog or not applicable
- [ ]
