### PR TITLE
Include build directory in github file search

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+build/** linguist-generated=false


### PR DESCRIPTION
By default the `build` directory is excluded from the github filesearch.

**See:**
https://docs.github.com/en/search-github/searching-on-github/finding-files-on-github#customizing-excluded-files

This PR configures the `build` directory to be included in the github filesearch.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
