### PR TITLE
Configure Git to use bearer token auth mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ listed in the changelog.
 
 ### Fixed
 
-- make create-kind-with-registry failed locally on mac ([#679](https://github.com/opendevstack/ods-pipeline/issues/679))
+- Configure Git to use bearer token auth mechanism ([#683](https://github.com/opendevstack/ods-pipeline/issues/683))
+- `make create-kind-with-registry` failed locally on Mac ([#679](https://github.com/opendevstack/ods-pipeline/issues/679))
 
 ## [0.11.0] - 2023-03-14
 

--- a/cmd/start/git.go
+++ b/cmd/start/git.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/opendevstack/pipeline/internal/command"
+	"github.com/opendevstack/pipeline/pkg/logging"
+)
+
+// gitCheckoutParams holds the parameters configuring the checkout.
+type gitCheckoutParams struct {
+	repoURL              string
+	bitbucketAccessToken string
+	recurseSubmodules    string
+	depth                string
+	gitFullRef           string
+}
+
+// gitCheckout encapsulates the steps required to perform a Git checkout
+func gitCheckout(p gitCheckoutParams) (err error) {
+	steps := [][]string{
+		{"init"},
+		// Even though Tekton prepares credentials to be used for each task,
+		// we set the auth explicitly here. The motivation is that Tekton uses
+		// basic auth to pass the username/token, which fails in environments
+		// that have basic auth disabled for Bitbucket.
+		{"config",
+			fmt.Sprintf("http.%s.extraHeader", p.repoURL),
+			fmt.Sprintf("Authorization: Bearer %s", p.bitbucketAccessToken),
+		},
+		{"config",
+			fmt.Sprintf("http.%s/info/lfs.extraHeader", p.repoURL),
+			fmt.Sprintf("Authorization: Bearer %s", p.bitbucketAccessToken),
+		},
+		{"remote", "add", "origin", p.repoURL},
+		{"fetch",
+			fmt.Sprintf("--recurse-submodules=%s", p.recurseSubmodules), fmt.Sprintf("--depth=%s", p.depth),
+			"origin", "--update-head-ok", "--force", p.gitFullRef,
+		},
+		{"checkout", "-f", "FETCH_HEAD"},
+	}
+	for _, args := range steps {
+		if err == nil {
+			err = runGitCmd(args...)
+		}
+	}
+	return
+}
+
+// runGitCmd executes git with given args.
+func runGitCmd(args ...string) error {
+	var output bytes.Buffer
+	err := command.Run("git", args, []string{}, &output, &output)
+	if err != nil {
+		return fmt.Errorf("git %v: %w\n%s", args, err, output.String())
+	}
+	return nil
+}
+
+func getCommitSHA(dir string) (string, error) {
+	content, err := os.ReadFile(filepath.Join(dir, ".git/HEAD"))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(content)), nil
+}
+
+func gitLfsInUse(logger logging.LeveledLoggerInterface, dir string) (lfs bool, err error) {
+	stdout, stderr, err := command.RunBufferedInDir("git", []string{"lfs", "ls-files", "--all"}, dir)
+	if err != nil {
+		return false, fmt.Errorf("cannot list git lfs files: %s (%w)", stderr, err)
+	}
+	return strings.TrimSpace(string(stdout)) != "", err
+}
+
+func gitLfsEnableAndPullFiles(logger logging.LeveledLoggerInterface, dir string) (err error) {
+	stdout, stderr, err := command.RunBufferedInDir("git", []string{"lfs", "install"}, dir)
+	if err != nil {
+		return fmt.Errorf("lfs install: %s (%w)", stderr, err)
+	}
+	logger.Infof(string(stdout))
+	stdout, stderr, err = command.RunBufferedInDir("git", []string{"lfs", "pull"}, dir)
+	if err != nil {
+		return fmt.Errorf("lfs pull: %s (%w)", stderr, err)
+	}
+	logger.Infof(string(stdout))
+	return err
+}

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-start.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-start.yaml
@@ -17,10 +17,6 @@ spec:
       description: 'Git revision to checkout (branch, tag, sha, ref, ...)'
       type: string
       default: ''
-    - name: refspec
-      description: (Optional) Git refspec to fetch before checking out revision.
-      type: string
-      default: ''
     - name: submodules
       description: Defines if the resource should initialize and fetch the submodules.
       type: string
@@ -31,12 +27,6 @@ spec:
         fetched.
       type: string
       default: '1'
-    - name: ssl-verify
-      description: >-
-        Defines if http.sslVerify should be set to `true` or `false` in the global
-        Git config.
-      type: string
-      default: 'true'
     - name: http-proxy
       description: Git HTTP proxy server for non-SSL requests.
       type: string
@@ -154,14 +144,12 @@ spec:
           -environment=$(params.environment) \
           -version=$(params.version) \
           -git-full-ref=$(params.git-full-ref) \
-          -git-ref-spec=$(params.refspec) \
           -url=$(params.url) \
           -pr-key=$(params.pr-key) \
           -pr-base=$(params.pr-base) \
           -http-proxy=$(params.http-proxy) \
           -https-proxy=$(params.https-proxy) \
           -no-proxy=$(params.no-proxy) \
-          -ssl-verify=$(params.ssl-verify) \
           -submodules=$(params.submodules) \
           -depth=$(params.depth) \
           -pipeline-run-name=$(params.pipeline-run-name)

--- a/docs/tasks/ods-start.adoc
+++ b/docs/tasks/ods-start.adoc
@@ -55,11 +55,6 @@ by the pipeline manager and cannot be customized by users at this point.*
 | Git revision to checkout (branch, tag, sha, ref, ...)
 
 
-| refspec
-| 
-| (Optional) Git refspec to fetch before checking out revision.
-
-
 | submodules
 | true
 | Defines if the resource should initialize and fetch the submodules.
@@ -68,11 +63,6 @@ by the pipeline manager and cannot be customized by users at this point.*
 | depth
 | 1
 | Performs a shallow clone where only the most recent commit(s) will be fetched.
-
-
-| ssl-verify
-| true
-| Defines if http.sslVerify should be set to `true` or `false` in the global Git config.
 
 
 | http-proxy

--- a/tasks/ods-start.yaml
+++ b/tasks/ods-start.yaml
@@ -19,10 +19,6 @@ spec:
       description: 'Git revision to checkout (branch, tag, sha, ref, ...)'
       type: string
       default: ''
-    - name: refspec
-      description: (Optional) Git refspec to fetch before checking out revision.
-      type: string
-      default: ''
     - name: submodules
       description: Defines if the resource should initialize and fetch the submodules.
       type: string
@@ -33,12 +29,6 @@ spec:
         fetched.
       type: string
       default: '1'
-    - name: ssl-verify
-      description: >-
-        Defines if http.sslVerify should be set to `true` or `false` in the global
-        Git config.
-      type: string
-      default: 'true'
     - name: http-proxy
       description: Git HTTP proxy server for non-SSL requests.
       type: string
@@ -156,14 +146,12 @@ spec:
           -environment=$(params.environment) \
           -version=$(params.version) \
           -git-full-ref=$(params.git-full-ref) \
-          -git-ref-spec=$(params.refspec) \
           -url=$(params.url) \
           -pr-key=$(params.pr-key) \
           -pr-base=$(params.pr-base) \
           -http-proxy=$(params.http-proxy) \
           -https-proxy=$(params.https-proxy) \
           -no-proxy=$(params.no-proxy) \
-          -ssl-verify=$(params.ssl-verify) \
           -submodules=$(params.submodules) \
           -depth=$(params.depth) \
           -pipeline-run-name=$(params.pipeline-run-name)


### PR DESCRIPTION
Tekton prepares the creds to be used through basic auth, which fails when the Bitbucket server has basic auth disabled.

Fixes #683

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
