### PR TITLE
adding an installation hint

### DIFF
--- a/deploy/ods-pipeline/values.yaml
+++ b/deploy/ods-pipeline/values.yaml
@@ -1,3 +1,12 @@
+# -----------------------  Installation hint  -----------------------
+#                          !!! Important !!!
+#  This is the default values file - if you're editing this as
+#  part of the ODS pipeline installation you're in the wrong file!
+#
+#  Please open ../values.yaml (the file you have created by making
+#  a copy of ../values.yaml.tmpl) and do your changes there.
+# -----------------------  Installation hint  -----------------------
+
 # ####################################### #
 # UMBRELLA                                #
 # ####################################### #


### PR DESCRIPTION
To avoid users get confused which file to actually edit during installation of ODS pipelines, I added hint (in form of a comment) to the file you should not edit

Tasks: 
- [ n/a ] Updated design documents in `docs/design` directory or not applicable
- [ n/a ] Updated user-facing documentation in `docs` directory or not applicable
- [ n/a ] Ran tests (e.g. `make test`) or not applicable
- [ n/a ] Updated changelog or not applicable
