### PR TITLE
remove addition of deprecated config value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ listed in the changelog.
 
 ## [Unreleased]
 
-### Changed
+### Fixed
 
 - Removed addition of `always-auth=true` to the npm config file for nodeJS builds ([#687](https://github.com/opendevstack/ods-pipeline/issues/687))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ listed in the changelog.
 
 ## [Unreleased]
 
+### Changed
+
+- Removed addition of `always-auth=true` to the npm config file for nodeJS builds ([#687](https://github.com/opendevstack/ods-pipeline/issues/687))
+
 ## [0.11.1] - 2023-03-31
 
 ### Fixed

--- a/build/package/scripts/build-npm.sh
+++ b/build/package/scripts/build-npm.sh
@@ -71,7 +71,6 @@ NEXUS_HOST=$(echo "${NEXUS_URL}" | sed -E 's/^\s*.*:\/\///g')
 if [ -n "${NEXUS_URL}" ] && [ -n "${NEXUS_USERNAME}" ] && [ -n "${NEXUS_PASSWORD}" ]; then
     NEXUS_AUTH="$(urlencode "${NEXUS_USERNAME}"):$(urlencode "${NEXUS_PASSWORD}")"
     npm config set registry="$NEXUS_URL"/repository/npmjs/
-    npm config set always-auth=true
     npm config set "//${NEXUS_HOST}/repository/npmjs/:_auth"="$(echo -n "$NEXUS_AUTH" | base64)"
     npm config set email=no-reply@opendevstack.org
     if [ -f /etc/ssl/certs/private-cert.pem ]; then


### PR DESCRIPTION
Fix for #687

Removing the addition of the deprecated (and according to the documentation unused and wrongly documented) config parameter `always-auth=true`

Tasks: 
- [ ] Updated design documents in `docs/design` directory or not applicable -> `n/a`
- [ ] Updated user-facing documentation in `docs` directory or not applicable -> `n/a`
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
