### PR TITLE
Do not error when no matching pipeline can be found

### DIFF
--- a/docs/ods-configuration.adoc
+++ b/docs/ods-configuration.adoc
@@ -142,6 +142,8 @@ The following selection criteria may be specified:
 `exceptTags`:: List of tags to which the triggering event may not refer. Patterns as supported by link:https://pkg.go.dev/path#Match[`path.Match`] may be used to match the excluded tags. Omitting the criterion will lead to none of the tags referred to in the webhook event to be excluded.
 `prComment`:: Define a prefix a comment has to start with. Might be used to implement functionality like slash commands. If omitted, comments won't be considered in the pipeline selection process.
 
+CAUTION: link:https://pkg.go.dev/path#Match[`path.Match`] does not match e.g. `feature/foo` when the pattern is just `\*`. If you want to match strings with slashes, specify the pattern `*/\*` as well. For example, to match all branches, write `branches: ["*", "\*/*"]`.
+
 Currently, the Bitbucket events `repo:refs_changed` (fired on push to a Bitbucket repository) and any Pull Request related events (event types with prefix `pr:`) are supported (for a full list of events, please refer to the link:https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html[Atlassian Bitbucket Documentation]). Only the first trigger matching all conditions will be selected. If no trigger section is specified, the pipeline will always match.
 
 ==== Passing parameters

--- a/test/testdata/fixtures/manager/non-matching-trigger-ods.yaml
+++ b/test/testdata/fixtures/manager/non-matching-trigger-ods.yaml
@@ -1,0 +1,11 @@
+pipelines:
+- triggers:
+  - branches: ["should-never-match"]
+  tasks:
+  - name: build
+    taskRef:
+      kind: Task
+      name: ods-build-go
+    workspaces:
+      - name: source
+        workspace: shared-workspace


### PR DESCRIPTION
Returning an error does not seem appropriate because there can be situations in which no pipeline should match which are "expected". For example, one might configure to act on PR comments of "/deploy", but for all other PR comment (events), nothing should happen.

The log will still report that there was no matching pipeline so that users can figure out what is going on.

The issue was introduced in #685. Since that has not been released yet, the bugfix will not be recorded in the changelog.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
