### PR TITLE
Perform non-shallow clone by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ listed in the changelog.
 
 ### Changed
 
+- Perform non-shallow clone by default ([#164](https://github.com/opendevstack/ods-pipeline/issues/164))
 - Update Git from 2.31 to 2.39 ([#693](https://github.com/opendevstack/ods-pipeline/pull/693))
 - Update Skopeo from 1.9 to 1.11 ([#693](https://github.com/opendevstack/ods-pipeline/pull/693))
 - Update Buildah from 1.27 to 1.29 ([#693](https://github.com/opendevstack/ods-pipeline/pull/693))

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -34,7 +34,7 @@ type options struct {
 	url                    string
 	gitFullRef             string
 	submodules             string
-	depth                  string
+	cloneDepth             string
 	cacheBuildTasksForDays int
 	debug                  bool
 }
@@ -52,7 +52,7 @@ func main() {
 	flag.StringVar(&opts.url, "url", ".", "URL to clone")
 	flag.StringVar(&opts.gitFullRef, "git-full-ref", "", "Git (full) ref to clone")
 	flag.StringVar(&opts.submodules, "submodules", "true", "defines if the resource should initialize and fetch the submodules")
-	flag.StringVar(&opts.depth, "depth", "1", "performs a shallow clone where only the most recent commit(s) will be fetched")
+	flag.StringVar(&opts.cloneDepth, "clone-depth", "", "perform a shallow clone where only the most recent commit(s) will be fetched")
 	flag.IntVar(&opts.cacheBuildTasksForDays, "cache-build-tasks-for-days", 7, "the number of days build outputs are cached. A negative number can be used to clear the cache.")
 	flag.StringVar(&opts.consoleURL, "console-url", os.Getenv("CONSOLE_URL"), "web console URL")
 	flag.StringVar(&opts.pipelineRunName, "pipeline-run-name", "", "name of pipeline run")
@@ -312,8 +312,8 @@ func checkoutAndAssembleContext(
 		repoURL:              url,
 		bitbucketAccessToken: opts.bitbucketAccessToken,
 		recurseSubmodules:    opts.submodules,
-		depth:                opts.depth,
-		gitFullRef:           gitFullRef,
+		depth:                opts.cloneDepth,
+		fullRef:              gitFullRef,
 	}); err != nil {
 		return nil, fmt.Errorf("git checkout: %w", err)
 	}

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-start.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-start.yaml
@@ -21,12 +21,13 @@ spec:
       description: Defines if the resource should initialize and fetch the submodules.
       type: string
       default: 'true'
-    - name: depth
+    - name: clone-depth
       description: >-
-        Performs a shallow clone where only the most recent commit(s) will be
-        fetched.
+        Perform a shallow clone where only the most recent commit(s) will be
+        fetched. By default, a full clone is performed. Note that the parameter is of string type,
+        therefore the depth value must be quoted, e.g. `value: '1'`.
       type: string
-      default: '1'
+      default: ''
     - name: http-proxy
       description: Git HTTP proxy server for non-SSL requests.
       type: string
@@ -134,7 +135,7 @@ spec:
           -https-proxy=$(params.https-proxy) \
           -no-proxy=$(params.no-proxy) \
           -submodules=$(params.submodules) \
-          -depth=$(params.depth) \
+          -clone-depth=$(params.clone-depth) \
           -pipeline-run-name=$(params.pipeline-run-name) \
           -artifact-source=$(params.artifact-source)
 

--- a/docs/design/software-design-specification.adoc
+++ b/docs/design/software-design-specification.adoc
@@ -211,7 +211,7 @@ Input parameters: TODO
 
 | SDS-TASK-9
 | `start` binary
-a| The task checks out the repository of a given URL and Git ref into the mounted workspace, cleaning previous contents, except for the caching area at `./ods-cache`. If the checked out `ods.y(a)ml` configures any child repositories, those are checked out as well from the configured URL and Git ref (either tag or branch, defaulting to `master`). All checkouts are by default shallow (depth=1) and include submodules.
+a| The task checks out the repository of a given URL and Git ref into the mounted workspace, cleaning previous contents, except for the caching area at `./ods-cache`. If the checked out `ods.y(a)ml` configures any child repositories, those are checked out as well from the configured URL and Git ref (either tag or branch, defaulting to `master`). All checkouts are by default non-shallow and include submodules.
 
 A build task may store cached dependencies under directory `.ods-cache/deps/<technology-name>/` where technology-name provides a namespace. For example this could be 'npm' if at some point in the future this would be supported. The task deletes files in folder `.ods-cache/deps/`. All other files in `.ods-cache` are reserved for future use. While they are not removed you must not rely on those locations except for experimentation.
 

--- a/docs/design/software-requirements-specification.adoc
+++ b/docs/design/software-requirements-specification.adoc
@@ -102,6 +102,7 @@ a| The task shall check out a fresh copy of a Git repository.
 * If child repositories are configured, those shall be checked out as well. The branch/tag to be checked out shall be configurable.
 * All checkouts shall support Git submodules.
 * All checkouts shall support Git LFS extension.
+* The clone history depth shall be configurable.
 
 | SRS-TASK-START-2
 a| The task shall store context information for each checked out repository (such as project and component key, Git commit SHA, target environment, etc.)

--- a/docs/tasks/ods-start.adoc
+++ b/docs/tasks/ods-start.adoc
@@ -42,9 +42,9 @@ by the pipeline manager. To customize parameters, configure them in the relevant
 | Defines if the resource should initialize and fetch the submodules.
 
 
-| depth
-| 1
-| Performs a shallow clone where only the most recent commit(s) will be fetched.
+| clone-depth
+| 
+| Perform a shallow clone where only the most recent commit(s) will be fetched. By default, a full clone is performed. Note that the parameter is of string type, therefore the depth value must be quoted, e.g. `value: '1'`.
 
 
 | http-proxy

--- a/tasks/ods-start.yaml
+++ b/tasks/ods-start.yaml
@@ -23,12 +23,13 @@ spec:
       description: Defines if the resource should initialize and fetch the submodules.
       type: string
       default: 'true'
-    - name: depth
+    - name: clone-depth
       description: >-
-        Performs a shallow clone where only the most recent commit(s) will be
-        fetched.
+        Perform a shallow clone where only the most recent commit(s) will be
+        fetched. By default, a full clone is performed. Note that the parameter is of string type,
+        therefore the depth value must be quoted, e.g. `value: '1'`.
       type: string
-      default: '1'
+      default: ''
     - name: http-proxy
       description: Git HTTP proxy server for non-SSL requests.
       type: string
@@ -136,7 +137,7 @@ spec:
           -https-proxy=$(params.https-proxy) \
           -no-proxy=$(params.no-proxy) \
           -submodules=$(params.submodules) \
-          -depth=$(params.depth) \
+          -clone-depth=$(params.clone-depth) \
           -pipeline-run-name=$(params.pipeline-run-name) \
           -artifact-source=$(params.artifact-source)
 


### PR DESCRIPTION
That way, the SonarQube scan does not complain anymore about missing blame info. Users prefering a faster clone can revert to the old behaviour by specifying the `start.clone-depth` parameter.

Closes #164.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
