### PR TITLE
Take working-dir param into account when supplying SQ default properties

### DIFF
--- a/build/package/scripts/supply-sonar-project-properties-default.sh
+++ b/build/package/scripts/supply-sonar-project-properties-default.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 set -eu
 
+working_dir="."
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+    --working-dir) working_dir="$2"; shift;;
+    --working-dir=*) working_dir="${1#*=}";;
+  *) echo "Unknown parameter passed: $1"; exit 1;;
+esac; shift; done
+
 echo "Checking for sonar-project.properties ..."
-if [ ! -f sonar-project.properties ]; then
+if [ ! -f "${working_dir}/sonar-project.properties" ]; then
   echo "No sonar-project.properties present, using default:"
   cat /usr/local/default-sonar-project.properties
-  cp /usr/local/default-sonar-project.properties sonar-project.properties
+  cp /usr/local/default-sonar-project.properties "${working_dir}/sonar-project.properties"
 fi

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-go.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-go.yaml
@@ -87,7 +87,7 @@ spec:
       resources:
         {{- (.Values.go).resources | default dict | toYaml | nindent 8 }}
       script: |
-        supply-sonar-project-properties-default
+        supply-sonar-project-properties-default --working-dir=$(params.working-dir)
         echo -n "" > $(results.build-reused-from-location.path)
         cache_build_key=go-$(params.go-os)-$(params.go-arch)
         if copy-build-if-cached \

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
@@ -108,7 +108,7 @@ spec:
       resources:
         {{- (.Values.gradle).resources | default dict | toYaml | nindent 8 }}
       script: |
-        supply-sonar-project-properties-default
+        supply-sonar-project-properties-default --working-dir=$(params.working-dir)
         echo -n "" > $(results.build-reused-from-location.path)
         cache_build_key=gradle
         if copy-build-if-cached \

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-npm.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-npm.yaml
@@ -106,7 +106,7 @@ spec:
       resources:
         {{- (.Values.npm).resources | default dict | toYaml | nindent 8 }}
       script: |
-        supply-sonar-project-properties-default
+        supply-sonar-project-properties-default --working-dir=$(params.working-dir)
         echo -n "" > $(results.build-reused-from-location.path)
         cache_build_key=npm
         if copy-build-if-cached \

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-python.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-python.yaml
@@ -94,7 +94,7 @@ spec:
       resources:
         {{- (.Values.python).resources | default dict | toYaml | nindent 8 }}
       script: |
-        supply-sonar-project-properties-default
+        supply-sonar-project-properties-default --working-dir=$(params.working-dir)
         echo -n "" > $(results.build-reused-from-location.path)
         cache_build_key=python
         if copy-build-if-cached \

--- a/tasks/ods-build-go.yaml
+++ b/tasks/ods-build-go.yaml
@@ -84,7 +84,7 @@ spec:
       resources:
         {}
       script: |
-        supply-sonar-project-properties-default
+        supply-sonar-project-properties-default --working-dir=$(params.working-dir)
         echo -n "" > $(results.build-reused-from-location.path)
         cache_build_key=go-$(params.go-os)-$(params.go-arch)
         if copy-build-if-cached \

--- a/tasks/ods-build-gradle.yaml
+++ b/tasks/ods-build-gradle.yaml
@@ -105,7 +105,7 @@ spec:
       resources:
         {}
       script: |
-        supply-sonar-project-properties-default
+        supply-sonar-project-properties-default --working-dir=$(params.working-dir)
         echo -n "" > $(results.build-reused-from-location.path)
         cache_build_key=gradle
         if copy-build-if-cached \

--- a/tasks/ods-build-npm.yaml
+++ b/tasks/ods-build-npm.yaml
@@ -103,7 +103,7 @@ spec:
       resources:
         {}
       script: |
-        supply-sonar-project-properties-default
+        supply-sonar-project-properties-default --working-dir=$(params.working-dir)
         echo -n "" > $(results.build-reused-from-location.path)
         cache_build_key=npm
         if copy-build-if-cached \

--- a/tasks/ods-build-python.yaml
+++ b/tasks/ods-build-python.yaml
@@ -91,7 +91,7 @@ spec:
       resources:
         {}
       script: |
-        supply-sonar-project-properties-default
+        supply-sonar-project-properties-default --working-dir=$(params.working-dir)
         echo -n "" > $(results.build-reused-from-location.path)
         cache_build_key=python
         if copy-build-if-cached \


### PR DESCRIPTION
Fixes #674

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
