### PR TITLE
Allow to execute diff only, without upgrade.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@ listed in the changelog.
 
 ## [Unreleased]
 
+### Added
+
+- Allow to execute Helm diff only, without running upgrade afterwards (related to [#622](https://github.com/opendevstack/ods-pipeline/issues/622))
+
 ### Changed
 
+- Only push images when Helm detects drift ([#589](https://github.com/opendevstack/ods-pipeline/issues/589))
 - Perform non-shallow clone by default ([#164](https://github.com/opendevstack/ods-pipeline/issues/164))
 - Update Git from 2.31 to 2.39 ([#693](https://github.com/opendevstack/ods-pipeline/pull/693))
 - Update Skopeo from 1.9 to 1.11 ([#693](https://github.com/opendevstack/ods-pipeline/pull/693))

--- a/cmd/deploy-helm/main.go
+++ b/cmd/deploy-helm/main.go
@@ -42,6 +42,8 @@ type options struct {
 	certDir string
 	// Whether to TLS verify the source image registry.
 	srcRegistryTLSVerify bool
+	// Whether to perform just a diff without any upgrade.
+	diffOnly bool
 	// Whether to enable debug mode.
 	debug bool
 }
@@ -95,6 +97,7 @@ func main() {
 	flag.StringVar(&opts.namespace, "namespace", defaultOptions.namespace, "Target K8s namespace (or OpenShift project) to deploy into")
 	flag.StringVar(&opts.certDir, "cert-dir", defaultOptions.certDir, "Use certificates at the specified path to access the registry")
 	flag.BoolVar(&opts.srcRegistryTLSVerify, "src-registry-tls-verify", defaultOptions.srcRegistryTLSVerify, "TLS verify source registry")
+	flag.BoolVar(&opts.diffOnly, "diff-only", defaultOptions.diffOnly, "Whether to perform only a diff")
 	flag.BoolVar(&opts.debug, "debug", defaultOptions.debug, "debug mode")
 	flag.Parse()
 
@@ -110,13 +113,13 @@ func main() {
 		skipOnEmptyNamespace(),
 		setReleaseTarget(),
 		detectSubrepos(),
-		detectImageDigests(),
-		copyImagesIntoReleaseNamespace(),
 		listHelmPlugins(),
 		packageHelmChartWithSubcharts(),
 		collectValuesFiles(),
 		importAgeKey(),
 		diffHelmRelease(),
+		detectImageDigests(),
+		copyImagesIntoReleaseNamespace(),
 		upgradeHelmRelease(),
 	)
 	if err != nil {

--- a/cmd/deploy-helm/skopeo.go
+++ b/cmd/deploy-helm/skopeo.go
@@ -21,6 +21,7 @@ func (d *deployHelm) copyImage(imageArtifact artifact.Image, destRegistryToken s
 	// requests error out with "server gave HTTP response to HTTPS client".
 	if strings.HasPrefix(imageArtifact.Registry, "kind-registry.kind") {
 		srcRegistryTLSVerify = false
+		destRegistryTLSVerify = false
 	}
 	if d.targetConfig.RegistryHost != "" && d.targetConfig.RegistryTLSVerify != nil {
 		destRegistryTLSVerify = *d.targetConfig.RegistryTLSVerify

--- a/cmd/deploy-helm/steps.go
+++ b/cmd/deploy-helm/steps.go
@@ -317,6 +317,9 @@ func diffHelmRelease() DeployStep {
 		if err != nil {
 			return d, fmt.Errorf("helm diff: %w", err)
 		}
+		if d.opts.diffOnly {
+			return d, &skipRemainingSteps{"Only diff was requested, skipping helm upgrade."}
+		}
 		if inSync {
 			return d, &skipRemainingSteps{"No diff detected, skipping helm upgrade."}
 		}

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-deploy-helm.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-deploy-helm.yaml
@@ -67,6 +67,12 @@ spec:
         If not given, the registy host of the source image is used.
       type: string
       default: ''
+    - name: diff-only
+      description: |
+        If set to true, the task will only perform a diff, and then stop.
+        No images will be promoted or upgrades attempted.
+      type: string
+      default: 'false'
   steps:
     - name: helm-upgrade-from-repo
       # Image is built from build/package/Dockerfile.helm.
@@ -91,7 +97,8 @@ spec:
           -age-key-secret=$(params.age-key-secret) \
           -api-server=$(params.api-server) \
           -api-credentials-secret=$(params.api-credentials-secret) \
-          -registry-host=$(params.registry-host)
+          -registry-host=$(params.registry-host) \
+          -diff-only=$(params.diff-only)
       volumeMounts:
         - mountPath: /etc/ssl/certs/private-cert.pem
           name: private-cert

--- a/docs/tasks/ods-deploy-helm.adoc
+++ b/docs/tasks/ods-deploy-helm.adoc
@@ -130,6 +130,13 @@ If empty, the task will be a no-op.
 If not given, the registy host of the source image is used.
 
 
+
+| diff-only
+| false
+| If set to true, the task will only perform a diff, and then stop.
+No images will be promoted or upgrades attempted.
+
+
 |===
 
 == Results

--- a/scripts/kind-with-registry.sh
+++ b/scripts/kind-with-registry.sh
@@ -115,4 +115,16 @@ EOF
 
 for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
   kubectl annotate node "${node}" tilt.dev/registry=localhost:"${REGISTRY_PORT}";
+
+  # Add the registry config to the nodes.
+  # This is necessary because localhost resolves to loopback addresses that are
+  # network-namespace local.
+  # In other words: localhost in the container is not localhost on the host.
+  # We want a consistent name that works from both ends, so we tell containerd to
+  # alias localhost:${reg_port} to the registry container when pulling images.
+  REGISTRY_DIR="/etc/containerd/certs.d/localhost:${REGISTRY_PORT}"
+  docker exec "${node}" mkdir -p "${REGISTRY_DIR}"
+  cat <<EOF | docker exec -i "${node}" cp /dev/stdin "${REGISTRY_DIR}/hosts.toml"
+[host."http://${REGISTRY_NAME}:5000"]
+EOF
 done

--- a/tasks/ods-deploy-helm.yaml
+++ b/tasks/ods-deploy-helm.yaml
@@ -68,6 +68,12 @@ spec:
         If not given, the registy host of the source image is used.
       type: string
       default: ''
+    - name: diff-only
+      description: |
+        If set to true, the task will only perform a diff, and then stop.
+        No images will be promoted or upgrades attempted.
+      type: string
+      default: 'false'
   steps:
     - name: helm-upgrade-from-repo
       # Image is built from build/package/Dockerfile.helm.
@@ -92,7 +98,8 @@ spec:
           -age-key-secret=$(params.age-key-secret) \
           -api-server=$(params.api-server) \
           -api-credentials-secret=$(params.api-credentials-secret) \
-          -registry-host=$(params.registry-host)
+          -registry-host=$(params.registry-host) \
+          -diff-only=$(params.diff-only)
       volumeMounts:
         - mountPath: /etc/ssl/certs/private-cert.pem
           name: private-cert

--- a/test/testdata/workspaces/helm-sample-app/chart/values.yaml
+++ b/test/testdata/workspaces/helm-sample-app/chart/values.yaml
@@ -5,9 +5,9 @@
 replicaCount: 1
 
 image:
-  registry: index.docker.io
+  registry: localhost:5000
   # Overrides the image namespace whose default is the release namespace.
-  namespace: crccheck
+  # namespace: crccheck
   # Overrides the image repository whose default is the chart name.
   repository: hello-world
   pullPolicy: IfNotPresent


### PR DESCRIPTION
This necessitates that the image promotion happens after the diff, which is something we wanted to do anyway.

The new feature plays nicely with the newly introduced trigger-based params as those allow to set diff-only for certain cases, e.g. only when a PR comment is made.

Closes #589.
Solves #622 partially. It runs the diff but does not post to Bitbucket yet. Not perfect, but already good enough to provide value.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
