### PR TITLE
Mark /workspace/source as safe dir for Git

### DIFF
--- a/build/package/Dockerfile.aqua-scan
+++ b/build/package/Dockerfile.aqua-scan
@@ -22,4 +22,6 @@ COPY --from=builder /usr/local/bin/ods-aqua-scan /usr/local/bin/ods-aqua-scan
 # Add scripts
 COPY build/package/scripts/download-aqua-scanner.sh /usr/local/bin/download-aqua-scanner
 
+VOLUME /workspace/source
+
 USER 1001

--- a/build/package/Dockerfile.finish
+++ b/build/package/Dockerfile.finish
@@ -17,4 +17,5 @@ RUN cd cmd/finish && CGO_ENABLED=0 go build -o /usr/local/bin/ods-finish
 # ubi-micro cannot be used as it misses the ca-certificates package.
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 COPY --from=builder /usr/local/bin/ods-finish /usr/local/bin/ods-finish
+VOLUME /workspace/source
 USER 1001

--- a/build/package/Dockerfile.go-toolset
+++ b/build/package/Dockerfile.go-toolset
@@ -26,4 +26,9 @@ RUN chmod +x /usr/local/bin/build-go && \
 # Add sonar-project.properties
 COPY build/package/sonar-project.properties.d/go.properties /usr/local/default-sonar-project.properties
 
+VOLUME /workspace/source
+# Ensure that file permissions do not prevent Git checkout into workspace.
+# See https://git-scm.com/docs/git-config/#Documentation/git-config.txt-safedirectory.
+RUN git config --system --add safe.directory '/workspace/source'
+
 USER 1001

--- a/build/package/Dockerfile.gradle-toolset
+++ b/build/package/Dockerfile.gradle-toolset
@@ -29,6 +29,9 @@ RUN cd /opt && \
     chmod -R g=u /workspace/source $HOME
 
 VOLUME /workspace/source
+# Ensure that file permissions do not prevent Git checkout into workspace.
+# See https://git-scm.com/docs/git-config/#Documentation/git-config.txt-safedirectory.
+RUN git config --system --add safe.directory '/workspace/source'
 
 # Add scripts
 COPY build/package/scripts/cache-build.sh /usr/local/bin/cache-build

--- a/build/package/Dockerfile.helm
+++ b/build/package/Dockerfile.helm
@@ -65,4 +65,9 @@ RUN mkdir -p $HELM_PLUGINS \
     && sops --version \
     && age --version
 
+VOLUME /workspace/source
+# Ensure that file permissions do not prevent Git checkout into workspace.
+# See https://git-scm.com/docs/git-config/#Documentation/git-config.txt-safedirectory.
+RUN git config --system --add safe.directory '/workspace/source'
+
 USER 1001

--- a/build/package/Dockerfile.node16-npm-toolset
+++ b/build/package/Dockerfile.node16-npm-toolset
@@ -33,4 +33,9 @@ RUN chmod +x /usr/local/bin/build-npm && \
 # Add sonar-project.properties
 COPY build/package/sonar-project.properties.d/npm.properties /usr/local/default-sonar-project.properties
 
+VOLUME /workspace/source
+# Ensure that file permissions do not prevent Git checkout into workspace.
+# See https://git-scm.com/docs/git-config/#Documentation/git-config.txt-safedirectory.
+RUN git config --system --add safe.directory '/workspace/source'
+
 USER 1001

--- a/build/package/Dockerfile.node18-npm-toolset
+++ b/build/package/Dockerfile.node18-npm-toolset
@@ -33,4 +33,9 @@ RUN chmod +x /usr/local/bin/build-npm && \
 # Add sonar-project.properties
 COPY build/package/sonar-project.properties.d/npm.properties /usr/local/default-sonar-project.properties
 
+VOLUME /workspace/source
+# Ensure that file permissions do not prevent Git checkout into workspace.
+# See https://git-scm.com/docs/git-config/#Documentation/git-config.txt-safedirectory.
+RUN git config --system --add safe.directory '/workspace/source'
+
 USER 1001

--- a/build/package/Dockerfile.package-image
+++ b/build/package/Dockerfile.package-image
@@ -43,6 +43,7 @@ ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot
 
 VOLUME /var/lib/containers
 VOLUME /home/build/.local/share/containers
+VOLUME /workspace/source
 
 # Install Trivy
 RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin "v${TRIVY_VERSION}"

--- a/build/package/Dockerfile.python-toolset
+++ b/build/package/Dockerfile.python-toolset
@@ -21,4 +21,9 @@ RUN chmod +x /usr/local/bin/build-python && \
 # Add sonar-project.properties
 COPY build/package/sonar-project.properties.d/python.properties /usr/local/default-sonar-project.properties
 
+VOLUME /workspace/source
+# Ensure that file permissions do not prevent Git checkout into workspace.
+# See https://git-scm.com/docs/git-config/#Documentation/git-config.txt-safedirectory.
+RUN git config --system --add safe.directory '/workspace/source'
+
 USER 1001

--- a/build/package/Dockerfile.sonar
+++ b/build/package/Dockerfile.sonar
@@ -45,4 +45,6 @@ COPY build/package/scripts/configure-truststore.sh /usr/local/bin/configure-trus
 
 ENV PATH=/usr/local/sonar-scanner-cli/bin:$PATH
 
+VOLUME /workspace/source
+
 USER 1001

--- a/build/package/Dockerfile.start
+++ b/build/package/Dockerfile.start
@@ -39,6 +39,7 @@ COPY --from=builder /usr/local/bin/ods-start /usr/local/bin/ods-start
 COPY --from=builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
 RUN git lfs version
 
+VOLUME /workspace/source
 # Ensure that file permissions do not prevent Git checkout into workspace.
 # See https://git-scm.com/docs/git-config/#Documentation/git-config.txt-safedirectory.
 RUN git config --system --add safe.directory '/workspace/source'


### PR DESCRIPTION
Needs to happen not just in ods-start, but wherever Git is used.

Related to https://github.com/opendevstack/ods-pipeline/commit/22fddae36bf10421f6134ce0e746f81517f9cda1.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
