### PR TITLE
Fix artifact and output caching of Gradle task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ listed in the changelog.
 
 ## [Unreleased]
 
+### Added
+
+- Gradle build dir is now configurable ([#703](https://github.com/opendevstack/ods-pipeline/pull/703))
+
+### Fixed
+
+- Gradle task artifacts are not picked up by cache ([#700](https://github.com/opendevstack/ods-pipeline/issues/700))
+- Gradle task ignores `working-dir` param ([#702](https://github.com/opendevstack/ods-pipeline/issues/702))
+
 ## [0.13.0] - 2023-06-01
 
 ### Added

--- a/build/package/scripts/build-gradle.sh
+++ b/build/package/scripts/build-gradle.sh
@@ -1,55 +1,66 @@
 #!/bin/bash
 set -eu
 
-OUTPUT_DIR="docker"
-WORKING_DIR="."
-ROOT_DIR=$(pwd)
-export ARTIFACTS_DIR=$ROOT_DIR/.ods/artifacts
-ARTIFACT_PREFIX=
-DEBUG="${DEBUG:-false}"
-GRADLE_ADDITIONAL_TASKS=
-GRADLE_OPTIONS=
+# the copy commands are based on GNU cp tools
+# On a mac `brew install coreutils` gives `g` prefixed cmd line tools such as gcp
+# to use these define env variable GNU_CP=gcp before invoking this script.
+CP="${GNU_CP:-cp}"
+
+output_dir="docker"
+working_dir="."
+artifact_prefix=""
+debug="${DEBUG:-false}"
+gradle_build_dir="build"
+gradle_additional_tasks=
+gradle_options=
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
 
-    --working-dir) WORKING_DIR="$2"; shift;;
-    --working-dir=*) WORKING_DIR="${1#*=}";;
+    --working-dir) working_dir="$2"; shift;;
+    --working-dir=*) working_dir="${1#*=}";;
 
-    --output-dir) OUTPUT_DIR="$2"; shift;;
-    --output-dir=*) OUTPUT_DIR="${1#*=}";;
+    --output-dir) output_dir="$2"; shift;;
+    --output-dir=*) output_dir="${1#*=}";;
 
-    --gradle-additional-tasks) GRADLE_ADDITIONAL_TASKS="$2"; shift;;
-    --gradle-additional-tasks=*) GRADLE_ADDITIONAL_TASKS="${1#*=}";;
+    --gradle-build-dir) gradle_build_dir="$2"; shift;;
+    --gradle-build-dir=*) gradle_build_dir="${1#*=}";;
+
+    --gradle-additional-tasks) gradle_additional_tasks="$2"; shift;;
+    --gradle-additional-tasks=*) gradle_additional_tasks="${1#*=}";;
 
     # Gradle project properties ref: https://docs.gradle.org/7.4.2/userguide/build_environment.html#sec:gradle_configuration_properties
     # Gradle options ref: https://docs.gradle.org/7.4.2/userguide/command_line_interface.html
-    --gradle-options) GRADLE_OPTIONS="$2"; shift;;
-    --gradle-options=*) GRADLE_OPTIONS="${1#*=}";;
+    --gradle-options) gradle_options="$2"; shift;;
+    --gradle-options=*) gradle_options="${1#*=}";;
 
   *) echo "Unknown parameter passed: $1"; exit 1;;
 esac; shift; done
 
-if [ "${WORKING_DIR}" != "." ]; then
-  WORKING_DIR="${ROOT_DIR}"
-  ARTIFACT_PREFIX="${WORKING_DIR/\//-}-"
+root_dir=$(pwd)
+tmp_artifacts_dir="${root_dir}/.ods/tmp-artifacts"
+# tmp_artifacts_dir enables keeping artifacts created by this build
+# separate from other builds in the same repo to facilitate caching.
+rm -rf "${tmp_artifacts_dir}"
+if [ "${working_dir}" != "." ]; then
+  cd "${working_dir}"
+  artifact_prefix="${working_dir/\//-}-"
 fi
 
-if [ "${DEBUG}" == "true" ]; then
+if [ "${debug}" == "true" ]; then
   set -x
 fi
 
 echo "Using NEXUS_URL=$NEXUS_URL"
 echo "Using GRADLE_OPTS=$GRADLE_OPTS"
 echo "Using GRADLE_USER_HOME=$GRADLE_USER_HOME"
-echo "Using ARTIFACTS_DIR=$ARTIFACTS_DIR"
 mkdir -p "${GRADLE_USER_HOME}"
 
 configure-gradle
 
 echo
-cd "${WORKING_DIR}"
-echo "Working on Gradle project in '${WORKING_DIR}'..."
+cd "${working_dir}"
+echo "Working on Gradle project in '${working_dir}'..."
 echo
 echo "Gradlew version: "
 ./gradlew -version
@@ -61,37 +72,35 @@ echo " that this build expects generated application artifacts to be copied to."
 echo " The project gradle script should read this env var to copy all the "
 echo " generated application artifacts."
 echo
-export ODS_OUTPUT_DIR=${OUTPUT_DIR}
-echo "Exported env var 'ODS_OUTPUT_DIR' with value '${OUTPUT_DIR}'"
+export ODS_OUTPUT_DIR=${output_dir}
+echo "Exported env var 'ODS_OUTPUT_DIR' with value '${output_dir}'"
 echo
 echo "Building (Compile and Test) ..."
 # shellcheck disable=SC2086
-./gradlew clean build ${GRADLE_ADDITIONAL_TASKS} ${GRADLE_OPTIONS}
+./gradlew clean build ${gradle_additional_tasks} ${gradle_options}
 echo
 
 echo "Verifying unit test report was generated  ..."
-BUILD_DIR="build"
-UNIT_TEST_RESULT_DIR="${BUILD_DIR}/test-results/test"
-
-if [ -d "${UNIT_TEST_RESULT_DIR}" ]; then
-    UNIT_TEST_ARTIFACTS_DIR="${ARTIFACTS_DIR}/xunit-reports"
-    mkdir -p "${UNIT_TEST_ARTIFACTS_DIR}"
+unit_test_result_dir="${gradle_build_dir}/test-results/test"
+if [ -d "${unit_test_result_dir}" ]; then
+    unit_test_artifacts_dir="${tmp_artifacts_dir}/xunit-reports"
+    mkdir -p "${unit_test_artifacts_dir}"
     # Each test class produces its own report file, but they contain a fully qualified class
     # name in their file name. Due to that, we do not need to add an artifact prefix to
     # distinguish them with reports from other artifacts of the same repo/pipeline build.
-    cp "${UNIT_TEST_RESULT_DIR}/"*.xml "${UNIT_TEST_ARTIFACTS_DIR}"
+    "$CP" "${unit_test_result_dir}/"*.xml "${unit_test_artifacts_dir}"
 else
-  echo "Build failed: no unit test results found in ${UNIT_TEST_RESULT_DIR}"
+  echo "Build failed: no unit test results found in ${unit_test_result_dir}"
   exit 1
 fi
 
 echo "Verifying unit test coverage report was generated  ..."
-COVERAGE_RESULT_DIR="${BUILD_DIR}/reports/jacoco/test"
-if [ -d "${COVERAGE_RESULT_DIR}" ]; then
-    CODE_COVERAGE_ARTIFACTS_DIR="${ARTIFACTS_DIR}/code-coverage"
-    mkdir -p "${CODE_COVERAGE_ARTIFACTS_DIR}"
-    cp "${COVERAGE_RESULT_DIR}/jacocoTestReport.xml" "${CODE_COVERAGE_ARTIFACTS_DIR}/${ARTIFACT_PREFIX}coverage.xml"
+coverage_result_dir="${gradle_build_dir}/reports/jacoco/test"
+if [ -d "${coverage_result_dir}" ]; then
+    code_coverage_artifacts_dir="${tmp_artifacts_dir}/code-coverage"
+    mkdir -p "${code_coverage_artifacts_dir}"
+    "$CP" "${coverage_result_dir}/jacocoTestReport.xml" "${code_coverage_artifacts_dir}/${artifact_prefix}coverage.xml"
 else
-  echo "Build failed: no unit test coverage report was found in ${COVERAGE_RESULT_DIR}"
+  echo "Build failed: no unit test coverage report was found in ${coverage_result_dir}"
   exit 1
 fi

--- a/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
+++ b/deploy/ods-pipeline/charts/tasks/templates/task-ods-build-gradle.yaml
@@ -59,6 +59,11 @@ spec:
         for details how the build script is invoked.
       type: string
       default: "/usr/local/bin/build-gradle"
+    - name: gradle-build-dir
+      description: >-
+        Path to the directory into which Gradle publishes its build.
+      type: string
+      default: build
     - name: sonar-quality-gate
       description: Whether the SonarQube quality gate needs to pass for the task to succeed.
       type: string
@@ -125,6 +130,7 @@ spec:
         $(params.build-script) \
           --working-dir=$(params.working-dir) \
           --output-dir=$(params.output-dir) \
+          --gradle-build-dir=$(params.gradle-build-dir) \
           --gradle-additional-tasks="$(params.gradle-additional-tasks)" \
           --gradle-options="$(params.gradle-options)"
         build_exit=$?

--- a/docs/tasks/ods-build-gradle.adoc
+++ b/docs/tasks/ods-build-gradle.adoc
@@ -149,6 +149,11 @@ without leading `./` and trailing `/`.
 | Build script to execute. The link:https://github.com/opendevstack/ods-pipeline/blob/master/build/package/scripts/build-gradle.sh[default script] is located in the container image. If you specify a relative path instead, it will be resolved from the workspace. See the task definition for details how the build script is invoked.
 
 
+| gradle-build-dir
+| build
+| Path to the directory into which Gradle publishes its build.
+
+
 | sonar-quality-gate
 | false
 | Whether the SonarQube quality gate needs to pass for the task to succeed.

--- a/tasks/ods-build-gradle.yaml
+++ b/tasks/ods-build-gradle.yaml
@@ -60,6 +60,11 @@ spec:
         for details how the build script is invoked.
       type: string
       default: "/usr/local/bin/build-gradle"
+    - name: gradle-build-dir
+      description: >-
+        Path to the directory into which Gradle publishes its build.
+      type: string
+      default: build
     - name: sonar-quality-gate
       description: Whether the SonarQube quality gate needs to pass for the task to succeed.
       type: string
@@ -122,6 +127,7 @@ spec:
         $(params.build-script) \
           --working-dir=$(params.working-dir) \
           --output-dir=$(params.output-dir) \
+          --gradle-build-dir=$(params.gradle-build-dir) \
           --gradle-additional-tasks="$(params.gradle-additional-tasks)" \
           --gradle-options="$(params.gradle-options)"
         build_exit=$?

--- a/test/tasks/ods-build-gradle_test.go
+++ b/test/tasks/ods-build-gradle_test.go
@@ -45,14 +45,13 @@ func TestTaskODSBuildGradle(t *testing.T) {
 						)
 					}
 
-					logContains(ctxt.CollectedLogs, t,
+					logContains(t, ctxt.CollectedLogs,
 						"No sonar-project.properties present, using default:",
 						"ods-test-nexus",
 						"Gradle 7.4.2",
 						"Using GRADLE_OPTS=-Dorg.gradle.jvmargs=-Xmx512M",
 						"Using GRADLE_USER_HOME=/workspace/source/.ods-cache/deps/gradle",
 						"To honour the JVM settings for this build a single-use Daemon process will be forked.",
-						"Using ARTIFACTS_DIR=/workspace/source/.ods/artifacts",
 					)
 				},
 			},
@@ -85,14 +84,13 @@ func TestTaskODSBuildGradle(t *testing.T) {
 						)
 					}
 
-					logContains(ctxt.CollectedLogs, t,
+					logContains(t, ctxt.CollectedLogs,
 						"No sonar-project.properties present, using default:",
 						"ods-test-nexus",
 						"Gradle 7.4.2",
 						"Using GRADLE_OPTS=-Dorg.gradle.jvmargs=-Xmx512M",
 						"Using GRADLE_USER_HOME=/workspace/source/.ods-cache/deps/gradle",
 						"To honour the JVM settings for this build a single-use Daemon process will be forked.",
-						"Using ARTIFACTS_DIR=/workspace/source/.ods/artifacts",
 					)
 				},
 				AdditionalRuns: []tasktesting.TaskRunCase{{
@@ -122,7 +120,7 @@ func TestTaskODSBuildGradle(t *testing.T) {
 							)
 						}
 
-						logContains(ctxt.CollectedLogs, t,
+						logContains(t, ctxt.CollectedLogs,
 							"Copying prior build artifacts from cache: /workspace/source/.ods-cache/build-task/gradle",
 							"Copying prior build output from cache: /workspace/source/.ods-cache/build-task/gradle",
 						)
@@ -132,7 +130,8 @@ func TestTaskODSBuildGradle(t *testing.T) {
 		})
 }
 
-func logContains(collectedLogs []byte, t *testing.T, wantLogMsgs ...string) {
+func logContains(t *testing.T, collectedLogs []byte, wantLogMsgs ...string) {
+	t.Helper()
 	logString := string(collectedLogs)
 
 	for _, msg := range wantLogMsgs {


### PR DESCRIPTION
* Change working dir to the one specified by the `working-dir` param
* Place artifacts into `.ods/tmp-artifacts` so that they are properly cached
* Make Gradle build dir configurable instead of hardcoding to `build`

Fixes #700.
Fixes #702.

FYI @oalyman @henrjk 

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
