### PR TITLE
Remove duplicated cd instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ listed in the changelog.
 
 ## [Unreleased]
 
+### Fixed
+
+- Gradle build script changes twice into working dir ([#705](https://github.com/opendevstack/ods-pipeline/issues/705))
+
 ## [0.13.1] - 2023-06-05
 
 ### Added

--- a/build/package/scripts/build-gradle.sh
+++ b/build/package/scripts/build-gradle.sh
@@ -59,7 +59,6 @@ mkdir -p "${GRADLE_USER_HOME}"
 configure-gradle
 
 echo
-cd "${working_dir}"
 echo "Working on Gradle project in '${working_dir}'..."
 echo
 echo "Gradlew version: "


### PR DESCRIPTION
Fixes #705.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
