### PR TITLE
Consult artifact repository in artifact check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ listed in the changelog.
 
 ### Fixed
 
+- Artifacts may not be uploaded to target repository when the target repository differs from the source repository ([#715](https://github.com/opendevstack/ods-pipeline/pull/715))
 - Gradle build script changes twice into working dir ([#705](https://github.com/opendevstack/ods-pipeline/issues/705))
 
 ## [0.13.1] - 2023-06-05

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -232,7 +232,7 @@ func main() {
 }
 
 func writeEmptyArtifactManifests(subrepoContexts []*pipelinectxt.ODSContext) error {
-	emptyManifest := &pipelinectxt.ArtifactsManifest{Artifacts: []pipelinectxt.ArtifactInfo{}}
+	emptyManifest := pipelinectxt.NewArtifactsManifest("")
 	err := pipelinectxt.WriteJsonArtifact(emptyManifest, pipelinectxt.ArtifactsPath, pipelinectxt.ArtifactsManifestFilename)
 	if err != nil {
 		return fmt.Errorf("write repo empty manifest: %w", err)

--- a/pkg/pipelinectxt/artifacts_test.go
+++ b/pkg/pipelinectxt/artifacts_test.go
@@ -118,6 +118,84 @@ func TestDownloadGroup(t *testing.T) {
 	}
 }
 
+func TestContains(t *testing.T) {
+	tests := map[string]struct {
+		manifest *ArtifactsManifest
+		repo     string
+		dir      string
+		name     string
+		want     bool
+	}{
+		"different repo": {
+			manifest: &ArtifactsManifest{
+				Repository: "a",
+				Artifacts: []ArtifactInfo{
+					{
+						Directory: "b",
+						Name:      "c",
+					},
+				},
+			},
+			repo: "x",
+			dir:  "b",
+			name: "c",
+			want: false,
+		},
+		"same repo, different dir": {
+			manifest: &ArtifactsManifest{
+				Repository: "a",
+				Artifacts: []ArtifactInfo{
+					{
+						Directory: "b",
+						Name:      "c",
+					},
+				},
+			},
+			repo: "a",
+			dir:  "x",
+			name: "c",
+			want: false,
+		},
+		"same repo, same dir, different name": {
+			manifest: &ArtifactsManifest{
+				Repository: "a",
+				Artifacts: []ArtifactInfo{
+					{
+						Directory: "b",
+						Name:      "c",
+					},
+				},
+			},
+			repo: "a",
+			dir:  "b",
+			name: "x",
+			want: false,
+		},
+		"match": {
+			manifest: &ArtifactsManifest{
+				Repository: "a",
+				Artifacts: []ArtifactInfo{
+					{
+						Directory: "b",
+						Name:      "c",
+					},
+				},
+			},
+			repo: "a",
+			dir:  "b",
+			name: "c",
+			want: true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tc.manifest.Contains(tc.repo, tc.dir, tc.name) != tc.want {
+				t.Errorf("Want %q to contain=%v, but did not", name, tc.want)
+			}
+		})
+	}
+}
+
 func findArtifact(url string, artifacts []ArtifactInfo) *ArtifactInfo {
 	for _, a := range artifacts {
 		if a.URL == url {

--- a/test/tasks/ods-finish_test.go
+++ b/test/tasks/ods-finish_test.go
@@ -59,14 +59,13 @@ func TestTaskODSFinish(t *testing.T) {
 					); err != nil {
 						t.Fatal(err)
 					}
-					am := pipelinectxt.ArtifactsManifest{
-						Artifacts: []pipelinectxt.ArtifactInfo{
-							{
-								Directory: pipelinectxt.CodeCoveragesDir,
-								Name:      "coverage.out",
-							},
+					am := pipelinectxt.NewArtifactsManifest(
+						nexus.TestTemporaryRepository,
+						pipelinectxt.ArtifactInfo{
+							Directory: pipelinectxt.CodeCoveragesDir,
+							Name:      "coverage.out",
 						},
-					}
+					)
 					if err := pipelinectxt.WriteJsonArtifact(
 						am,
 						filepath.Join(wsDir, pipelinectxt.ArtifactsPath),
@@ -87,7 +86,7 @@ func TestTaskODSFinish(t *testing.T) {
 					checkBuildStatus(t, bitbucketClient, ctxt.ODS.GitCommitSHA, bitbucket.BuildStatusSuccessful)
 					checkArtifactsAreInNexus(t, ctxt, nexus.TestTemporaryRepository)
 
-					wantLogMsg := "Artifact coverage.out is already present in Nexus repository"
+					wantLogMsg := "Artifact \"coverage.out\" is already present in Nexus repository"
 					if !strings.Contains(string(ctxt.CollectedLogs), wantLogMsg) {
 						t.Fatalf("Want:\n%s\n\nGot:\n%s", wantLogMsg, string(ctxt.CollectedLogs))
 					}


### PR DESCRIPTION
Artifacts may be downloaded in the start task from repository A, but should be uploaded to repository B in the finish task. In this case, Contains erroneously returned true before this change. Contains should only return true if the artifacts were downloaded from the same repository earlier. When the repositories differ, the task must fetch a manifest from the target repository before checking the manifest.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
