### PR TITLE
Read from /dev/tty in install script

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -174,11 +174,11 @@ installSecret () {
         if [ -z "${flagValue}" ]; then
             if [ -n "${usernamePrompt}" ]; then
                 echo "${usernamePrompt}"
-                read -r authUser
+                read -r authUser </dev/tty
             fi
             if [ -n "${passwordPrompt}" ]; then
                 echo "${passwordPrompt}"
-                read -rs authPassword
+                read -rs authPassword </dev/tty
             else
                 authUser=''
                 authPassword=$(LC_ALL=C tr -dc 'A-Za-z0-9#%*+\-<=>_{|}' </dev/urandom | head -c 32 ; echo)


### PR DESCRIPTION
Otherwise username/password input is written from script on stdin ...

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
