### PR TITLE
Run tests for start and finish task also with private cert

### DIFF
--- a/docs/development.adoc
+++ b/docs/development.adoc
@@ -22,8 +22,8 @@ As mentioned above, `make test` will run all tests. You may also run only a subs
 * `make test-cmd` for the packages under `cmd`
 * `make test-pkg` for the packages under `pkg`
 * `make test-internal` for the packages under `internal`
+* `make test-e2e-tasks` for the task tests
+* `make test-e2e-pipelineruns` for the pipeline run tests
 * `make test-e2e` for the task tests and the pipeline run tests
-
-Tests can be run both without a private certificate (which is the default) or using a private certificate to test how the tasks perform when the services use a certificate which is not part of the OS default trusted certs. If you want to use a private certificate in the task tests, pass `-private-cert` to `go test`.
 
 Images used in tasks are rebuilt automatically before executing tests. This provides the best accuracy but it can slow down testing considerably. If you did not make changes since the last test run that would affect the images, you can pass `-ods-reuse-images` to `go test`.

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1,7 +1,0 @@
-package e2e
-
-import (
-	"flag"
-)
-
-var privateCertFlag = flag.Bool("private-cert", false, "Whether to run tests using a private cert")

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -92,9 +92,9 @@ func newTektonClient(t *testing.T) *tekton.Clientset {
 // then commits and pushes to Bitbucket.
 // The workspace will also be setup with an ODS context directory in .ods
 // with the given namespace.
-func initBitbucketRepo(t *testing.T, k8sClient kubernetes.Interface, namespace string) ttr.WorkspaceOpt {
+func initBitbucketRepo(t *testing.T, k8sClient kubernetes.Interface, namespace string, privateCert bool) ttr.WorkspaceOpt {
 	return func(c *ttr.WorkspaceConfig) error {
-		_ = tasktesting.SetupBitbucketRepo(t, k8sClient, namespace, c.Dir, tasktesting.BitbucketProjectKey, false)
+		_ = tasktesting.SetupBitbucketRepo(t, k8sClient, namespace, c.Dir, tasktesting.BitbucketProjectKey, privateCert)
 		return nil
 	}
 }
@@ -102,19 +102,19 @@ func initBitbucketRepo(t *testing.T, k8sClient kubernetes.Interface, namespace s
 // withBitbucketSourceWorkspace configures the task run with a workspace named
 // "source", mapped to the directory sourced from sourceDir. The directory is
 // initialised as a Git repository with an ODS context with the given namespace.
-func withBitbucketSourceWorkspace(t *testing.T, sourceDir string, k8sClient kubernetes.Interface, namespace string, opts ...ttr.WorkspaceOpt) ttr.TaskRunOpt {
+func withBitbucketSourceWorkspace(t *testing.T, sourceDir string, k8sClient kubernetes.Interface, namespace string, privateCert bool, opts ...ttr.WorkspaceOpt) ttr.TaskRunOpt {
 	return ott.WithSourceWorkspace(
 		t, sourceDir,
-		append([]ttr.WorkspaceOpt{initBitbucketRepo(t, k8sClient, namespace)}, opts...)...,
+		append([]ttr.WorkspaceOpt{initBitbucketRepo(t, k8sClient, namespace, privateCert)}, opts...)...,
 	)
 }
 
 func checkBuildStatus(t *testing.T, c *bitbucket.Client, gitCommit, wantBuildStatus string) {
 	buildStatusPage, err := c.BuildStatusList(gitCommit)
-	buildStatus := buildStatusPage.Values[0]
 	if err != nil {
 		t.Fatal(err)
 	}
+	buildStatus := buildStatusPage.Values[0]
 	if buildStatus.State != wantBuildStatus {
 		t.Fatalf("Got: %s, want: %s", buildStatus.State, wantBuildStatus)
 	}

--- a/test/e2e/pipeline_run_test.go
+++ b/test/e2e/pipeline_run_test.go
@@ -57,7 +57,7 @@ func TestPipelineRun(t *testing.T) {
 	}
 	t.Logf("Workspace is in %s", wsDir)
 	odsContext := tasktesting.SetupBitbucketRepo(
-		t, k8sClient, namespaceConfig.Name, wsDir, tasktesting.BitbucketProjectKey, *privateCertFlag,
+		t, k8sClient, namespaceConfig.Name, wsDir, tasktesting.BitbucketProjectKey, false,
 	)
 
 	// The webhook URL needs to be the address of the KinD control plane on the node port.
@@ -75,7 +75,7 @@ func TestPipelineRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get Bitbucket webhook secret: %s", err)
 	}
-	bitbucketClient := tasktesting.BitbucketClientOrFatal(t, k8sClient, namespaceConfig.Name, *privateCertFlag)
+	bitbucketClient := tasktesting.BitbucketClientOrFatal(t, k8sClient, namespaceConfig.Name, false)
 	_, err = bitbucketClient.WebhookCreate(
 		odsContext.Project,
 		odsContext.Repository,

--- a/test/testdata/workspaces/hello-world-app-with-artifacts/.ods/artifacts/manifest.json
+++ b/test/testdata/workspaces/hello-world-app-with-artifacts/.ods/artifacts/manifest.json
@@ -1,4 +1,4 @@
 {
-    "sourceRepository": "ods-temporary-artifacts",
+    "repository": "ods-temporary-artifacts",
     "artifacts": []
 }


### PR DESCRIPTION
Before #722, it was possible to run all tests using a private cert, by supplying `-private-cert` to `go test`. The downside of this was that all tests on GitHub ran without it, to avoid overly long test times. Now that the overall test time is way shorter, we can afford to add one test for each task to run with private cert enabled.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
