### PR TITLE
Add pipeline run name to ctxt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ listed in the changelog.
 
 ## [Unreleased]
 
+### Added
+
+- Add PipelineRun name to ODS context ([#737](https://github.com/opendevstack/ods-pipeline/issues/737))
+
 ### Fixed
 
 - Reading username / password did not work when the install script was piped into bash. See [#733](https://github.com/opendevstack/ods-pipeline/pull/733).

--- a/cmd/artifact-download/artifact_download.go
+++ b/cmd/artifact-download/artifact_download.go
@@ -121,6 +121,6 @@ func assembleODSContext(namespace string, workingDir string) (*pipelinectxt.ODSC
 	ctxt := &pipelinectxt.ODSContext{
 		Namespace: namespace,
 	}
-	err := ctxt.Assemble(workingDir)
+	err := ctxt.Assemble(workingDir, "")
 	return ctxt, err
 }

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -345,7 +345,7 @@ func checkoutAndAssembleContext(
 	ctxt = baseCtxt.Copy()
 	ctxt.GitFullRef = gitFullRef
 	ctxt.GitCommitSHA = sha
-	err = ctxt.Assemble(absCheckoutDir)
+	err = ctxt.Assemble(absCheckoutDir, opts.pipelineRunName)
 	if err != nil {
 		return nil, fmt.Errorf("assemble ODS context: %w", err)
 	}

--- a/internal/tasktesting/git.go
+++ b/internal/tasktesting/git.go
@@ -34,6 +34,7 @@ func SetupFakeRepo(t *testing.T, ns, wsDir string) *pipelinectxt.ODSContext {
 		GitFullRef:   "refs/heads/master",
 		GitRef:       "master",
 		GitURL:       "http://bitbucket.acme.org/scm/myproject/myrepo.git",
+		PipelineRun:  "foo-n8j4k",
 	}
 	err := ctxt.WriteCache(wsDir)
 	if err != nil {
@@ -43,7 +44,7 @@ func SetupFakeRepo(t *testing.T, ns, wsDir string) *pipelinectxt.ODSContext {
 }
 
 func assembleAndCacheOdsCtxtOrFatal(t *testing.T, ctxt *pipelinectxt.ODSContext, wsDir string) {
-	err := ctxt.Assemble(wsDir)
+	err := ctxt.Assemble(wsDir, "")
 	if err != nil {
 		t.Fatalf("could not assemble ODS context information: %s", err)
 	}

--- a/pkg/pipelinectxt/context_test.go
+++ b/pkg/pipelinectxt/context_test.go
@@ -22,7 +22,7 @@ func TestAssemble(t *testing.T) {
 	}
 	defer cleanup()
 
-	err = c.Assemble(dir)
+	err = c.Assemble(dir, "foo-n8j4k")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,6 +37,7 @@ func TestAssemble(t *testing.T) {
 		GitURL:          "https://example.bitbucket.com/scm/ODS/ods-pipeline.git",
 		PullRequestBase: "",
 		PullRequestKey:  "",
+		PipelineRun:     "foo-n8j4k",
 	}
 	if diff := cmp.Diff(wantContext, c); diff != "" {
 		t.Fatalf("context mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
Closes #737.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
