### PR TITLE
Use pipeline run name as Bitbucket build status key

### DIFF
--- a/cmd/finish/main.go
+++ b/cmd/finish/main.go
@@ -23,13 +23,18 @@ type options struct {
 	bitbucketAccessToken string
 	bitbucketURL         string
 	consoleURL           string
-	pipelineRunName      string
-	aggregateTasksStatus string
-	nexusURL             string
-	nexusUsername        string
-	nexusPassword        string
-	artifactTarget       string
-	debug                bool
+	// pipelineRunName is the name of the Tekton PipelineRun resource.
+	pipelineRunName string
+	// preferredPipelineRunName is either the name of the Tekton PipelineRun
+	// resource or the name of the resource for which this pipeline run
+	// is a re-run.
+	preferredPipelineRunName string
+	aggregateTasksStatus     string
+	nexusURL                 string
+	nexusUsername            string
+	nexusPassword            string
+	artifactTarget           string
+	debug                    bool
 }
 
 func main() {
@@ -40,6 +45,7 @@ func main() {
 	flag.StringVar(&opts.bitbucketURL, "bitbucket-url", os.Getenv("BITBUCKET_URL"), "bitbucket-url")
 	flag.StringVar(&opts.consoleURL, "console-url", os.Getenv("CONSOLE_URL"), "web console URL")
 	flag.StringVar(&opts.pipelineRunName, "pipeline-run-name", "", "name of pipeline run")
+	flag.StringVar(&opts.preferredPipelineRunName, "preferred-pipeline-run-name", os.Getenv("PREFERRED_PIPELINE_RUN_NAME"), "preferred name of pipeline run")
 	// See https://tekton.dev/docs/pipelines/pipelines/#using-aggregate-execution-status-of-all-tasks.
 	// Possible values are: Succeeded, Failed, Completed, None.
 	flag.StringVar(&opts.aggregateTasksStatus, "aggregate-tasks-status", "None", "aggregate status of all the tasks")
@@ -84,8 +90,8 @@ func main() {
 
 	err = bitbucketClient.BuildStatusCreate(ctxt.GitCommitSHA, bitbucket.BuildStatusCreatePayload{
 		State:       getBitbucketBuildStatus(opts.aggregateTasksStatus),
-		Key:         ctxt.GitCommitSHA,
-		Name:        ctxt.GitCommitSHA,
+		Key:         bitbucket.BuildStatusKey(opts.preferredPipelineRunName, opts.pipelineRunName),
+		Name:        bitbucket.BuildStatusKey(opts.preferredPipelineRunName, opts.pipelineRunName),
 		URL:         prURL,
 		Description: "ODS Pipeline Build",
 	})

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -17,26 +17,31 @@ import (
 )
 
 type options struct {
-	bitbucketAccessToken   string
-	bitbucketURL           string
-	consoleURL             string
-	pipelineRunName        string
-	nexusURL               string
-	nexusUsername          string
-	nexusPassword          string
-	artifactSource         string
-	project                string
-	prKey                  string
-	prBase                 string
-	httpProxy              string
-	httpsProxy             string
-	noProxy                string
-	url                    string
-	gitFullRef             string
-	submodules             string
-	cloneDepth             string
-	cacheBuildTasksForDays int
-	debug                  bool
+	bitbucketAccessToken string
+	bitbucketURL         string
+	consoleURL           string
+	// pipelineRunName is the name of the Tekton PipelineRun resource.
+	pipelineRunName string
+	// preferredPipelineRunName is either the name of the Tekton PipelineRun
+	// resource or the name of the resource for which this pipeline run
+	// is a re-run.
+	preferredPipelineRunName string
+	nexusURL                 string
+	nexusUsername            string
+	nexusPassword            string
+	artifactSource           string
+	project                  string
+	prKey                    string
+	prBase                   string
+	httpProxy                string
+	httpsProxy               string
+	noProxy                  string
+	url                      string
+	gitFullRef               string
+	submodules               string
+	cloneDepth               string
+	cacheBuildTasksForDays   int
+	debug                    bool
 }
 
 func main() {
@@ -56,6 +61,7 @@ func main() {
 	flag.IntVar(&opts.cacheBuildTasksForDays, "cache-build-tasks-for-days", 7, "the number of days build outputs are cached. A negative number can be used to clear the cache.")
 	flag.StringVar(&opts.consoleURL, "console-url", os.Getenv("CONSOLE_URL"), "web console URL")
 	flag.StringVar(&opts.pipelineRunName, "pipeline-run-name", "", "name of pipeline run")
+	flag.StringVar(&opts.preferredPipelineRunName, "preferred-pipeline-run-name", os.Getenv("PREFERRED_PIPELINE_RUN_NAME"), "preferred name of pipeline run")
 	flag.StringVar(&opts.nexusURL, "nexus-url", os.Getenv("NEXUS_URL"), "Nexus URL")
 	flag.StringVar(&opts.nexusUsername, "nexus-username", os.Getenv("NEXUS_USERNAME"), "Nexus username")
 	flag.StringVar(&opts.nexusPassword, "nexus-password", os.Getenv("NEXUS_PASSWORD"), "Nexus password")
@@ -139,8 +145,8 @@ func main() {
 
 	err = bitbucketClient.BuildStatusCreate(ctxt.GitCommitSHA, bitbucket.BuildStatusCreatePayload{
 		State:       bitbucket.BuildStatusInProgress,
-		Key:         ctxt.GitCommitSHA,
-		Name:        ctxt.GitCommitSHA,
+		Key:         bitbucket.BuildStatusKey(opts.preferredPipelineRunName, opts.pipelineRunName),
+		Name:        bitbucket.BuildStatusKey(opts.preferredPipelineRunName, opts.pipelineRunName),
 		URL:         prURL,
 		Description: "ODS Pipeline Build",
 	})

--- a/deploy/chart/templates/task-finish.yaml
+++ b/deploy/chart/templates/task-finish.yaml
@@ -59,6 +59,14 @@ spec:
             configMapKeyRef:
               key: debug
               name: ods-pipeline
+        - name: PREFERRED_PIPELINE_RUN_NAME
+          valueFrom:
+            fieldRef:
+              # preferredName is either the name of the Tekton PipelineRun
+              # resource or the name of the resource for which this pipeline run
+              # is a re-run. ods-finish reads this env var to determine the
+              # Bitbucket build status key.
+              fieldPath: 'metadata.annotations[''pipeline.openshift.io/preferredName'']'
       computeResources: {}
       script: |
 

--- a/deploy/chart/templates/task-start.yaml
+++ b/deploy/chart/templates/task-start.yaml
@@ -115,6 +115,14 @@ spec:
             configMapKeyRef:
               key: debug
               name: ods-pipeline
+        - name: PREFERRED_PIPELINE_RUN_NAME
+          valueFrom:
+            fieldRef:
+              # preferredName is either the name of the Tekton PipelineRun
+              # resource or the name of the resource for which this pipeline run
+              # is a re-run. ods-start reads this env var to determine the
+              # Bitbucket build status key.
+              fieldPath: 'metadata.annotations[''pipeline.openshift.io/preferredName'']'
       computeResources: {}
       script: |
         if [ -f /etc/ssl/certs/private-cert.pem ]; then

--- a/pkg/bitbucket/build_status.go
+++ b/pkg/bitbucket/build_status.go
@@ -82,3 +82,12 @@ func (c *Client) BuildStatusList(gitCommit string) (*BuildStatusPage, error) {
 	}
 
 }
+
+// BuildStatusKey returns the key to use for the Bitbucket build status.
+func BuildStatusKey(preferredName, name string) string {
+	if preferredName != "" {
+		return preferredName
+	} else {
+		return name
+	}
+}


### PR DESCRIPTION
* Multiple runs for the same commit now create multiple build status records
* Re-runs of pipeline runs update the build status corrresponding to the original pipeline run

Closes #736.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
