### PR TITLE
Log sub repo context

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -182,6 +182,7 @@ func main() {
 			if err != nil {
 				log.Fatal(err)
 			}
+			logger.Infof("Assembled context for sub-repo %q: %+v", subrepo.Name, subrepoCtxt)
 			subrepoContexts = append(subrepoContexts, subrepoCtxt)
 		}
 	}


### PR DESCRIPTION
Closes #708.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
