### PR TITLE
Special case single star branch/tag constraint

### DIFF
--- a/internal/manager/receive.go
+++ b/internal/manager/receive.go
@@ -223,6 +223,12 @@ func anyPatternMatches(s string, patterns []string) bool {
 		return true
 	}
 
+	// Treat a single star as a special case, matching everything.
+	// See https://github.com/opendevstack/ods-pipeline/issues/691
+	if patterns[0] == "*" {
+		return true
+	}
+
 	for _, pattern := range patterns {
 		if matched, err := path.Match(pattern, s); matched && err == nil {
 			return true

--- a/internal/manager/receive_test.go
+++ b/internal/manager/receive_test.go
@@ -450,6 +450,18 @@ func TestIdentifyPipelineConfig(t *testing.T) {
 			wantPipelineIndex: 0,
 			wantTriggerIndex:  0,
 		},
+		"branch push - pipeline with one trigger with * constraint": {
+			pInfo: PipelineInfo{ChangeRefType: "BRANCH", GitRef: "feature/foo"},
+			odsConfig: config.ODS{
+				Pipelines: []config.Pipeline{
+					{Triggers: []config.Trigger{
+						{Branches: []string{"*"}},
+					}},
+				},
+			},
+			wantPipelineIndex: 0,
+			wantTriggerIndex:  0,
+		},
 		"branch push - pipeline with one trigger with matching branch constraint upper case": {
 			pInfo: PipelineInfo{ChangeRefType: "BRANCH", GitRef: "feature/FOO-123-hello-world"},
 			odsConfig: config.ODS{


### PR DESCRIPTION
If the constraint is e.g. `branches: ["*"]`, then all branch names are matched, even ones containing slashes. Before this change, e.g. `feature/foo` would not have matched.

Closes #691.

Tasks: 
- [x] Updated design documents in `docs/design` directory or not applicable
- [x] Updated user-facing documentation in `docs` directory or not applicable
- [x] Ran tests (e.g. `make test`) or not applicable
- [x] Updated changelog or not applicable
